### PR TITLE
Make JSON test suite generator output consistent across platforms

### DIFF
--- a/buildSrc/src/main/kotlin/org/kson/jsonsuite/JsonTestSuiteGenerator.kt
+++ b/buildSrc/src/main/kotlin/org/kson/jsonsuite/JsonTestSuiteGenerator.kt
@@ -3,6 +3,7 @@ package org.kson.jsonsuite
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import java.io.File
 import java.nio.file.Path
 
 /**
@@ -340,7 +341,7 @@ private class JsonTestDataLoader(private val testDefinitionFilesDir: Path, priva
                 it.nameWithoutExtension,
                 // explicitly note UTF-8 here since the JSON spec specifies that as the proper json encoding
                 it.readText(Charsets.UTF_8),
-                it.absolutePath.replace("$projectRoot/", ""),
+                it.absolutePath.replace(File.separatorChar, '/').replace("${projectRoot.toString().replace(File.separatorChar, '/')}/", ""),
                 JsonTestSuiteEditList.get(it.name)
             )
         }.sortedBy { it.rawTestName }
@@ -371,7 +372,7 @@ private class SchemaTestDataLoader(private val testDefinitionFilesDir: Path, pri
                 val schemaTestGroups: List<SchemaTestGroup> = prettyPrintingJson.decodeFromString(contents)
                 SchemaTestData(
                     it.nameWithoutExtension,
-                    it.absolutePath.replace("$projectRoot/", ""),
+                    it.absolutePath.replace(File.separatorChar, '/').replace("${projectRoot.toString().replace(File.separatorChar, '/')}/", ""),
                     schemaTestGroups,
                 )
             }.sortedBy { it.filePathFromProjectRoot }


### PR DESCRIPTION
Internally, the test suite generator was using `/` as a path separator. However, when displaying paths it used the platform's path separator (because that's the default for types like `Path`). As a consequence, the generated files on Windows were slightly different than on *nix platforms (which in turn resulted in git thinking the generated files had been updated).

This change makes sure we use `/` when displaying paths as well, thereby ensuring that the generated files are exactly the same regardless of the operating system that runs the `generateJsonTestSuite` command.