### PR TITLE
Process `stringContent` in KsonApi

### DIFF
--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -364,6 +364,10 @@ interface StringNode : KsonValueNode
 class StringNodeError(content: String, location: Location) : StringNode, AstNodeError(content, location)
 abstract class StringNodeImpl(location: Location) : StringNode, KsonValueNodeImpl(location) {
     abstract val stringContent: String
+
+    val processedStringContent: String by lazy {
+        unescapeStringContent(stringContent)
+    }
 }
 
 /**

--- a/src/commonMain/kotlin/org/kson/ast/Escaping.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Escaping.kt
@@ -97,3 +97,110 @@ private fun appendSurrogatePair(sb: StringBuilder, codePoint: Int) {
     appendUnicodeEscape(sb, high)
     appendUnicodeEscape(sb, low)
 }
+
+/**
+ * Unescape a string by converting escape sequences back to their original characters.
+ * This is the reverse operation of [renderForJsonString].
+ *
+ * @param stringContent to unescape
+ * @return the unescaped string
+ */
+fun unescapeStringContent(stringContent: String): String {
+    val sb = StringBuilder(stringContent.length)
+    var i = 0
+    
+    while (i < stringContent.length) {
+        val char = stringContent[i]
+        
+        if (char == '\\' && i + 1 < stringContent.length) {
+            when (val escaped = stringContent[i + 1]) {
+                '"', '\\', '/' -> {
+                    sb.append(escaped)
+                    i += 2
+                }
+                'b' -> {
+                    sb.append('\b')
+                    i += 2
+                }
+                'f' -> {
+                    sb.append('\u000C')
+                    i += 2
+                }
+                'n' -> {
+                    sb.append('\n')
+                    i += 2
+                }
+                'r' -> {
+                    sb.append('\r')
+                    i += 2
+                }
+                't' -> {
+                    sb.append('\t')
+                    i += 2
+                }
+                'u' -> {
+                    val (chars, consumed) = handleUnicodeEscape(stringContent.substring(i))
+                    for (c in chars) {
+                        sb.append(c)
+                    }
+                    i += consumed
+                }
+                else -> {
+                    // Unknown escape sequence, append backslash as is
+                    sb.append(char)
+                    i++
+                }
+            }
+        } else {
+            sb.append(char)
+            i++
+        }
+    }
+    
+    return sb.toString()
+}
+
+/**
+ * Handles Unicode escape sequences including surrogate pairs.
+ *
+ * @param input the string containing the Unicode escape starting with \u
+ * @return Pair of (characters produced, characters consumed from input)
+ */
+private fun handleUnicodeEscape(input: String): Pair<CharArray, Int> {
+    // Check if we have enough characters for a Unicode escape (\uXXXX = 6 chars)
+    if (input.length < 6) {
+        // Not enough characters for a valid Unicode escape
+        return Pair(charArrayOf('\\'), 1)
+    }
+
+    // Check if this is actually a Unicode escape
+    if (input[0] != '\\' || input[1] != 'u') {
+        return Pair(charArrayOf('\\'), 1)
+    }
+
+    val hexStr = input.substring(2, 6)
+    val codePoint = hexStr.toIntOrNull(16) ?: run {
+        // Invalid hex sequence, return backslash
+        return Pair(charArrayOf('\\'), 1)
+    }
+
+    // Check for high surrogate
+    if (codePoint.toChar().isHighSurrogate()) {
+        // Look for low surrogate
+        if (input.length >= 12 &&
+            input[6] == '\\' &&
+            input[7] == 'u') {
+
+            val lowHexStr = input.substring(8, 12)
+            val lowCodePoint = lowHexStr.toIntOrNull(16)
+
+            if (lowCodePoint != null && lowCodePoint.toChar().isLowSurrogate()) {
+                // Valid surrogate pair - return both surrogates and consumed 12 chars
+                return Pair(charArrayOf(codePoint.toChar(), lowCodePoint.toChar()), 12)
+            }
+        }
+    }
+
+    // Regular Unicode character or unpaired surrogate - consumed 6 chars
+    return Pair(charArrayOf(codePoint.toChar()), 6)
+}

--- a/src/commonMain/kotlin/org/kson/ast/KsonApi.kt
+++ b/src/commonMain/kotlin/org/kson/ast/KsonApi.kt
@@ -160,7 +160,7 @@ fun AstNode.toKsonApi(): KsonApi {
             value.toKsonApi() as KsonValue,
             location)
         is EmbedBlockNode -> EmbedBlock(embedTag, embedContent, location)
-        is StringNodeImpl -> KsonString(stringContent, location)
+        is StringNodeImpl -> KsonString(processedStringContent, location)
         is NumberNode -> KsonNumber(value, location)
         is TrueNode -> KsonBoolean(true, location)
         is FalseNode -> KsonBoolean(false, location)


### PR DESCRIPTION
To account for unprocessed characters in string inputs, the `KsonApi` now returns the `processedStringContent` instead of the `stringContent`. This change is aimed at resolving issues caused by unprocessed escape sequences, Unicode characters, and control characters in the string content.
Specifically we ran into an issue with this when evaluating a `patternProperty` from a JsonSchema that contained `'\/'`. Passing that unprocessed to `Regex` results in a syntax error. First processing or evaluating the string solves this class of issues.
