### PR TITLE
Prevent auto insertion in commented lines

### DIFF
--- a/tooling/jetbrains/src/test/kotlin/org/kson/jetbrains/editor/KsonTypedHandlerDelegateTest.kt
+++ b/tooling/jetbrains/src/test/kotlin/org/kson/jetbrains/editor/KsonTypedHandlerDelegateTest.kt
@@ -15,6 +15,33 @@ class KsonTypedHandlerDelegateTest : KsonEditorActionTest() {
                 '<',
                 "<<caret>>"
             )
+
+            // should not auto-insert in comment block
+            doCharTest(
+                "#    <caret>",
+                '<',
+                "#    <<caret>"
+            )
+
+            // should not auto-insert in comment block
+            doCharTest(
+                """
+                    # This is a commented line
+                    <caret>
+                """.trimIndent(),
+                '<',
+                """
+                    # This is a commented line
+                    <<caret>>
+                """.trimIndent(),
+            )
+
+            // should not auto-insert in comment block
+            doCharTest(
+                "#<caret>",
+                '<',
+                "#<<caret>"
+            )
         }
 
         withConfigSetting(ConfigProperty.AUTOINSERT_PAIR_BRACKET(), false) {
@@ -133,6 +160,17 @@ class KsonTypedHandlerDelegateTest : KsonEditorActionTest() {
                     $altFullDelim
                         $fullDelim<caret>
                     $altFullDelim
+                    """.trimIndent()
+                )
+
+                // should not auto-insert in commented line
+                doCharTest(
+                    """
+                    # $halfDelim<caret>
+                    """.trimIndent(),
+                    halfDelim,
+                    """
+                    # $fullDelim<caret>
                     """.trimIndent()
                 )
             }


### PR DESCRIPTION
The `TypedHandlerDelegate` returns early if the caret is in a commented line. This prevents undesirable auto-insertion when typing a `<` or a `$` in a commented line.