### PR TITLE
Fix: embed delimiter extraction in `KsonEmbedBlock`

### DIFF
--- a/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/psi/KsonEmbedBlock.kt
+++ b/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/psi/KsonEmbedBlock.kt
@@ -19,9 +19,9 @@ class KsonEmbedBlock(node: ASTNode) : KsonPsiElement(node) {
 
     companion object {
         private fun getDelim(host: KsonEmbedBlock): EmbedDelim {
-            return host.children.find {
-                it.node.elementType == elem(TokenType.EMBED_OPEN_DELIM)
-            }?.text?.let { EmbedDelim.fromString(it) } ?: throw ShouldNotHappenException("Embed delimiter not found")
+            val openEmbedDelim = host.children.getOrNull(0) ?: throw ShouldNotHappenException("Embed delimiter not found")
+            val embedDelim = openEmbedDelim.text.firstOrNull().let { EmbedDelim.fromString("$it$it") }
+            return embedDelim
         }
     }
 }

--- a/tooling/jetbrains/src/test/resources/testData/folding/embedBlockFolding.kson
+++ b/tooling/jetbrains/src/test/resources/testData/folding/embedBlockFolding.kson
@@ -15,3 +15,9 @@ tagged_block: <fold text='%%kotlin...%%'>%%kotlin
         console.log("Hello");
     }
 %%</fold>
+
+single_start_delim: <fold text='%%kotlin...%%'>%kotlin
+    function test() {
+        console.log("Hello");
+    }
+%%</fold>


### PR DESCRIPTION
The assumption in the existing getDelim code was that every embed block needs to have the token `EMBED_OPEN_DELIM`. However, that is not true. During parsing we also create an `EMBED_BLOCK_NODE` when the first delimiter is a `EMBED_OPEN_PARTIAL_DELIM`. What does stay true, is that an embed delimiter is always the first element in an embed block.