### PR TITLE
Formatting for docs with illegal trailing content

### DIFF
--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -164,6 +164,7 @@ interface KsonRoot : AstNode
 class KsonRootError(content: String, location: Location) : KsonRoot, AstNodeError(content, location)
 class KsonRootImpl(
     val rootNode: KsonValueNode,
+    private val trailingContent: KsonValueNodeError?,
     override val comments: List<String>,
     private val documentEndComments: List<String>,
     location: Location
@@ -180,6 +181,10 @@ class KsonRootImpl(
                 // remove any trailing newlines
                 while(ksonDocument.endsWith("\n")) {
                     ksonDocument = ksonDocument.removeSuffix("\n")
+                }
+
+                if (trailingContent != null) {
+                    ksonDocument += "\n\n" + trailingContent.toSourceWithNext(indent, null, compileTarget)
                 }
 
                 if (compileTarget.preserveComments && documentEndComments.isNotEmpty()) {

--- a/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
+++ b/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
@@ -1209,4 +1209,24 @@ class FormatterTest {
         """.trimIndent()
         )
     }
+
+    /**
+     * If a Kson document is fairly well-formed but has some unexpected trialing content, we should still
+     * be able to format the valid portion of the document
+     */
+    @Test
+    fun testFormattingSucceedsWithInvalidTrailingContent() {
+        assertFormatting(
+            """
+                {outer:{inner: value}}
+                "Illegal trailing content"
+            """.trimIndent(),
+            """
+                outer:
+                  inner: value
+
+                "Illegal trailing content"
+            """.trimIndent()
+        )
+    }
 }


### PR DESCRIPTION
If a Kson document is fairly well-formed but has some unexpected trialing content, we should still be able to format the valid portion of the document.  This also offsets the illegal trailing content, likely helping a user see and understand the error more easily.

Contrived example: given a syntactically noisy case like

```
{key:[{}]}[]
```

we are now able to format, yielding clarity for both legal value and the illegal trailing `[]`:

```
key:
  - {}

[] # <-- this is marked as "Unexpected trailing content"
```