### PR TITLE
Fix bug Compact Formatting

### DIFF
--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -255,6 +255,9 @@ class ObjectNode(val properties: List<ObjectPropertyNode>, location: Location) :
                     property is ObjectPropertyNodeImpl &&
                     result.last() != '\n' &&
                     when (property.value) {
+                        is QuotedStringNode -> {
+                            StringUnquoted.isUnquotable(property.value.stringContent)
+                        }
                         is UnquotedStringNode,
                         is NumberNode,
                         is TrueNode,
@@ -348,9 +351,8 @@ class ObjectPropertyNodeImpl(
         val firstObjectPropertyHasComments =
             (value is ObjectNode) && (value.properties.first() is ObjectPropertyNodeImpl)
                     && ((value.properties.first() as ObjectPropertyNodeImpl).comments.isNotEmpty())
-
-
         val nextNodeHasComments = (nextNode is Documented && nextNode.comments.isNotEmpty())
+
         return name.toSourceWithNext(indent, value, compileTarget) + ":" +
                 if (firstObjectPropertyHasComments) {
                     "\n"

--- a/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
+++ b/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
@@ -1414,6 +1414,19 @@ class FormatterTest {
     fun testCompactFormattingStyleSimpleObject() {
         assertFormatting(
             """
+                "type": "object",
+                "properties": {
+                x: w
+                }
+            """.trimIndent(),
+            """
+                type:object properties:x:w
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.COMPACT
+        )
+
+        assertFormatting(
+            """
                 {
                   key: value
                   key: value


### PR DESCRIPTION
Of course we should also add a space in compact mode if the properties value can be formatted as an unquoted string.