### PR TITLE
Helpful errors for reserved word object keys

### DIFF
--- a/src/commonMain/kotlin/org/kson/parser/Parser.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Parser.kt
@@ -500,6 +500,21 @@ class Parser(private val builder: AstBuilder, private val maxNestingLevel: Int =
      * keyword -> ( UNQUOTED_STRING | string ) ":"
      */
     private fun keyword(): Boolean {
+        // helpful errors for keywords that clash with reserved words
+        if ((builder.getTokenType() == NULL
+                    || builder.getTokenType() == TRUE
+                    || builder.getTokenType() == FALSE
+                ) && builder.lookAhead(1) == COLON) {
+            val keywordMark = builder.mark()
+            val reservedWord = builder.getTokenText()
+            builder.advanceLexer()
+            keywordMark.error(OBJECT_KEYWORD_RESERVED_WORD.create(reservedWord))
+
+            // advance past the COLON
+            builder.advanceLexer()
+            return true
+        }
+
         // try to parse a keyword in the style of "UNQUOTED_STRING followed by :"
         if (builder.getTokenType() == UNQUOTED_STRING && builder.lookAhead(1) == COLON) {
             val keywordMark = builder.mark()

--- a/src/commonMain/kotlin/org/kson/parser/messages/Message.kt
+++ b/src/commonMain/kotlin/org/kson/parser/messages/Message.kt
@@ -127,6 +127,16 @@ enum class MessageType {
             return "This object key must be followed by a value"
         }
     },
+    OBJECT_KEYWORD_RESERVED_WORD {
+        override fun expectedArgs(): List<String> {
+            return listOf("Reserved Word")
+        }
+
+        override fun doFormat(parsedArgs: ParsedErrorArgs): String {
+            val reservedWord = parsedArgs.getArg("Reserved Word")
+            return "`$reservedWord` cannot be used as an object key"
+        }
+    },
     IGNORED_OBJECT_END_DOT {
         override fun expectedArgs(): List<String> {
             return emptyList()

--- a/src/commonTest/kotlin/org/kson/KsonTestObjectError.kt
+++ b/src/commonTest/kotlin/org/kson/KsonTestObjectError.kt
@@ -57,4 +57,17 @@ class KsonTestObjectError : KsonTestError {
             listOf(IGNORED_OBJECT_END_DOT, IGNORED_OBJECT_END_DOT)
         )
     }
+
+    @Test
+    fun testHelpfulErrorForReservedWordKeys() {
+        assertParserRejectsSource(
+            """
+               key: value
+               null: "can't use null as a key" 
+               true: "can't use true as a key" 
+               false: "can't use false as a key" 
+            """.trimIndent(),
+            listOf(OBJECT_KEYWORD_RESERVED_WORD, OBJECT_KEYWORD_RESERVED_WORD, OBJECT_KEYWORD_RESERVED_WORD)
+        )
+    }
 }


### PR DESCRIPTION
Improve our parsing and error messaging when `null`/`true`/`false` are used as keywords.  We used to stop parsing early in this case because we'd parse the reserved word then bump into an unexpected colon. We now allow parsing to continue as if this were a legal keyword, marking it with a helpful and precise error.