### PR TITLE
Add instructions for new developers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,27 @@ TODO document the language, remembering to clearly note:
 
 * Clone this repo, then run `./gradlew check` in its root dir to validate everything builds and runs correctly.
 
-* **IntelliJ setup:** ensure you have the Kotlin and Gradle plugins installed in Intellij, then simply open the root [`build.gradle.kts`](build.gradle.kts) file "as a Project"
+* **IntelliJ setup:** ensure you have the Kotlin and Gradle plugins installed in Intellij (default in recent versions), then simply open the root [`build.gradle.kts`](build.gradle.kts) file "as a Project". Tests can be run by right-clicking the org.kson package in `commonTest` folder and selecting "Run tests in 'org.kson'".
+
+
+#### Some useful gradle commands:
+
+```sh
+# build and test
+./gradlew build
+
+# run all tests
+./gradlew allTests
+
+# build (if necessary) and run jvm tests
+./gradlew jvmTest
+./gradlew jvmTest --tests "org.kson.parser.*" 
+
+# Run a test and rerun each time a source file changes.
+./gradlew jvmTest --continuous --tests "org.kson.parser.LexerTest" 
+```
+
+#### Troubleshooting setup:
 
 * **Ubuntu setup:** if an error is reported by gradle similar to `error while loading shared libraries: libtinfo.so.5`, install libncurses5 with `apt install libcurses5`. See also [Kotlin/Native Setup instructions](https://github.com/JetBrains/kotlin-native/blob/27232bca5f2fb0164f1aa465d38e5042c6d7d55b/README.md).
 


### PR DESCRIPTION
Since job 1 for a new developer is 'build and run the tests!', this commit adds
clear instructions on how to do this.

Additionally, this moves the less-likely-useful Ubuntu troubleshooting to a new
section that may grow over time with other troubleshooting steps.