### PR TITLE
Update build to large resource class in config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ jobs:
       # Choose the `-browsers variant` of the openjdk 11 image, see https://circleci.com/developer/images/image/cimg/openjdk#browsers
       # for details
       - image: cimg/openjdk:11.0-browsers
-
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
@@ -50,7 +49,7 @@ jobs:
       - run:
           name: Get rid of erroneous git config
           command: |
-              rm -rf ~/.gitconfig
+            rm -rf ~/.gitconfig
       - run: ./gradlew dependencies
 
       - save_cache:
@@ -60,3 +59,5 @@ jobs:
 
       # run tests!
       - run: ./gradlew check
+    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
+    resource_class: large


### PR DESCRIPTION
CircleCI suggested this setting while I was troubleshooting it not running the build on https://github.com/kson-org/kson/pull/50.  Give it a try and see if this nudges builds to start running on Pulls again...