### PR TITLE
Tooling: Fix "Refactor File..." undo bug

### DIFF
--- a/tooling/jetbrains/src/test/kotlin/org/kson/jetbrains/formatter/KsonExternalFormatterTest.kt
+++ b/tooling/jetbrains/src/test/kotlin/org/kson/jetbrains/formatter/KsonExternalFormatterTest.kt
@@ -1,6 +1,9 @@
 package org.kson.jetbrains.formatter
 
 import com.intellij.application.options.CodeStyle
+import com.intellij.formatting.service.AbstractDocumentFormattingService
+import com.intellij.formatting.service.AsyncDocumentFormattingService
+import com.intellij.openapi.actionSystem.IdeActions
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.CommandProcessor
 import com.intellij.psi.PsiFile
@@ -8,11 +11,12 @@ import com.intellij.psi.codeStyle.CodeStyleManager
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import junit.framework.TestCase
-import org.kson.Kson
+import org.kson.tools.format
 import org.kson.jetbrains.KsonLanguage
+import org.kson.jetbrains.file.KsonFileType
 
 /**
- * Note that since [KsonExternalFormatter] delegates to [Kson.format], the testing here
+ * Note that since [KsonExternalFormatter] delegates to [format], the testing here
  * is mostly sanity checking that things are hooked up correctly and that IDE-specific
  * functionality is working, such as IDE configuration
  */
@@ -25,6 +29,45 @@ class KsonExternalFormatterTest : BasePlatformTestCase() {
         val commonSettings = settings.getCommonSettings(KsonLanguage)
         commonSettings.indentOptions?.INDENT_SIZE = 2
         commonSettings.indentOptions?.USE_TAB_CHARACTER = false
+    }
+
+    /**
+     * A not-quite-effective regression test for a bug in how [KsonExternalFormatter] interacted with the undo stack
+     * in the IDE: an earlier version of [KsonExternalFormatter] extended [AsyncDocumentFormattingService] rather than
+     * [AbstractDocumentFormattingService], an in the actual IDE the steps captured in this test (type some chars,
+     * perform a "Reformat File..", then Undo) would result in the format and one or more of the chars being Undone.
+     *
+     * What makes this test "not-quite-effective" is that the intellij plugin test framework seems to synchronize
+     * these operations, so this test is not actually able to reproduce the bug on the old code.  But it does document
+     * the issue, and it does verify that something that must work does work, so here it is.
+     */
+    fun testFormatAndUndo() {
+        val beforeFormat = "{ key: 'value' nested: { inner: stuff } }"
+        val afterFormat = """
+            key: value
+            nested:
+              inner: stuff
+        """.trimIndent()
+
+        val settings = CodeStyle.createTestSettings()
+        CodeStyle.doWithTemporarySettings(project, settings, Runnable {
+            myFixture.configureByText(KsonFileType, "<caret>\n$beforeFormat")
+
+            // type some stuff
+            myFixture.type("#")
+            myFixture.type("1")
+            myFixture.type("2")
+
+            // perform and verify the format action
+            myFixture.performEditorAction(IdeActions.ACTION_EDITOR_REFORMAT)
+            assertEquals("#12\n$afterFormat", myFixture.editor.document.text)
+
+            // undo the format
+            myFixture.performEditorAction(IdeActions.ACTION_UNDO)
+
+            // expect to be at exactly the previous state of unformatted + typed chars
+            assertEquals("#12\n$beforeFormat", myFixture.editor.document.text)
+        })
     }
 
     fun testObjectIndentation() {


### PR DESCRIPTION
Make `KsonExternalFormatter` an `AbstractDocumentFormattingService` rather than an `AsyncDocumentFormattingService` to work around a bug in how `AsyncDocumentFormattingService` formatting interacts with the IDE's undo stack.

Fixes an issue where, for example, if a user:
 - types some chars
 - performs a "Reformat File.."
 - performs an Undo

then the Undo would incorrectly undo one or more of the chars along with the format.

Note that we weren't using `AsyncDocumentFormattingService` for any particular reason other than finding it in example when learning how to implement an `ExternalFormatter` which could delegate down to `Kson.format`. Turns out `AsyncDocumentFormattingService` is intended for very slow formatters, which we are not and aspire to never be. `AbstractDocumentFormattingService` is simpler and more robust.