### PR TITLE
Add bin folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Thumbs.db
 out
 target
 build
+bin
 # gradlew generated files
 .gradle
 gradle/jdk


### PR DESCRIPTION
Setting `binaries.executable()` in the `build.gradle.kts` resulted in `bin` directories being created during build.