### PR TITLE
Bugfix message location

### DIFF
--- a/src/commonMain/kotlin/org/kson/parser/Lexer.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Lexer.kt
@@ -101,10 +101,8 @@ private class SourceScanner(private val source: String) {
      */
     fun currentLocation() =
         Location(
-            selectionFirstLine,
-            selectionFirstColumn,
-            selectionEndLine,
-            selectionEndColumn,
+            Position(selectionFirstLine, selectionFirstColumn),
+            Position(selectionEndLine, selectionEndColumn),
             selectionStartOffset,
             selectionEndOffset
         )
@@ -117,25 +115,37 @@ private class SourceScanner(private val source: String) {
 data class Lexeme(val text: String, val location: Location)
 
 /**
+ * [Position]s are used to describe the [Location.start] and [Location.end] of a chunk inside a
+ * given source file.
+ *
+ * @param line The zero-based line number
+ * @param column The zero-based column number
+ */
+data class Position(val line: Int, val column: Int) {
+    /**
+     *  Override the [toString] to easily print locations in error messages as base-1 indexed line/column numbers
+     *  following [the gnu standard](https://www.gnu.org/prep/standards/html_node/Errors.html)
+     *  for this sort of output
+     */
+    override fun toString(): String {
+        return "${line + 1}.${column + 1}"
+    }
+}
+
+/**
  * [Location]s describe the position of a chunk of source inside a given kson source file
  */
 data class Location(
     /**
-     * Line where this location starts (counting lines starting at zero)
+     * [Position] where this [Location] starts
      */
-    val firstLine: Int,
+    val start: Position,
+
     /**
-     * Column of [firstLine] where this location starts (counting columns starting zero)
+     * [Position] where this [Location] ends
      */
-    val firstColumn: Int,
-    /**
-     * Line where this location ends (counting lines starting at zero)
-     */
-    val lastLine: Int,
-    /**
-     * Column of [lastLine] where this location ends (counting columns starting at zero)
-     */
-    val lastColumn: Int,
+    val end: Position,
+
     /**
      * The zero-based start offset of this location relative to the whole document
      */
@@ -147,6 +157,36 @@ data class Location(
 ) {
     companion object {
         /**
+         * Creates a new [Location] instance using line and column positions directly.
+         *
+         * This factory method provides a convenient way to create a [Location] by specifying the positions
+         * as individual line and column numbers, without needing to construct [Position] objects first.
+         *
+         * @param firstLine The zero-based line number where the location starts
+         * @param firstColumn The zero-based column number where the location starts
+         * @param lastLine The zero-based line number where the location ends
+         * @param lastColumn The zero-based column number where the location ends
+         * @param startOffset The zero-based character offset from the start of the document to the location's start
+         * @param endOffset The zero-based character offset from the start of the document to the location's end
+         * @return A new [Location] instance with the specified positions
+         */
+        fun create(
+            firstLine: Int,
+            firstColumn: Int,
+            lastLine: Int,
+            lastColumn: Int,
+            startOffset: Int,
+            endOffset: Int
+        ): Location {
+            return Location(
+                Position(firstLine, firstColumn),
+                Position(lastLine, lastColumn),
+                startOffset,
+                endOffset
+            )
+        }
+
+        /**
          * Merge two locations into a Location which spans from the beginning of [startLocation] to the end of
          * [endLocation].  [startLocation] must be positioned before [endLocation]
          */
@@ -155,10 +195,8 @@ data class Location(
                 throw RuntimeException("`startLocation` must be before `endLocation`")
             }
             return Location(
-                startLocation.firstLine,
-                startLocation.firstColumn,
-                endLocation.lastLine,
-                endLocation.lastColumn,
+                startLocation.start,
+                endLocation.end,
                 startLocation.startOffset,
                 endLocation.endOffset
             )

--- a/src/commonMain/kotlin/org/kson/parser/MessageSink.kt
+++ b/src/commonMain/kotlin/org/kson/parser/MessageSink.kt
@@ -9,16 +9,17 @@ data class LoggedMessage(
 ) {
     companion object {
         /**
-         * Print a user-friendly version of a [List] of [LoggedMessage].  Note: locations
-         * are output as base-1 indexed firstLine/firstColumn/lastLine/lastColumn numbers
+         * Print a user-friendly version of a [List] of [LoggedMessage].
+         *
+         * Note: locations are output as base-1 indexed firstLine/firstColumn/lastLine/lastColumn numbers
          * following [the gnu standard](https://www.gnu.org/prep/standards/html_node/Errors.html)
          * for this sort of output
          */
         fun print(loggedMessages: List<LoggedMessage>): String {
             return loggedMessages.joinToString("\n") { loggedMessage ->
                 val location = loggedMessage.location
-                "Error:${location.firstLine + 1}.${location.firstColumn + 1}" +
-                        " - ${location.lastLine + 1}.${location.lastColumn + 1}, ${
+                "Error:${location.start}" +
+                        " - ${location.end}, ${
                             loggedMessage.message
                         }"
             }

--- a/src/commonTest/kotlin/org/kson/KsonTestError.kt
+++ b/src/commonTest/kotlin/org/kson/KsonTestError.kt
@@ -109,7 +109,7 @@ open class KsonTestError {
         assertParserRejectsSourceWithLocation(
             "{ key: value } 4.5",
             listOf(EOF_NOT_REACHED),
-            listOf(Location(0, 15, 0, 18, 15, 18))
+            listOf(Location.create(0, 15, 0, 18, 15, 18))
         )
         assertParserRejectsSource("key: value illegal extra identifiers", listOf(EOF_NOT_REACHED))
     }

--- a/src/commonTest/kotlin/org/kson/KsonTestListError.kt
+++ b/src/commonTest/kotlin/org/kson/KsonTestListError.kt
@@ -23,7 +23,7 @@ class KsonTestListError : KsonTestError() {
 
     @Test
     fun testUnclosedListError() {
-        assertParserRejectsSourceWithLocation("[", listOf(LIST_NO_CLOSE), listOf(Location(0, 0, 0, 1, 0, 1)))
+        assertParserRejectsSourceWithLocation("[", listOf(LIST_NO_CLOSE), listOf(Location.create(0, 0, 0, 1, 0, 1)))
         assertParserRejectsSource("[1,2,", listOf(LIST_NO_CLOSE))
     }
 

--- a/src/commonTest/kotlin/org/kson/parser/LexerTest.kt
+++ b/src/commonTest/kotlin/org/kson/parser/LexerTest.kt
@@ -640,24 +640,24 @@ class LexerTest {
             |}
             """.trimMargin(),
             listOf(
-                Pair(CURLY_BRACE_L, Location(0, 0, 0, 1, 0, 1)),
-                Pair(UNQUOTED_STRING, Location(1, 4, 1, 7, 6, 9)),
-                Pair(COLON, Location(1, 7, 1, 8, 9, 10)),
-                Pair(UNQUOTED_STRING, Location(1, 9, 1, 12, 11, 14)),
-                Pair(UNQUOTED_STRING, Location(2, 4, 2, 8, 19, 23)),
-                Pair(COLON, Location(2, 8, 2, 9, 23, 24)),
-                Pair(SQUARE_BRACKET_L, Location(2, 10, 2, 11, 25, 26)),
-                Pair(TRUE, Location(2, 11, 2, 15, 26, 30)),
-                Pair(COMMA, Location(2, 15, 2, 16, 30, 31)),
-                Pair(FALSE, Location(2, 17, 2, 22, 32, 37)),
-                Pair(SQUARE_BRACKET_R, Location(2, 22, 2, 23, 37, 38)),
-                Pair(UNQUOTED_STRING, Location(3, 4, 3, 9, 43, 48)),
-                Pair(COLON, Location(3, 9, 3, 10, 48, 49)),
-                Pair(EMBED_OPEN_DELIM, Location(3, 11, 3, 13, 50, 52)),
-                Pair(EMBED_PREAMBLE_NEWLINE, Location(3, 13, 4, 0, 52, 53)),
-                Pair(EMBED_CONTENT, Location(4, 0, 7, 6, 53, 128)),
-                Pair(EMBED_CLOSE_DELIM, Location(7, 6, 7, 8, 128, 130)),
-                Pair(CURLY_BRACE_R, Location(8, 0, 8, 1, 131, 132))
+                Pair(CURLY_BRACE_L, Location.create(0, 0, 0, 1, 0, 1)),
+                Pair(UNQUOTED_STRING, Location.create(1, 4, 1, 7, 6, 9)),
+                Pair(COLON, Location.create(1, 7, 1, 8, 9, 10)),
+                Pair(UNQUOTED_STRING, Location.create(1, 9, 1, 12, 11, 14)),
+                Pair(UNQUOTED_STRING, Location.create(2, 4, 2, 8, 19, 23)),
+                Pair(COLON, Location.create(2, 8, 2, 9, 23, 24)),
+                Pair(SQUARE_BRACKET_L, Location.create(2, 10, 2, 11, 25, 26)),
+                Pair(TRUE, Location.create(2, 11, 2, 15, 26, 30)),
+                Pair(COMMA, Location.create(2, 15, 2, 16, 30, 31)),
+                Pair(FALSE, Location.create(2, 17, 2, 22, 32, 37)),
+                Pair(SQUARE_BRACKET_R, Location.create(2, 22, 2, 23, 37, 38)),
+                Pair(UNQUOTED_STRING, Location.create(3, 4, 3, 9, 43, 48)),
+                Pair(COLON, Location.create(3, 9, 3, 10, 48, 49)),
+                Pair(EMBED_OPEN_DELIM, Location.create(3, 11, 3, 13, 50, 52)),
+                Pair(EMBED_PREAMBLE_NEWLINE, Location.create(3, 13, 4, 0, 52, 53)),
+                Pair(EMBED_CONTENT, Location.create(4, 0, 7, 6, 53, 128)),
+                Pair(EMBED_CLOSE_DELIM, Location.create(7, 6, 7, 8, 128, 130)),
+                Pair(CURLY_BRACE_R, Location.create(8, 0, 8, 1, 131, 132))
             )
         )
     }
@@ -772,14 +772,14 @@ class LexerTest {
                 |
             """.trimMargin(),
             listOf(
-                Pair(WHITESPACE, Location(0, 0, 0, 2, 0, 2)),
-                Pair(UNQUOTED_STRING, Location(0, 2, 0, 8, 2, 8)),
-                Pair(COLON, Location(0, 8, 0, 9, 8, 9)),
-                Pair(WHITESPACE, Location(0, 9, 0, 10, 9, 10)),
-                Pair(STRING_OPEN_QUOTE, Location(0, 10, 0, 11, 10, 11)),
-                Pair(STRING_CONTENT, Location(0, 11, 0, 17, 11, 17)),
-                Pair(STRING_CLOSE_QUOTE, Location(0, 17, 0, 18, 17, 18)),
-                Pair(WHITESPACE, Location(0, 18, 1, 0, 18, 19))
+                Pair(WHITESPACE, Location.create(0, 0, 0, 2, 0, 2)),
+                Pair(UNQUOTED_STRING, Location.create(0, 2, 0, 8, 2, 8)),
+                Pair(COLON, Location.create(0, 8, 0, 9, 8, 9)),
+                Pair(WHITESPACE, Location.create(0, 9, 0, 10, 9, 10)),
+                Pair(STRING_OPEN_QUOTE, Location.create(0, 10, 0, 11, 10, 11)),
+                Pair(STRING_CONTENT, Location.create(0, 11, 0, 17, 11, 17)),
+                Pair(STRING_CLOSE_QUOTE, Location.create(0, 17, 0, 18, 17, 18)),
+                Pair(WHITESPACE, Location.create(0, 18, 1, 0, 18, 19))
             ),
             true
         )

--- a/src/commonTest/kotlin/org/kson/parser/ParserTest.kt
+++ b/src/commonTest/kotlin/org/kson/parser/ParserTest.kt
@@ -20,8 +20,8 @@ class ParserTest {
     @Test
     fun testSanityCheckParse() {
         val nullTokenStream = listOf(
-            Token(TokenType.NULL, Lexeme("null", Location(0, 0, 0, 4, 0, 4)), "null"),
-            Token(TokenType.EOF, Lexeme("", Location(0, 4, 0, 4, 4, 4)), "")
+            Token(TokenType.NULL, Lexeme("null", Location.create(0, 0, 0, 4, 0, 4)), "null"),
+            Token(TokenType.EOF, Lexeme("", Location.create(0, 4, 0, 4, 4, 4)), "")
         )
         val builder = KsonBuilder(nullTokenStream)
         Parser(builder).parse()


### PR DESCRIPTION
The fuction `Location.merge()` accidentally used the `Location.firstLine` instead of `Location.firstColumn`. 

In commit  d2ccb9a7c1872fac8799958ab54ccf2882643d54 we fix this bug. In commit f556aa2d155466a528cf424f5e0230e7a95bc2d1 we refactor `Location` to use `Position` for the start and end location which makes it harder to run into the same mistake in the future.