### PR TITLE
Move string errors up into Parser from Lexer

### DIFF
--- a/src/commonMain/kotlin/org/kson/parser/Lexer.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Lexer.kt
@@ -363,7 +363,6 @@ class Lexer(source: String, private val messageSink: MessageSink, gapFree: Boole
         addToken(TokenType.STRING, rawStringLexeme, escapedString)
 
         if (sourceScanner.peek() == EOF) {
-            messageSink.error(sourceScanner.currentLocation(), STRING_NO_CLOSE.create())
             return
         } else {
             // not at EOF, so we must be looking at the quote that ends this string

--- a/src/commonMain/kotlin/org/kson/parser/Parser.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Parser.kt
@@ -293,6 +293,7 @@ class Parser(val builder: AstBuilder) {
             return false
         }
 
+        val possiblyUnclosedString = builder.mark()
         // consume our open quote
         builder.advanceLexer()
 
@@ -301,9 +302,16 @@ class Parser(val builder: AstBuilder) {
         builder.advanceLexer()
         stringMark.done(STRING)
 
-        // consume our close quote
-        builder.advanceLexer()
-        return true
+        if (builder.eof()) {
+            possiblyUnclosedString.error(STRING_NO_CLOSE.create())
+            return true
+        } else {
+            // string is closed, don't need this marker
+            possiblyUnclosedString.drop()
+            // consume our close quote
+            builder.advanceLexer()
+            return true
+        }
     }
 
     /**

--- a/src/commonTest/kotlin/org/kson/parser/LexerTest.kt
+++ b/src/commonTest/kotlin/org/kson/parser/LexerTest.kt
@@ -614,24 +614,24 @@ class LexerTest {
 
     @Test
     fun testUnterminatedString() {
-        val unclosedStringTokens = assertTokenizesWithMessages(
+        assertTokenizesTo(
             """
             "this string has no end quote
             """,
-            listOf(STRING_NO_CLOSE)
+            listOf(STRING_QUOTE, STRING),
+            "should simply tokenize unterminated strings.  Errors are handled in parsing."
         )
-        assertEquals(listOf(STRING_QUOTE, STRING), unclosedStringTokens.map { it.tokenType })
     }
 
     @Test
     fun testUnterminatedAltString() {
-        val unclosedStringTokens = assertTokenizesWithMessages(
+        assertTokenizesTo(
             """
             'this string has no end quote
             """,
-            listOf(STRING_NO_CLOSE)
+            listOf(STRING_QUOTE, STRING),
+            "should simply tokenize unterminated strings.  Errors are handled in parsing."
         )
-        assertEquals(listOf(STRING_QUOTE, STRING), unclosedStringTokens.map { it.tokenType })
     }
 
     @Test

--- a/tooling/jetbrains/src/test/resources/testData/parser/UnclosedString.txt
+++ b/tooling/jetbrains/src/test/resources/testData/parser/UnclosedString.txt
@@ -1,4 +1,5 @@
 FILE(0,9)
-  PsiElement(IElementTokenType(tokenType=STRING_QUOTE))('"')(0,1)
-  KsonPsiElement(IElementTokenType(tokenType=STRING))(1,9)
-    PsiElement(IElementTokenType(tokenType=STRING))('unclosed')(1,9)
+  PsiErrorElement:Unterminated string(0,9)
+    PsiElement(IElementTokenType(tokenType=STRING_QUOTE))('"')(0,1)
+    KsonPsiElement(IElementTokenType(tokenType=STRING))(1,9)
+      PsiElement(IElementTokenType(tokenType=STRING))('unclosed')(1,9)


### PR DESCRIPTION
To step toward completing our goal of eliminating error reporting from the Lexer (https://github.com/kson-org/kson/issues/69)