### PR TITLE
Fix embed delimiter escape boundary

### DIFF
--- a/src/commonMain/kotlin/org/kson/parser/Lexer.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Lexer.kt
@@ -566,18 +566,7 @@ class Lexer(source: String, gapFree: Boolean = false) {
             !sourceScanner.eof()
             && !(sourceScanner.peek() == delimChar && sourceScanner.peekNext() == delimChar)
         ) {
-            if (sourceScanner.peek() == delimChar && sourceScanner.peekNext() == '\\') {
-                // if this is all slashes until "delimChar", we're looking at an escaped embed delimiter
-                sourceScanner.advance()
-                while (sourceScanner.peek() == '\\') {
-                    sourceScanner.advance()
-                }
-                if (sourceScanner.peek() == delimChar) {
-                    sourceScanner.advance()
-                }
-            } else {
-                sourceScanner.advance()
-            }
+            sourceScanner.advance()
         }
 
         val embedBlockLexeme = sourceScanner.extractLexeme()

--- a/src/commonTest/kotlin/org/kson/KsonTestEmbedBlock.kt
+++ b/src/commonTest/kotlin/org/kson/KsonTestEmbedBlock.kt
@@ -165,4 +165,25 @@ class KsonTestEmbedBlock : KsonTest() {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun testEmbedBlockEndingInSlash() {
+        assertParsesTo(
+            """
+                %%
+                %\%%
+            """.trimIndent(),
+            """
+                %%
+                %\%%
+            """.trimIndent(),
+            """
+                |
+                  %\
+            """.trimIndent(),
+            """
+                "%\\"
+            """.trimIndent()
+        )
+    }
 } 


### PR DESCRIPTION
The design of the two-char (`%%`, `$$`) delimiters for embed blocks specifically means that a naive exact-match search for the end delimiter will always succeed.  But our Lexer had some unnecessary code which Lexed things incorrectly in this case:

```
%%
This embed should end "%\", without a newline at the end.
It should NOT cause an unclosed embed block error %\%%
```

Root cause: this is cruft left over from when we were trying to detect and handle escapes in the Lexer (mostly refactored away in ede3d3b5).

Simplify away the buggy code and add a regression test.