### PR TITLE
Fix Parser grammar doc

### DIFF
--- a/src/commonMain/kotlin/org/kson/parser/Parser.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Parser.kt
@@ -13,9 +13,11 @@ import org.kson.parser.TokenType.*
  * kson -> (objectInternals | list | value) <end-of-file> ;
  * objectInternals -> ( keyword (value | list) ","? )* ;
  * value -> objectDefinition
+ *        | list
  *        | literal
  *        | embedBlock ;
  * objectDefinition -> ( objectName | "" ) "{" objectInternals "}" ;
+ * list -> dashList | bracketList
  * # NOTE: dashList may not be (directly) contained in a dashList to avoid ambiguity
  * dashList -> ( LIST_DASH ( value | bracketList ) )*
  * # note that either list type may be contained in a bracket list since there is no ambiguity
@@ -34,7 +36,7 @@ import org.kson.parser.TokenType.*
 class Parser(val builder: AstBuilder) {
 
     /**
-     * kson -> (objectInternals | value) EOF ;
+     * kson -> (objectInternals | list | value) <end-of-file> ;
      */
     fun parse() {
         if (objectInternals(false) || value()) {
@@ -46,7 +48,7 @@ class Parser(val builder: AstBuilder) {
     }
 
     /**
-     * objectInternals -> ( keyword value ","? )* ;
+     * objectInternals -> ( keyword (value | list) ","? )* ;
      */
     private fun objectInternals(allowEmpty: Boolean): Boolean {
         var foundProperties = false
@@ -245,7 +247,7 @@ class Parser(val builder: AstBuilder) {
     }
 
     /**
-     * embeddedBlock -> "%%" (embedTag) NEWLINE CONTENT "%%" ;
+     * embeddedBlock -> EMBED_START (embedTag) NEWLINE CONTENT EMBED_END ;
      */
     private fun embedBlock(): Boolean {
         if (builder.getTokenType() == EMBED_START) {


### PR DESCRIPTION
The grammar specification on the Parser class is the canonical doc for the grammar, and wants to match the doc on each of the methods implementing a grammar rule.  We drifted a bit after the grammar change for dash-delimited lists in f982c82f8

Stretch goal: at some point it would likely be nice to put some manner of automated check to keep these grammar doc inconsistencies from happening in the future