### PR TITLE
Improve build error on dirty git build dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/org/kson/jsonsuite/TestSuiteGitCheckout.kt
+++ b/buildSrc/src/main/kotlin/org/kson/jsonsuite/TestSuiteGitCheckout.kt
@@ -4,6 +4,11 @@ import org.kson.CleanGitCheckout
 import java.nio.file.Path
 
 class JsonSuiteGitCheckout(jsonTestSuiteSHA: String, destinationDir: Path)
-    : CleanGitCheckout("https://github.com/nst/JSONTestSuite.git", jsonTestSuiteSHA, destinationDir, "JSONTestSuite")
+    : CleanGitCheckout("https://github.com/nst/JSONTestSuite.git", jsonTestSuiteSHA, destinationDir, "JSONTestSuite", dirtyMessage)
 class SchemaSuiteGitCheckout(schemaTestSuiteSHA: String, destinationDir: Path)
-    : CleanGitCheckout("https://github.com/json-schema-org/JSON-Schema-Test-Suite.git", schemaTestSuiteSHA, destinationDir, "JSON-Schema-Test-Suite")
+    : CleanGitCheckout("https://github.com/json-schema-org/JSON-Schema-Test-Suite.git", schemaTestSuiteSHA, destinationDir, "JSON-Schema-Test-Suite", dirtyMessage)
+
+/**
+ * The rationale for why these [CleanGitCheckout]s must be clean
+ */
+private const val dirtyMessage = "This needs to be clean since we generate files from this repo.\n"

--- a/buildSrc/src/test/kotlin/org/kson/jsonsuite/CleanGitCheckoutTest.kt
+++ b/buildSrc/src/test/kotlin/org/kson/jsonsuite/CleanGitCheckoutTest.kt
@@ -147,12 +147,14 @@ class CleanGitCheckoutTest {
         // reach into the checkout we just ensured and dirty it up
         Paths.get(cleanGitCheckout.checkoutDir.toString(), dirtyFileName).toFile().createNewFile()
 
+        val dirtyMessage = "this message should be included in our exception"
         val exception = assertFailsWith<DirtyRepoException>("should error on a dirty git dir") {
             CleanGitCheckout(
                 gitTestFixturePath,
                 desiredCheckoutSHA,
                 testCheckoutDir,
-                "GitFixture"
+                "GitFixture",
+                dirtyMessage
             )
         }
 
@@ -164,6 +166,11 @@ class CleanGitCheckoutTest {
         assertTrue(
             exception.message!!.contains(dirtyFileName),
             "Exception message should name any file dirtying up the directory"
+        )
+
+        assertTrue(
+            exception.message!!.contains(dirtyMessage),
+            "Exception message should contain the given additional message"
         )
     }
 


### PR DESCRIPTION
Improve this unhelpful error message:

```
Could not create task ':generateJsonTestSuite'.
> Could not create task of type 'GenerateJsonTestSuiteTask'.
   > ERROR: Dirty git status in /Aboslute/path/to/kson/buildSrc/support/jsonsuite.  Please ensure the git status is clean or delete the directory and re-run this script
```

This error message wasn't doing a good enough job of explaining what the problem is and why it needs to be fixed.  Even worse, it would also blow up on OS files `.DS_Store` and `Thumbs.db` that can quietly sneak in. This naturally caused some real confusion for some developers. So, to improve all this, we:
- edit the error message to be more clear and include a listing of dirty
  files in its output
- allow the build to proceed if the only "dirtyness" in the git repo is
  harmless untracked `.DS_Store` or `Thumbs.db` files

Here's the new error message format:

```
Could not create task ':generateJsonTestSuite'.
> Could not create task of type 'GenerateJsonTestSuiteTask'.
   > ERROR: Dirty git status in `/Absolute/path/to/kson/buildSrc/support/jsonsuite/JSONTestSuite`.
     This needs to be clean since we generate files from this repo.
     Suggested fixes:
     - either clean up the git status in `/Absolute/path/to/kson/buildSrc/support/jsonsuite/JSONTestSuite`
     - or, delete `/Absolute/path/to/kson/buildSrc/support/jsonsuite/JSONTestSuite`
       so it is re-cloned on the next build

     # Dirty Git Status in `/Absolute/path/to/kson/buildSrc/support/jsonsuite/JSONTestSuite`:
     Added files: [dirty_added.txt]
     Untracked files: [dirty_untracked.txt]
     Modified files (not staged): [test_parsing/i_number_huge_exp.json]
```

This pull also refators `CleanGitCheckout` a bit, see https://github.com/kson-org/kson/commit/5ffb3526fbbdea84457c36b9cceb56ef70613b4b