### PR TITLE
Add .kotlin folder to our .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ build
 gradle/jdk
 # intellij settings
 .idea
+# kotlin metadata
+.kotlin


### PR DESCRIPTION
This is needed after the upgrade to Kotlin 2+ performed in af977f4140cfc9852a339ac78c8edaccfd17adfd

More details here:
https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects