### PR TITLE
Revert "Bugfix message location"

### DIFF
--- a/src/commonMain/kotlin/org/kson/parser/Lexer.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Lexer.kt
@@ -103,8 +103,10 @@ private class SourceScanner(private val source: String) {
      */
     fun currentLocation() =
         Location(
-            Position(selectionFirstLine, selectionFirstColumn),
-            Position(selectionEndLine, selectionEndColumn),
+            selectionFirstLine,
+            selectionFirstColumn,
+            selectionEndLine,
+            selectionEndColumn,
             selectionStartOffset,
             selectionEndOffset
         )
@@ -119,39 +121,27 @@ private class SourceScanner(private val source: String) {
 data class Lexeme(val text: String, val location: Location)
 
 /**
- * [Position]s are used to describe the [Location.start] and [Location.end] of a chunk inside a
- * given source file.
- *
- * @param line The zero-based line number
- * @param column The zero-based column number
- */
-data class Position(val line: Int, val column: Int) {
-    /**
-     *  Override the [toString] to easily print locations in error messages as base-1 indexed line/column numbers
-     *  following [the gnu standard](https://www.gnu.org/prep/standards/html_node/Errors.html)
-     *  for this sort of output
-     */
-    override fun toString(): String {
-        return "${line + 1}.${column + 1}"
-    }
-}
-
-/**
  * [Location]s describe the position of a chunk of source inside a given kson source file
  */
 @OptIn(ExperimentalJsExport::class)
 @JsExport
 data class Location(
     /**
-     * [Position] where this [Location] starts
+     * Line where this location starts (counting lines starting at zero)
      */
-    val start: Position,
-
+    val firstLine: Int,
     /**
-     * [Position] where this [Location] ends
+     * Column of [firstLine] where this location starts (counting columns starting zero)
      */
-    val end: Position,
-
+    val firstColumn: Int,
+    /**
+     * Line where this location ends (counting lines starting at zero)
+     */
+    val lastLine: Int,
+    /**
+     * Column of [lastLine] where this location ends (counting columns starting at zero)
+     */
+    val lastColumn: Int,
     /**
      * The zero-based start offset of this location relative to the whole document
      */
@@ -163,36 +153,6 @@ data class Location(
 ) {
     companion object {
         /**
-         * Creates a new [Location] instance using line and column positions directly.
-         *
-         * This factory method provides a convenient way to create a [Location] by specifying the positions
-         * as individual line and column numbers, without needing to construct [Position] objects first.
-         *
-         * @param firstLine The zero-based line number where the location starts
-         * @param firstColumn The zero-based column number where the location starts
-         * @param lastLine The zero-based line number where the location ends
-         * @param lastColumn The zero-based column number where the location ends
-         * @param startOffset The zero-based character offset from the start of the document to the location's start
-         * @param endOffset The zero-based character offset from the start of the document to the location's end
-         * @return A new [Location] instance with the specified positions
-         */
-        fun create(
-            firstLine: Int,
-            firstColumn: Int,
-            lastLine: Int,
-            lastColumn: Int,
-            startOffset: Int,
-            endOffset: Int
-        ): Location {
-            return Location(
-                Position(firstLine, firstColumn),
-                Position(lastLine, lastColumn),
-                startOffset,
-                endOffset
-            )
-        }
-
-        /**
          * Merge two locations into a Location which spans from the beginning of [startLocation] to the end of
          * [endLocation].  [startLocation] must be positioned before [endLocation]
          */
@@ -201,8 +161,10 @@ data class Location(
                 throw RuntimeException("`startLocation` must be before `endLocation`")
             }
             return Location(
-                startLocation.start,
-                endLocation.end,
+                startLocation.firstLine,
+                startLocation.firstLine,
+                endLocation.lastLine,
+                endLocation.lastColumn,
                 startLocation.startOffset,
                 endLocation.endOffset
             )

--- a/src/commonMain/kotlin/org/kson/parser/MessageSink.kt
+++ b/src/commonMain/kotlin/org/kson/parser/MessageSink.kt
@@ -13,17 +13,16 @@ data class LoggedMessage(
 ) {
     companion object {
         /**
-         * Print a user-friendly version of a [List] of [LoggedMessage].
-         *
-         * Note: locations are output as base-1 indexed firstLine/firstColumn/lastLine/lastColumn numbers
+         * Print a user-friendly version of a [List] of [LoggedMessage].  Note: locations
+         * are output as base-1 indexed firstLine/firstColumn/lastLine/lastColumn numbers
          * following [the gnu standard](https://www.gnu.org/prep/standards/html_node/Errors.html)
          * for this sort of output
          */
         fun print(loggedMessages: List<LoggedMessage>): String {
             return loggedMessages.joinToString("\n") { loggedMessage ->
                 val location = loggedMessage.location
-                "Error:${location.start}" +
-                        " - ${location.end}, ${
+                "Error:${location.firstLine + 1}.${location.firstColumn + 1}" +
+                        " - ${location.lastLine + 1}.${location.lastColumn + 1}, ${
                             loggedMessage.message
                         }"
             }

--- a/src/commonTest/kotlin/org/kson/KsonTestError.kt
+++ b/src/commonTest/kotlin/org/kson/KsonTestError.kt
@@ -1,10 +1,10 @@
 package org.kson
 
 import org.kson.ast.KsonRoot
-import org.kson.parser.Location
 import org.kson.parser.LoggedMessage
 import org.kson.parser.messages.MessageType
 import org.kson.parser.messages.MessageType.*
+import org.kson.stdlibx.collections.ImmutableList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -56,31 +56,6 @@ open class KsonTestError {
         return parseResult.messages
     }
 
-    /**
-     * Calls [assertParserRejectsSource], but also tests the [Location] of each [LoggedMessage]
-     * by asserting it against [expectedParseMessageLocation].
-     *
-     * @param source is the kson source to parse into a [KsonRoot]
-     * @param expectedParseMessageTypes a list of [MessageType]s produced by parsing [source]
-     * @param expectedParseMessageLocation a list of [Location]s produced by parsing [source]
-     * @param maxNestingLevel the maximum allowable nested lists and objects to configure the parser to accept
-     * @return the produced messages for further validation
-     */
-    protected fun assertParserRejectsSourceWithLocation(
-        source: String,
-        expectedParseMessageTypes: List<MessageType>,
-        expectedParseMessageLocation: List<Location>,
-        maxNestingLevel: Int? = null,
-    ): List<LoggedMessage> {
-        val loggedMessages = assertParserRejectsSource(source, expectedParseMessageTypes, maxNestingLevel)
-        assertEquals(
-            expectedParseMessageLocation,
-            loggedMessages.map { it.location },
-            "Should have the expected locations for the messages."
-        )
-        return loggedMessages
-    }
-
     @Test
     fun testBlankKsonSource() {
         assertParserRejectsSource("", listOf(BLANK_SOURCE))
@@ -106,11 +81,7 @@ open class KsonTestError {
     @Test
     fun testInvalidTrailingKson() {
         assertParserRejectsSource("[1] illegal_key: illegal_value", listOf(EOF_NOT_REACHED))
-        assertParserRejectsSourceWithLocation(
-            "{ key: value } 4.5",
-            listOf(EOF_NOT_REACHED),
-            listOf(Location.create(0, 15, 0, 18, 15, 18))
-        )
+        assertParserRejectsSource("{ key: value } 4.5", listOf(EOF_NOT_REACHED))
         assertParserRejectsSource("key: value illegal extra identifiers", listOf(EOF_NOT_REACHED))
     }
 

--- a/src/commonTest/kotlin/org/kson/KsonTestListError.kt
+++ b/src/commonTest/kotlin/org/kson/KsonTestListError.kt
@@ -3,6 +3,7 @@ package org.kson
 import org.kson.parser.Location
 import org.kson.parser.messages.MessageType.*
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class KsonTestListError : KsonTestError() {
     @Test
@@ -23,7 +24,8 @@ class KsonTestListError : KsonTestError() {
 
     @Test
     fun testUnclosedListError() {
-        assertParserRejectsSourceWithLocation("[", listOf(LIST_NO_CLOSE), listOf(Location.create(0, 0, 0, 1, 0, 1)))
+        val errorMessages = assertParserRejectsSource("[", listOf(LIST_NO_CLOSE))
+        assertEquals(Location(0, 0, 0, 1, 0, 1), errorMessages[0].location)
         assertParserRejectsSource("[1,2,", listOf(LIST_NO_CLOSE))
     }
 

--- a/src/commonTest/kotlin/org/kson/parser/LexerTest.kt
+++ b/src/commonTest/kotlin/org/kson/parser/LexerTest.kt
@@ -640,24 +640,24 @@ class LexerTest {
             |}
             """.trimMargin(),
             listOf(
-                Pair(CURLY_BRACE_L, Location.create(0, 0, 0, 1, 0, 1)),
-                Pair(UNQUOTED_STRING, Location.create(1, 4, 1, 7, 6, 9)),
-                Pair(COLON, Location.create(1, 7, 1, 8, 9, 10)),
-                Pair(UNQUOTED_STRING, Location.create(1, 9, 1, 12, 11, 14)),
-                Pair(UNQUOTED_STRING, Location.create(2, 4, 2, 8, 19, 23)),
-                Pair(COLON, Location.create(2, 8, 2, 9, 23, 24)),
-                Pair(SQUARE_BRACKET_L, Location.create(2, 10, 2, 11, 25, 26)),
-                Pair(TRUE, Location.create(2, 11, 2, 15, 26, 30)),
-                Pair(COMMA, Location.create(2, 15, 2, 16, 30, 31)),
-                Pair(FALSE, Location.create(2, 17, 2, 22, 32, 37)),
-                Pair(SQUARE_BRACKET_R, Location.create(2, 22, 2, 23, 37, 38)),
-                Pair(UNQUOTED_STRING, Location.create(3, 4, 3, 9, 43, 48)),
-                Pair(COLON, Location.create(3, 9, 3, 10, 48, 49)),
-                Pair(EMBED_OPEN_DELIM, Location.create(3, 11, 3, 13, 50, 52)),
-                Pair(EMBED_PREAMBLE_NEWLINE, Location.create(3, 13, 4, 0, 52, 53)),
-                Pair(EMBED_CONTENT, Location.create(4, 0, 7, 6, 53, 128)),
-                Pair(EMBED_CLOSE_DELIM, Location.create(7, 6, 7, 8, 128, 130)),
-                Pair(CURLY_BRACE_R, Location.create(8, 0, 8, 1, 131, 132))
+                Pair(CURLY_BRACE_L, Location(0, 0, 0, 1, 0, 1)),
+                Pair(UNQUOTED_STRING, Location(1, 4, 1, 7, 6, 9)),
+                Pair(COLON, Location(1, 7, 1, 8, 9, 10)),
+                Pair(UNQUOTED_STRING, Location(1, 9, 1, 12, 11, 14)),
+                Pair(UNQUOTED_STRING, Location(2, 4, 2, 8, 19, 23)),
+                Pair(COLON, Location(2, 8, 2, 9, 23, 24)),
+                Pair(SQUARE_BRACKET_L, Location(2, 10, 2, 11, 25, 26)),
+                Pair(TRUE, Location(2, 11, 2, 15, 26, 30)),
+                Pair(COMMA, Location(2, 15, 2, 16, 30, 31)),
+                Pair(FALSE, Location(2, 17, 2, 22, 32, 37)),
+                Pair(SQUARE_BRACKET_R, Location(2, 22, 2, 23, 37, 38)),
+                Pair(UNQUOTED_STRING, Location(3, 4, 3, 9, 43, 48)),
+                Pair(COLON, Location(3, 9, 3, 10, 48, 49)),
+                Pair(EMBED_OPEN_DELIM, Location(3, 11, 3, 13, 50, 52)),
+                Pair(EMBED_PREAMBLE_NEWLINE, Location(3, 13, 4, 0, 52, 53)),
+                Pair(EMBED_CONTENT, Location(4, 0, 7, 6, 53, 128)),
+                Pair(EMBED_CLOSE_DELIM, Location(7, 6, 7, 8, 128, 130)),
+                Pair(CURLY_BRACE_R, Location(8, 0, 8, 1, 131, 132))
             )
         )
     }
@@ -772,14 +772,14 @@ class LexerTest {
                 |
             """.trimMargin(),
             listOf(
-                Pair(WHITESPACE, Location.create(0, 0, 0, 2, 0, 2)),
-                Pair(UNQUOTED_STRING, Location.create(0, 2, 0, 8, 2, 8)),
-                Pair(COLON, Location.create(0, 8, 0, 9, 8, 9)),
-                Pair(WHITESPACE, Location.create(0, 9, 0, 10, 9, 10)),
-                Pair(STRING_OPEN_QUOTE, Location.create(0, 10, 0, 11, 10, 11)),
-                Pair(STRING_CONTENT, Location.create(0, 11, 0, 17, 11, 17)),
-                Pair(STRING_CLOSE_QUOTE, Location.create(0, 17, 0, 18, 17, 18)),
-                Pair(WHITESPACE, Location.create(0, 18, 1, 0, 18, 19))
+                Pair(WHITESPACE, Location(0, 0, 0, 2, 0, 2)),
+                Pair(UNQUOTED_STRING, Location(0, 2, 0, 8, 2, 8)),
+                Pair(COLON, Location(0, 8, 0, 9, 8, 9)),
+                Pair(WHITESPACE, Location(0, 9, 0, 10, 9, 10)),
+                Pair(STRING_OPEN_QUOTE, Location(0, 10, 0, 11, 10, 11)),
+                Pair(STRING_CONTENT, Location(0, 11, 0, 17, 11, 17)),
+                Pair(STRING_CLOSE_QUOTE, Location(0, 17, 0, 18, 17, 18)),
+                Pair(WHITESPACE, Location(0, 18, 1, 0, 18, 19))
             ),
             true
         )

--- a/src/commonTest/kotlin/org/kson/parser/ParserTest.kt
+++ b/src/commonTest/kotlin/org/kson/parser/ParserTest.kt
@@ -20,8 +20,8 @@ class ParserTest {
     @Test
     fun testSanityCheckParse() {
         val nullTokenStream = listOf(
-            Token(TokenType.NULL, Lexeme("null", Location.create(0, 0, 0, 4, 0, 4)), "null"),
-            Token(TokenType.EOF, Lexeme("", Location.create(0, 4, 0, 4, 4, 4)), "")
+            Token(TokenType.NULL, Lexeme("null", Location(0, 0, 0, 4, 0, 4)), "null"),
+            Token(TokenType.EOF, Lexeme("", Location(0, 4, 0, 4, 4, 4)), "")
         )
         val builder = KsonBuilder(nullTokenStream)
         Parser(builder).parse()


### PR DESCRIPTION
Reverts kson-org/kson#127

How unusual... prior to merging, this [successfully built](https://app.circleci.com/pipelines/github/kson-org/kson/257/workflows/6fa37c74-6e21-41a1-ab53-59f1479134a3/jobs/257), but then our builds started failing and needing the fix in https://github.com/kson-org/kson/pull/129.  And now the `Position` class introduced in #127 causes an issue with our build??

One possible explanation: CircleCI may have upgraded the linux image our tests run on, causing the `libncurses` issue that #129 fixes, and possibly also revealing a new and valid issue with #127.

We definitely want to reapply #127, but to make troubleshooting organized and clear, I'm reverting it here, then I'll hopefully get a green run of #129 so we can merge that, then we can see how things behave on the changes in #127

/cc @holodorum  