### PR TITLE
Test to ensure optional comma precedence

### DIFF
--- a/src/commonTest/kotlin/org/kson/KsonTestObject.kt
+++ b/src/commonTest/kotlin/org/kson/KsonTestObject.kt
@@ -61,6 +61,81 @@ class KsonTestObject : KsonTest {
         )
     }
 
+    /**
+     * For plain/un-delimited objects nested in []-bracket lists, objects have precedence for any optional commas given
+     */
+    @Test
+    fun testObjectCommaPrecedence() {
+        assertParsesTo(
+            """
+                [
+                  ObjA1: 1,
+                  ObjA2: [
+                    nested1:v,
+                    nested2:v,
+                    nested3:v,
+                    .,
+                    alsoNested:v,
+                  ],
+                  ObjA3: 3,
+                  
+                  "A string",
+                  
+                  ObjB4: 4,
+                ]
+            """.trimIndent(),
+            """
+                - ObjA1: 1
+                  ObjA2:
+                    - nested1: v
+                      nested2: v
+                      nested3: v
+                
+                    - alsoNested: v
+                      .
+                  ObjA3: 3
+
+                - 'A string'
+                - ObjB4: 4
+            """.trimIndent(),
+            """
+                - ObjA1: 1
+                  ObjA2:
+                    - nested1: v
+                      nested2: v
+                      nested3: v
+                
+                    - alsoNested: v
+                  ObjA3: 3
+
+                - "A string"
+                - ObjB4: 4
+            """.trimIndent(),
+            """
+                [
+                  {
+                    "ObjA1": 1,
+                    "ObjA2": [
+                      {
+                        "nested1": "v",
+                        "nested2": "v",
+                        "nested3": "v"
+                      },
+                      {
+                        "alsoNested": "v"
+                      }
+                    ],
+                    "ObjA3": 3
+                  },
+                  "A string",
+                  {
+                    "ObjB4": 4
+                  }
+                ]
+            """.trimIndent()
+        )
+    }
+
     @Test
     fun testObjectSourceMixedWithStringContainingRawNewlines() {
         assertParsesTo(


### PR DESCRIPTION
Add a test to ensure our precedence for optional commas: a comma between two object properties in a bracket-list belongs to the object, not the list.  i.e. this value:

```
[
  k1: v,
  k2: v
]
```

is always parsed as a list of one object with two properties:

```
- k1: v
  k2: v
```

The grammar for objects already specifies this fairly clearly, but it's nice to have a test which explicitly ensures this remains true in the face of future changes since it is a subtle and important distinction.