### PR TITLE
Polish our Kson API into `KsonValue`

### DIFF
--- a/lib-kotlin/src/commonMain/kotlin/org/kson/Kson.kt
+++ b/lib-kotlin/src/commonMain/kotlin/org/kson/Kson.kt
@@ -5,7 +5,6 @@ package org.kson
 
 import org.kson.Kson.parseSchema
 import org.kson.Kson.publishMessages
-import org.kson.ast.KsonValue
 import org.kson.parser.*
 import org.kson.schema.JsonSchema
 import org.kson.tools.FormattingStyle as InternalFormattingStyle
@@ -135,9 +134,9 @@ class SchemaValidator internal constructor(private val schema: JsonSchema) {
         }
 
         val messageSink = MessageSink()
-        val ksonApi = astParseResult.api
-        if (ksonApi != null) {
-            schema.validate(ksonApi as KsonValue, messageSink)
+        val ksonValue = astParseResult.ksonValue
+        if (ksonValue != null) {
+            schema.validate(ksonValue, messageSink)
         }
 
         return publishMessages(messageSink.loggedMessages())

--- a/src/commonMain/kotlin/org/kson/KsonCore.kt
+++ b/src/commonMain/kotlin/org/kson/KsonCore.kt
@@ -18,8 +18,8 @@ import org.kson.tools.KsonFormatterConfig
 object KsonCore {
     /**
      * Parse the given Kson [source] to an [AstParseResult]. This is the base parse for all the [CompileTarget]s
-     * we support, and may be used as a standalone parse to validate a [Kson] document or obtain a [KsonApi]
-     * from [AstParseResult.api]
+     * we support, and may be used as a standalone parse to validate a [Kson] document or obtain a [KsonValue]
+     * from [AstParseResult.ksonValue]
      *
      * @param source The Kson source to parse
      * @param coreCompileConfig the [CoreCompileConfig] for this parse
@@ -46,7 +46,7 @@ object KsonCore {
         } else {
             val jsonSchema = coreCompileConfig.schemaJson
             // validate against our schema, logging any errors to our message sink
-            jsonSchema.validate(ast?.toKsonApi() as KsonValue, messageSink)
+            jsonSchema.validate(ast?.toKsonValue() as KsonValue, messageSink)
             return AstParseResult(ast, tokens, messageSink)
         }
     }
@@ -63,13 +63,13 @@ object KsonCore {
         if (firstToken.tokenType == TokenType.EOF) {
             return SchemaParseResult(null, listOf(LoggedMessage(firstToken.lexeme.location, SCHEMA_EMPTY_SCHEMA.create())))
         }
-        val ksonApi = astParseResult.api
-        if (ksonApi == null || astParseResult.hasErrors()) {
+        val ksonValue = astParseResult.ksonValue
+        if (ksonValue == null || astParseResult.hasErrors()) {
             return SchemaParseResult(null, astParseResult.messages)
         }
 
         val messageSink = MessageSink()
-        val jsonSchema = SchemaParser.parseSchemaElement(ksonApi as KsonValue, messageSink)
+        val jsonSchema = SchemaParser.parseSchemaElement(ksonValue, messageSink)
         return SchemaParseResult(jsonSchema, messageSink.loggedMessages())
     }
 
@@ -146,14 +146,14 @@ data class AstParseResult(
     override val messages = messageSink.loggedMessages()
 
     /**
-     * A [KsonApi] on the AST constructed here, or null if there were errors trying to parse
+     * A [KsonValue] on the AST constructed here, or null if there were errors trying to parse
      * (consult [messageSink] for information on any errors)
      */
-    val api: KsonApi? by lazy {
+    val ksonValue: KsonValue? by lazy {
         if (ast == null || hasErrors()) {
             null
         } else {
-            ast.toKsonApi()
+            ast.toKsonValue()
         }
     }
 

--- a/src/commonMain/kotlin/org/kson/KsonValue.kt
+++ b/src/commonMain/kotlin/org/kson/KsonValue.kt
@@ -1,16 +1,16 @@
-package org.kson.ast
+package org.kson
 
+import org.kson.ast.*
 import org.kson.parser.Location
 import org.kson.parser.NumberParser
+import org.kson.stdlibx.exceptions.ShouldNotHappenException
 
 /**
- * The [KsonApi] classes provide a client-friendly API interface for fully valid Kson [AstNode] trees that
+ * The [KsonValue] classes provide a client-friendly API interface for fully valid Kson [AstNode] trees that
  * exposes just the data properties of the represented Kson and can be traversed confidently without
  * any error- or null-checking
  */
-sealed class KsonApi(val location: Location)
-
-abstract class KsonValue(location: Location) : KsonApi(location) {
+sealed class KsonValue(val location: Location) {
     /**
      * Ensure all our [KsonValue] classes implement their [equals] and [hashCode]
      */
@@ -18,11 +18,11 @@ abstract class KsonValue(location: Location) : KsonApi(location) {
     abstract override fun hashCode(): Int
 }
 
-class KsonObject(val propertyList: List<KsonObjectProperty>, location: Location) : KsonValue(location) {
-    val propertyMap: Map<String, KsonValue> by lazy {
-        propertyList.associate { it.name.value to it.ksonValue }
-    }
-
+class KsonObject(val propertyMap: Map<KsonString, KsonValue>, location: Location) : KsonValue(location) {
+    /**
+     * Convenience lookup with the [KsonString] keys transformed to regular [String]s
+     */
+    val propertyLookup = propertyMap.mapKeys { it.key.value }
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is KsonObject) return false
@@ -39,7 +39,7 @@ class KsonObject(val propertyList: List<KsonObjectProperty>, location: Location)
     }
 }
 
-class KsonList(val elements: List<KsonListElement>, location: Location) : KsonValue(location) {
+class KsonList(val elements: List<KsonValue>, location: Location) : KsonValue(location) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is KsonList) return false
@@ -47,19 +47,15 @@ class KsonList(val elements: List<KsonListElement>, location: Location) : KsonVa
         if (elements.size != other.elements.size) return false
         
         return elements.zip(other.elements).all { (a, b) ->
-            a.ksonValue == b.ksonValue
+            a == b
         }
     }
 
     override fun hashCode(): Int {
-        return elements.map { it.ksonValue.hashCode() }.hashCode()
+        return elements.map { it.hashCode() }.hashCode()
     }
 }
 
-class KsonListElement(val ksonValue: KsonValue, location: Location) : KsonApi(location)
-class KsonObjectProperty(val name: KsonString,
-                         val ksonValue: KsonValue,
-                         location: Location) :KsonApi(location)
 class EmbedBlock(val embedTag: String,
                  val embedContent: String,
                  location: Location) : KsonValue(location) {
@@ -139,29 +135,44 @@ class KsonNull(location: Location) : KsonValue(location) {
     }
 }
 
-fun AstNode.toKsonApi(): KsonApi {
+fun AstNode.toKsonValue(): KsonValue {
     if (this !is AstNodeImpl) {
         /**
-         * Must have a fully valid [AstNodeImpl] to create an [KsonApi] for it
+         * Must have a fully valid [AstNodeImpl] to create an [KsonValue] for it
          */
-        throw RuntimeException("Cannot create ${KsonApi::class.simpleName} Node from a ${this::class.simpleName}")
+        throw RuntimeException("Cannot create ${KsonValue::class.simpleName} Node from a ${this::class.simpleName}")
     }
     return when (this) {
-        is KsonRootImpl -> rootNode.toKsonApi()
-        is ObjectNode -> KsonObject(properties.map { it.toKsonApi() as KsonObjectProperty }, location)
-        is ListNode -> KsonList(elements.map { it.toKsonApi() as KsonListElement }, location)
-        is ListElementNodeImpl -> KsonListElement(value.toKsonApi() as KsonValue, location)
-        is ObjectPropertyNodeImpl -> KsonObjectProperty(
-            name.toKsonApi() as KsonString,
-            value.toKsonApi() as KsonValue,
-            location)
+        is KsonRootImpl -> rootNode.toKsonValue()
+        is ObjectNode -> {
+            KsonObject(properties.associate { prop ->
+                val propImpl = prop as? ObjectPropertyNodeImpl
+                    ?: throw ShouldNotHappenException("this AST if fully valid")
+                val propName = propImpl.name as? StringNodeImpl
+                    ?: throw ShouldNotHappenException("this AST if fully valid")
+                propName.toKsonValue() as KsonString to propImpl.value.toKsonValue()
+            },
+                location)
+        }
+        is ListNode -> KsonList(elements.map { elem ->
+            val listElementNode = elem as? ListElementNodeImpl
+                ?: throw ShouldNotHappenException("this AST if fully valid")
+            listElementNode.value.toKsonValue()
+
+        }, location)
         is EmbedBlockNode -> EmbedBlock(embedTag, embedContent, location)
         is StringNodeImpl -> KsonString(processedStringContent, location)
         is NumberNode -> KsonNumber(value, location)
         is TrueNode -> KsonBoolean(true, location)
         is FalseNode -> KsonBoolean(false, location)
         is NullNode -> KsonNull(location)
-        is KsonValueNodeImpl -> this.toKsonApi() as KsonValue
-        is AstNodeError -> throw RuntimeException("Cannot create Valid Ast Node from ${this::class.simpleName}")
+        is KsonValueNodeImpl -> this.toKsonValue()
+        is ObjectPropertyNodeImpl -> {
+            throw ShouldNotHappenException("these properties are processed above in the ${ObjectNode::class.simpleName} case")
+        }
+        is ListElementNodeImpl -> {
+            throw ShouldNotHappenException("these elements are processed above in the ${ListNode::class.simpleName} case")
+        }
+        is AstNodeError -> throw ShouldNotHappenException("Cannot create Valid Ast Node from ${this::class.simpleName}")
     }
 }

--- a/src/commonMain/kotlin/org/kson/schema/JsonSchema.kt
+++ b/src/commonMain/kotlin/org/kson/schema/JsonSchema.kt
@@ -1,6 +1,7 @@
 package org.kson.schema
-import org.kson.ast.KsonNumber
-import org.kson.ast.KsonValue
+import org.kson.KsonNumber
+import org.kson.KsonString
+import org.kson.KsonValue
 import org.kson.parser.MessageSink
 import org.kson.parser.NumberParser
 import org.kson.parser.messages.MessageType
@@ -26,7 +27,7 @@ class JsonObjectSchema(
   val title: String?,
   val description: String?,
   val default: KsonValue?,
-  val definitions: Map<String, JsonSchema?>?,
+  val definitions: Map<KsonString, JsonSchema?>?,
 
   private val typeValidator: TypeValidator?,
   private val schemaValidators: List<JsonSchemaValidator>

--- a/src/commonMain/kotlin/org/kson/schema/JsonSchemaValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/JsonSchemaValidator.kt
@@ -1,10 +1,10 @@
 package org.kson.schema
 
-import org.kson.ast.KsonList
-import org.kson.ast.KsonNumber
-import org.kson.ast.KsonObject
-import org.kson.ast.KsonString
-import org.kson.ast.KsonValue
+import org.kson.KsonList
+import org.kson.KsonNumber
+import org.kson.KsonObject
+import org.kson.KsonString
+import org.kson.KsonValue
 import org.kson.parser.MessageSink
 
 // schema todo capture file/location info from schema to link back to schema def?

--- a/src/commonMain/kotlin/org/kson/schema/validators/AllOfValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/AllOfValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonValue
+import org.kson.KsonValue
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonSchema

--- a/src/commonMain/kotlin/org/kson/schema/validators/AnyOfValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/AnyOfValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonValue
+import org.kson.KsonValue
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonSchema

--- a/src/commonMain/kotlin/org/kson/schema/validators/ConstValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/ConstValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonValue
+import org.kson.KsonValue
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonSchemaValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/ContainsValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/ContainsValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonList
+import org.kson.KsonList
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonArrayValidator
@@ -10,7 +10,7 @@ class ContainsValidator(private val containsSchema: JsonSchema) : JsonArrayValid
     override fun validateArray(node: KsonList, messageSink: MessageSink) {
         val foundMatchingElement = node.elements.any { element ->
             val containsMessageSink = MessageSink()
-            containsSchema.validate(element.ksonValue, containsMessageSink)
+            containsSchema.validate(element, containsMessageSink)
             !containsMessageSink.hasErrors()
         }
         if (!foundMatchingElement) {

--- a/src/commonMain/kotlin/org/kson/schema/validators/DependenciesValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/DependenciesValidator.kt
@@ -1,12 +1,13 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonObject
+import org.kson.KsonObject
+import org.kson.KsonString
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonObjectValidator
 import org.kson.schema.JsonSchema
 
-class DependenciesValidator(private val dependencies: Map<String, DependencyValidator>)
+class DependenciesValidator(private val dependencies: Map<KsonString, DependencyValidator>)
     : JsonObjectValidator() {
     override fun validateObject(node: KsonObject, messageSink: MessageSink) {
         val properties = node.propertyMap
@@ -21,7 +22,7 @@ class DependenciesValidator(private val dependencies: Map<String, DependencyVali
 sealed interface DependencyValidator {
     fun validate(ksonObject: KsonObject, messageSink: MessageSink): Boolean
 }
-data class DependencyValidatorArray(val dependency: Set<String>) : DependencyValidator {
+data class DependencyValidatorArray(val dependency: Set<KsonString>) : DependencyValidator {
     override fun validate(ksonObject: KsonObject, messageSink: MessageSink): Boolean {
         val propertyNames = ksonObject.propertyMap.keys
         val allPresent = dependency.all {

--- a/src/commonMain/kotlin/org/kson/schema/validators/EnumValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/EnumValidator.kt
@@ -1,14 +1,14 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonList
-import org.kson.ast.KsonValue
+import org.kson.KsonList
+import org.kson.KsonValue
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonSchemaValidator
 
 class EnumValidator(private val enum: KsonList) : JsonSchemaValidator {
     override fun validate(ksonValue: KsonValue, messageSink: MessageSink) {
-        val enumValues = enum.elements.map { it.ksonValue }
+        val enumValues = enum.elements
         if (!enumValues.contains(ksonValue)) {
             messageSink.error(ksonValue.location, MessageType.SCHEMA_ENUM_VALUE_NOT_ALLOWED.create())
         }

--- a/src/commonMain/kotlin/org/kson/schema/validators/ExclusiveMaximumValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/ExclusiveMaximumValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonNumber
+import org.kson.KsonNumber
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonNumberValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/ExclusiveMinimumValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/ExclusiveMinimumValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonNumber
+import org.kson.KsonNumber
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonNumberValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/IfValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/IfValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonValue
+import org.kson.KsonValue
 import org.kson.parser.MessageSink
 import org.kson.schema.JsonSchema
 import org.kson.schema.JsonSchemaValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/ItemsValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/ItemsValidator.kt
@@ -1,7 +1,7 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonList
-import org.kson.ast.KsonValue
+import org.kson.KsonList
+import org.kson.KsonValue
 import org.kson.parser.Location
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
@@ -27,11 +27,11 @@ data class LeadingItemsTupleValidator(private val schemas: List<JsonSchema>) : L
             if (i >= list.elements.size) {
                 break
             }
-            schemas[i].validate(list.elements[i].ksonValue, messageSink)
+            schemas[i].validate(list.elements[i], messageSink)
             index = i + 1
         }
         return if (index < list.elements.size) {
-            list.elements.subList(index, list.elements.size).map { it.ksonValue }
+            list.elements.subList(index, list.elements.size)
         } else {
             emptyList()
         }
@@ -41,7 +41,7 @@ data class LeadingItemsTupleValidator(private val schemas: List<JsonSchema>) : L
 data class LeadingItemsSchemaValidator(private val jsonSchema: JsonSchema): LeadingItemsValidator {
     override fun validateArray(list: KsonList, messageSink: MessageSink): List<KsonValue> {
         list.elements.forEach {
-            jsonSchema.validate(it.ksonValue, messageSink)
+            jsonSchema.validate(it, messageSink)
         }
         return emptyList()
     }

--- a/src/commonMain/kotlin/org/kson/schema/validators/MaxItemsValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/MaxItemsValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonList
+import org.kson.KsonList
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonArrayValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/MaxLengthValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/MaxLengthValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonString
+import org.kson.KsonString
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonStringValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/MaxPropertiesValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/MaxPropertiesValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonObject
+import org.kson.KsonObject
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonObjectValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/MaximumValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/MaximumValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonNumber
+import org.kson.KsonNumber
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonNumberValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/MinItemsValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/MinItemsValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonList
+import org.kson.KsonList
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonArrayValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/MinLengthValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/MinLengthValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonString
+import org.kson.KsonString
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonStringValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/MinPropertiesValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/MinPropertiesValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonObject
+import org.kson.KsonObject
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonObjectValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/MinimumValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/MinimumValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonNumber
+import org.kson.KsonNumber
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonNumberValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/MultipleOfValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/MultipleOfValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonNumber
+import org.kson.KsonNumber
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonNumberValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/NotValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/NotValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonValue
+import org.kson.KsonValue
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonSchema

--- a/src/commonMain/kotlin/org/kson/schema/validators/OneOfValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/OneOfValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonValue
+import org.kson.KsonValue
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonSchema

--- a/src/commonMain/kotlin/org/kson/schema/validators/PatternValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/PatternValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonString
+import org.kson.KsonString
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonStringValidator

--- a/src/commonMain/kotlin/org/kson/schema/validators/PropertyNamesValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/PropertyNamesValidator.kt
@@ -1,14 +1,14 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonObject
+import org.kson.KsonObject
 import org.kson.parser.MessageSink
 import org.kson.schema.JsonObjectValidator
 import org.kson.schema.JsonSchema
 
 class PropertyNamesValidator(private val propertyNamesSchema: JsonSchema?) : JsonObjectValidator() {
     override fun validateObject(node: KsonObject, messageSink: MessageSink) {
-        node.propertyList.forEach {
-            propertyNamesSchema?.validate(it.name, messageSink)
+        node.propertyMap.forEach { (name, _) ->
+            propertyNamesSchema?.validate(name, messageSink)
         }
     }
 }

--- a/src/commonMain/kotlin/org/kson/schema/validators/RequiredValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/RequiredValidator.kt
@@ -1,11 +1,12 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonObject
+import org.kson.KsonObject
+import org.kson.KsonString
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonObjectValidator
 
-class RequiredValidator(private val required: List<String>) : JsonObjectValidator() {
+class RequiredValidator(private val required: List<KsonString>) : JsonObjectValidator() {
     override fun validateObject(node: KsonObject, messageSink: MessageSink) {
         val propertyNames = node.propertyMap.keys
         val missingProperties = required.filter { !propertyNames.contains(it) }

--- a/src/commonMain/kotlin/org/kson/schema/validators/TypeValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/TypeValidator.kt
@@ -1,6 +1,6 @@
 package org.kson.schema.validators
 
-import org.kson.ast.*
+import org.kson.*
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.asSchemaInteger

--- a/src/commonMain/kotlin/org/kson/schema/validators/UniqueItemsValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/UniqueItemsValidator.kt
@@ -1,7 +1,7 @@
 package org.kson.schema.validators
 
-import org.kson.ast.KsonList
-import org.kson.ast.KsonListElement
+import org.kson.KsonList
+import org.kson.KsonValue
 import org.kson.parser.MessageSink
 import org.kson.parser.messages.MessageType
 import org.kson.schema.JsonArrayValidator
@@ -16,10 +16,10 @@ class UniqueItemsValidator(private val uniqueItems: Boolean) : JsonArrayValidato
     /**
      * Check if all items in a list are unique using JSON Schema equality semantics.
      */
-    private fun areItemsUnique(elements: List<KsonListElement>): Boolean {
+    private fun areItemsUnique(elements: List<KsonValue>): Boolean {
         for (i in elements.indices) {
             for (j in i + 1 until elements.size) {
-                if (elements[i].ksonValue == elements[j].ksonValue) {
+                if (elements[i] == elements[j]) {
                     return false
                 }
             }


### PR DESCRIPTION
Satisfying refactor! Finally looked at `KsonApi` just right to succeed in fully object-modelling what we were actually after: a programmatic representation of Kson data, i.e. a `KsonValue`

The `KsonApi` class seemed necessary because neither `ListElement`s nor `ObjectProperty`s are Kson values, but that made the types just a bit awkward... finally fix it with an approach that seems obvious now that we've done it: we unpack `ListElement`s and `ObjectProperties` as part of creating `KsonList`s and `KsonObject`s.  The change then of course flows through to all callers really nicely, making their use of this "API" even cleaner.