### PR TITLE
Introduce the end-dash for dashLists

### DIFF
--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -284,7 +284,7 @@ class ListNode(
                      * thing in this document is a [ListElementNode] that does not belong to this list
                      */
                     if (nextNode is ListElementNode) {
-                        "$outputList\n${indent.bodyLinesIndent()}."
+                        "$outputList\n${indent.bodyLinesIndent()}="
                     } else {
                         outputList
                     }

--- a/src/commonMain/kotlin/org/kson/parser/ElementType.kt
+++ b/src/commonMain/kotlin/org/kson/parser/ElementType.kt
@@ -32,6 +32,8 @@ enum class TokenType : ElementType {
     COLON,
     // .
     DOT,
+    // =
+    END_DASH,
     // ,
     COMMA,
     // lines starting with `#`

--- a/src/commonMain/kotlin/org/kson/parser/Lexer.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Lexer.kt
@@ -283,6 +283,7 @@ class Lexer(source: String, gapFree: Boolean = false) {
             '>' -> addLiteralToken(ANGLE_BRACKET_R)
             ':' -> addLiteralToken(COLON)
             '.' -> addLiteralToken(DOT)
+            '=' -> addLiteralToken(END_DASH)
             ',' -> addLiteralToken(COMMA)
             '"', '\'' -> {
                 addLiteralToken(STRING_OPEN_QUOTE)

--- a/src/commonMain/kotlin/org/kson/parser/Parser.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Parser.kt
@@ -18,7 +18,7 @@ import org.kson.parser.messages.MessageType.*
  * objectInternals -> "," ( keyword ksonValue ","? )+
  *                  | ( ","? keyword ksonValue )*
  *                  | ( keyword ksonValue ","? )*
- * dashList -> dashListInternals "."+
+ * dashList -> dashListInternals "="+
  * dashListInternals -> ( LIST_DASH ksonValue )*
  * delimitedValue -> delimitedObject
  *                 | delimitedDashList
@@ -181,7 +181,7 @@ class Parser(private val builder: AstBuilder, private val maxNestingLevel: Int =
     }
 
     /**
-     * dashList -> dashListInternals "."+
+     * dashList -> dashListInternals "="+
      * dashListInternals -> ( LIST_DASH ksonValue )*
      *
      * Note: as in [plainObject], we combine these two grammar rules here so it's clean/easy to implement
@@ -204,14 +204,14 @@ class Parser(private val builder: AstBuilder, private val maxNestingLevel: Int =
                     listElementMark.error(DANGLING_LIST_DASH.create())
                 }
 
-                if (builder.getTokenType() == DOT) {
-                    val dot = builder.mark()
+                if (builder.getTokenType() == END_DASH) {
+                    val endDashMark = builder.mark()
                     builder.advanceLexer()
                     if (!isDelimited) {
-                        dot.drop()
+                        endDashMark.drop()
                         break
                     } else {
-                        dot.error(IGNORED_DASH_LIST_END_DOT.create())
+                        endDashMark.error(IGNORED_DASH_LIST_END_DASH.create())
                     }
                 }
             } while (builder.getTokenType() == LIST_DASH)

--- a/src/commonMain/kotlin/org/kson/parser/messages/Message.kt
+++ b/src/commonMain/kotlin/org/kson/parser/messages/Message.kt
@@ -140,14 +140,14 @@ enum class MessageType {
                     "End-dots only effect non-delimited objects"
         }
     },
-    IGNORED_DASH_LIST_END_DOT {
+    IGNORED_DASH_LIST_END_DASH {
         override fun expectedArgs(): List<String> {
             return emptyList()
         }
 
         override fun doFormat(parsedArgs: ParsedErrorArgs): String {
-            return "This end-dot is ignored because this list is `<>`-delimited. " +
-                    "End-dots only effect non-delimited dashed lists"
+            return "This end-dash is ignored because this list is `<>`-delimited. " +
+                    "End-dashes only effect non-delimited dashed lists"
         }
     },
     STRING_NO_CLOSE {

--- a/src/commonTest/kotlin/org/kson/KsonTest.kt
+++ b/src/commonTest/kotlin/org/kson/KsonTest.kt
@@ -8,6 +8,7 @@ import org.kson.testSupport.validateYaml
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 
 /**
  * Base class for tests that exercise and verify [Kson] behavior on valid Kson.  For tests parsing invalid Kson,
@@ -78,6 +79,12 @@ open class KsonTest {
             message
         )
 
+        assertEquals(
+            ksonParseResult.kson,
+            ksonParseResult.kson,
+            "Re-parsing our transpiled Kson must be idempotent"
+        )
+
         // now validate the Yaml produced for this source
         val yamlResult = Kson.parseToYaml(source, compileSettings.yamlSettings)
         assertEquals(
@@ -94,6 +101,49 @@ open class KsonTest {
             message
         )
 
+    }
+
+    /**
+     * A regression test that demonstrates as directly as possible the grammar ambiguity inherent to
+     * trying to use one syntax element (the end-dot `.`) for closing both lists and objects.  In
+     * a multi-level mixed nest situation, the parser cannot distinguish which order to unnest things
+     * in, and so in specific cases like the one demonstrated here, would collapse two different
+     * data structures into one Kson representation (which is of course incorrect on some of the input)
+     */
+    @Test
+    fun testParseAmbiguityRegression(){
+        val compileSettings = CompileSettings().ksonSettings
+
+        // Note that "test_key" is a sibling of "outer_key"
+        val parseTwoOuterKeys = Kson.parseToKson("""
+            "outer_key": {
+                "inner_key": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+            "test_key": "value"
+            """.trimIndent(), compileSettings)
+
+        val doubleParseTwoOuterKeys = Kson.parseToKson(parseTwoOuterKeys.kson!!, compileSettings)
+
+        // Note that "test_key" is a sibling of "inner_key"
+        val parseTwoInnerKeys = Kson.parseToKson(
+            """
+            "outer_key": {
+                "inner_key": [
+                  1,
+                  2,
+                  3
+                ],
+                "test_key": "value"
+              }
+            """.trimIndent(), compileSettings)
+
+        // under no circumstances should these parse results be the same
+        assertNotEquals(doubleParseTwoOuterKeys, parseTwoInnerKeys,
+            "should never format two different data structures into identical Kson")
     }
 
     @Test
@@ -135,6 +185,86 @@ open class KsonTest {
               ]
             }
         """.trimIndent()
+        )
+    }
+
+    /**
+     * Regression test demonstrating why using the end-dot for both objects and lists is too ambitious:
+     * no way around the ambiguity involved in trying to unnest multiple mixed objects and lists
+     */
+    @Test
+    fun testParsingMultiLevelMixedObjectsAndLists(){
+        assertParsesTo(
+            // the object containing `inner_key` should be unambiguously terminated
+            """
+            outer_key1:
+              inner_key:
+                - 1
+                - 2
+                - 3
+              .
+            outer_key2: value
+            """.trimIndent(),
+            """
+            outer_key1:
+              inner_key:
+                - 1
+                - 2
+                - 3
+              .
+            outer_key2: value
+            """.trimIndent(),
+            """
+            outer_key1:
+              inner_key:
+                - 1
+                - 2
+                - 3
+            outer_key2: value
+            """.trimIndent(),
+            """
+            {
+              "outer_key1": {
+                "inner_key": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "outer_key2": "value"
+            }
+            """.trimIndent(),
+        )
+
+        assertParsesTo(
+            // the list containing `inner_key: x` should be unambiguously terminated
+            """
+            - 
+              - inner_key: x
+              =
+            - outer_list_elem
+            """.trimIndent(),
+            """
+            - 
+              - inner_key: x
+              =
+            - outer_list_elem
+            """.trimIndent(),
+            """
+            - 
+              - inner_key: x
+            - outer_list_elem
+            """.trimIndent(),
+            """
+            [
+              [
+                {
+                  "inner_key": "x"
+                }
+              ],
+              "outer_list_elem"
+            ]
+            """.trimIndent(),
         )
     }
 }

--- a/src/commonTest/kotlin/org/kson/KsonTestComment.kt
+++ b/src/commonTest/kotlin/org/kson/KsonTestComment.kt
@@ -420,19 +420,19 @@ class KsonTestComment : KsonTest() {
                 # a nested list element
                 - 2.2
                 - 3.2
-                .
+                =
               - 
                 # a nested dash-delimited list
                 - 
                   - 10.2
-                  .
+                  =
                 # a further nested braced list
                 # trailing comment on nested list
                 - 
                   - 4.2
                   # a further nested braced list element
                   - 5.2
-                  .
+                  =
                 - 
                   - 9.2
                   - 8.2

--- a/src/commonTest/kotlin/org/kson/KsonTestList.kt
+++ b/src/commonTest/kotlin/org/kson/KsonTestList.kt
@@ -327,7 +327,7 @@ class KsonTestList : KsonTest() {
                     - a1
                     - b1
                     - c1
-                    .
+                    =
                   - c
             """.trimIndent(),
             """
@@ -371,7 +371,7 @@ class KsonTestList : KsonTest() {
             - true
             - 
               - sublist
-              .
+              =
             - 
               - another
               - sublist
@@ -408,14 +408,14 @@ class KsonTestList : KsonTest() {
                 - 
                   - "sub-list elem 1"
                   - "sub-list elem 2"
-                  .
+                  =
                 - "outer list elem 1"
             """.trimIndent(),
             """
                 - 
                   - 'sub-list elem 1'
                   - 'sub-list elem 2'
-                  .
+                  =
                 - 'outer list elem 1'
             """.trimIndent(),
             """

--- a/src/commonTest/kotlin/org/kson/KsonTestListError.kt
+++ b/src/commonTest/kotlin/org/kson/KsonTestListError.kt
@@ -81,12 +81,12 @@ class KsonTestListError : KsonTestError() {
         assertParserRejectsSource("""
             <
               - "sub-list elem 1"
-              - "sub-list elem 2" .
-              - "sub-list elem 3" .
+              - "sub-list elem 2" =
+              - "sub-list elem 3" =
               - "sub-list elem 4"
             >
             """.trimIndent(),
-            listOf(IGNORED_DASH_LIST_END_DOT, IGNORED_DASH_LIST_END_DOT)
+            listOf(IGNORED_DASH_LIST_END_DASH, IGNORED_DASH_LIST_END_DASH)
         )
     }
 }

--- a/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
+++ b/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
@@ -9,9 +9,16 @@ class FormatterTest {
         expected: String,
         indentType: IndentType = IndentType.Space(2)
     ) {
+        val formattedKson = format(source, KsonFormatterConfig(indentType))
         assertEquals(
             expected,
-            format(source, KsonFormatterConfig(indentType))
+            formattedKson
+        )
+
+        assertEquals(
+            expected,
+            format(formattedKson, KsonFormatterConfig(indentType)),
+            "formatting should be idempotent, but this reformat changed the result"
         )
     }
 
@@ -151,9 +158,9 @@ class FormatterTest {
             - 
               - 
                 - 3
-                .
+                =
               - 2
-              .
+              =
             - 1
             """.trimIndent()
         )
@@ -605,7 +612,7 @@ class FormatterTest {
             - 
               - inner1
               - inner2
-              .
+              =
             - outer2
             - 
               - inner3
@@ -638,9 +645,9 @@ class FormatterTest {
                     - 
                       - 
                         - x
-                        .
-                      .
-                    .
+                        =
+                      =
+                    =
                   - y
             """.trimIndent()
         )
@@ -663,7 +670,7 @@ class FormatterTest {
                 - 
                   - 1
                   - 2
-                  .
+                  =
                 - x: y
                 - 
                   - nested
@@ -702,10 +709,50 @@ class FormatterTest {
               - 
                 - 1
                 - 2
-                .
+                =
               - x: y
               - 
                 - nested
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testFormattingMixedUnnesting(){
+        assertFormatting(
+            """
+            outer_key1: {
+              inner_key: [1, 2, 3]
+            }
+            outer_key2: value
+            """.trimIndent(),
+            """
+            outer_key1:
+              inner_key:
+                - 1
+                - 2
+                - 3
+              .
+            outer_key2: value
+            """.trimIndent()
+        )
+
+        assertFormatting(
+            """
+             [
+              [
+                {
+                  "inner_key": "x"
+                }
+              ],
+              "outer_list_elem"
+            ]
+            """.trimIndent(),
+            """
+            - 
+              - inner_key: x
+              =
+            - outer_list_elem
             """.trimIndent()
         )
     }
@@ -1108,14 +1155,14 @@ class FormatterTest {
             """
                 - 
                 - "sub-list elem 1"
-                - 'sub-list elem 2' .
+                - "sub-list elem 2" =
                 - "outer list elem 1"
             """.trimIndent(),
             """
               - 
                 - 'sub-list elem 1'
                 - 'sub-list elem 2'
-                .
+                =
               - 'outer list elem 1'
             """.trimIndent()
         )

--- a/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/highlighter/KsonSyntaxHighlighter.kt
+++ b/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/highlighter/KsonSyntaxHighlighter.kt
@@ -28,6 +28,7 @@ class KsonSyntaxHighlighter : SyntaxHighlighterBase() {
                 TokenType.ANGLE_BRACKET_R -> getPackedTextAttributes(KSON_ANGLE_BRACKET)
                 TokenType.COLON -> getPackedTextAttributes(KSON_COLON)
                 TokenType.DOT -> getPackedTextAttributes(KSON_END_DOT)
+                TokenType.END_DASH -> getPackedTextAttributes(KSON_END_DOT)
                 TokenType.COMMA -> getPackedTextAttributes(KSON_COMMA)
                 TokenType.COMMENT -> getPackedTextAttributes(KSON_COMMENT)
                 TokenType.EMBED_OPEN_DELIM -> getPackedTextAttributes(KSON_DELIMITER)


### PR DESCRIPTION
The unified Kson grammar that was merged in 5923bc11dad732 was a bit too ambitious in its hopes of only introducing one bit of new `end-` syntax.  It's obvious now in hindsight, but it's impossible to unambiguously end mixed plainObjects and dashLists with the same syntax element because the order in which the mixed elements are closed is material. They newly added `KsonTest.testParseAmbiguityRegression` demonstrates a key example in code.

So: we restrict the "end-dot" `.` to being the syntax for explicitly closing objects, and we introduce the "end-dash" `=` for explicitly closing lists.  The grammar is otherwise unchanged.

We chose the equals sign for our `end-dash` syntax element due to:
- its visual relation to the list dash: `-` / `=`
- its position on the keyboard: users typing `-` to add list elements can easily/ergonomically reach the`=` to close that list