### PR TITLE
Fix "Default Kotlin Hierarchy" build warning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,13 +75,12 @@ kotlin {
     val hostOs = System.getProperty("os.name")
     val isMingwX64 = hostOs.startsWith("Windows")
     when {
-        hostOs == "Mac OS X" -> macosX64("native")
-        hostOs == "Linux" -> linuxX64("native")
-        isMingwX64 -> mingwX64("native")
+        hostOs == "Mac OS X" -> macosX64("nativeKson")
+        hostOs == "Linux" -> linuxX64("nativeKson")
+        isMingwX64 -> mingwX64("nativeKson")
         else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
     }
 
-    
     sourceSets {
         val commonMain by getting
         val commonTest by getting {
@@ -102,8 +101,8 @@ kotlin {
                 implementation(kotlin("test-js"))
             }
         }
-        val nativeMain by getting
-        val nativeTest by getting
+        val nativeKsonMain by getting
+        val nativeKsonTest by getting
     }
 }
 


### PR DESCRIPTION
The recent upgrade to Kotlin 1.9 brought this warning into the build:

```
$ ./gradlew clean

> Configure project :
w: The Default Kotlin Hierarchy Template was not applied to 'root project 'kson'':
Source sets created by the following targets will clash with source sets created by the template:
[native]

Consider renaming the targets or disabling the default template by adding
    'kotlin.mpp.applyDefaultHierarchyTemplate=false'
to your gradle.properties

Learn more about hierarchy templates: https://kotl.in/hierarchy-template
```

Fix the name clash that's the root cause of this be renaming our "native" target to "nativeKson".  Since our multiplatform needs/wants are pretty standard, there may be a way to clean this code up a bit by refactoring to use the these new hierarchies following the instructions at https://kotl.in/hierarchy-template, but this is all clear enough and working fine for now.