### PR TITLE
Refactor: Generalize return types from `ImmutableList` to `List` for `LoggedMessage`

### DIFF
--- a/src/commonMain/kotlin/org/kson/Kson.kt
+++ b/src/commonMain/kotlin/org/kson/Kson.kt
@@ -3,7 +3,6 @@ package org.kson
 import org.kson.CompileTarget.*
 import org.kson.CompileTarget.Kson
 import org.kson.ast.*
-import org.kson.stdlibx.collections.ImmutableList
 import org.kson.parser.*
 import org.kson.parser.messages.MessageType
 import org.kson.tools.KsonFormatterConfig
@@ -98,7 +97,7 @@ interface ParseResult {
     /**
      * The user-facing messages logged during this parse
      */
-    val messages: ImmutableList<LoggedMessage>
+    val messages: List<LoggedMessage>
 
     /**
      * True if the input source could not be parsed. [messages] will contain errors in this case.

--- a/src/commonMain/kotlin/org/kson/parser/MessageSink.kt
+++ b/src/commonMain/kotlin/org/kson/parser/MessageSink.kt
@@ -1,6 +1,5 @@
 package org.kson.parser
 
-import org.kson.stdlibx.collections.ImmutableList
 import org.kson.stdlibx.collections.toImmutableList
 import org.kson.parser.messages.Message
 
@@ -45,7 +44,7 @@ class MessageSink {
      * Return the list of all [LoggedMessage]s sent to this [MessageSink],
      * in the order they were logged
      */
-    fun loggedMessages(): ImmutableList<LoggedMessage> {
+    fun loggedMessages(): List<LoggedMessage> {
         return messages.toImmutableList()
     }
 }

--- a/src/commonTest/kotlin/org/kson/KsonTestError.kt
+++ b/src/commonTest/kotlin/org/kson/KsonTestError.kt
@@ -30,7 +30,7 @@ open class KsonTestError {
         source: String,
         expectedParseMessageTypes: List<MessageType>,
         maxNestingLevel: Int? = null
-    ): ImmutableList<LoggedMessage> {
+    ): List<LoggedMessage> {
         val parseResult = if (maxNestingLevel != null) {
             Kson.parseToAst(source, CoreCompileConfig(maxNestingLevel = maxNestingLevel))
         } else {


### PR DESCRIPTION
Following discussion in #117 (@aochagavia), we likely don't want to expose `ImmutableList` in public APIs. This issue highlighted the exposure of `ImmutableList<LoggedMessage>`, which has now been replaced with the more 
general `List<LoggedMessage>` while preserving immutability internally.
