### PR TITLE
Simplify `list ->` rule

### DIFF
--- a/src/commonMain/kotlin/org/kson/parser/Parser.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Parser.kt
@@ -14,9 +14,7 @@ import org.kson.ast.*
  *        | literal
  *        | embedBlock ;
  * objectDefinition -> ( objectName | "" ) "{" objectInternals "}" ;
- * list -> "[" "]"
- *       | "[" value "]"
- *       | "[" (value ",")* value? "]"
+ * list -> "[" (value ",")* value? "]"
  * keyword -> ( IDENTIFIER | STRING ) ":" ;
  * literal -> STRING, NUMBER, "true", "false", "null" ;
  * embeddedBlock -> "```" (embedTag) NEWLINE CONTENT "```" ;
@@ -107,9 +105,7 @@ class Parser(tokens: List<Token>) {
     }
 
     /**
-     * list -> "[" "]"
-     *       | "[" value "]"
-     *       | "[" (value ",")* value? "]"
+     * list -> "[" (value ",")* value? "]"
      */
     private fun list(): ListNode? {
         if (tokenScanner.peek() == TokenType.BRACKET_L) {


### PR DESCRIPTION
Collapse the grammar rule for `list ->` down to its equivalent one-liner---thanks for spotting this @joeslice!