### PR TITLE
Different higlighting object keys and strings

### DIFF
--- a/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/highlighter/KsonAnnotator.kt
+++ b/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/highlighter/KsonAnnotator.kt
@@ -1,0 +1,25 @@
+package org.kson.jetbrains.highlighter
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.project.DumbAware
+import com.intellij.psi.PsiElement
+import org.kson.jetbrains.parser.elem
+import org.kson.parser.ParsedElementType
+
+/**
+ * [KsonAnnotator] provides semantic highlighting for Kson files.
+ *
+ * Since we don't require any indices we can implement [DumbAware]
+ */
+class KsonAnnotator : Annotator, DumbAware {
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        // Implement syntax highlighter that distinguishes regular strings from object keys.
+        if (elem(ParsedElementType.OBJECT_KEY) == element.node.elementType){
+            holder.newSilentAnnotation(HighlightSeverity.INFORMATION).textAttributes(
+                KsonSyntaxHighlighter.getTextAttributesKey(KsonSyntaxHighlighter.KsonColorTag.KSON_OBJECT_KEY)
+            ).create()
+        }
+    }
+}

--- a/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/highlighter/KsonSyntaxHighlighter.kt
+++ b/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/highlighter/KsonSyntaxHighlighter.kt
@@ -71,7 +71,8 @@ class KsonSyntaxHighlighter : SyntaxHighlighterBase() {
         KSON_KEYWORD(KsonBundle.message("kson.syntaxHighlighter.keyword")),
         KSON_INVALID(KsonBundle.message("kson.syntaxHighlighter.invalid")),
         KSON_NUMBER(KsonBundle.message("kson.syntaxHighlighter.number")),
-        KSON_CONTENT(KsonBundle.message("kson.syntaxHighlighter.content"));
+        KSON_CONTENT(KsonBundle.message("kson.syntaxHighlighter.content")),
+        KSON_OBJECT_KEY(KsonBundle.message("kson.syntaxHighlighter.key"));
     }
 
     companion object {
@@ -85,11 +86,12 @@ class KsonSyntaxHighlighter : SyntaxHighlighterBase() {
             KSON_COMMENT to DefaultLanguageHighlighterColors.BLOCK_COMMENT,
             KSON_DELIMITER to DefaultLanguageHighlighterColors.SEMICOLON,
             KSON_EMBED_TAG to DefaultLanguageHighlighterColors.METADATA,
-            KSON_UNQUOTED_STRING to DefaultLanguageHighlighterColors.INSTANCE_FIELD,
+            KSON_UNQUOTED_STRING to DefaultLanguageHighlighterColors.STRING,
             KSON_KEYWORD to DefaultLanguageHighlighterColors.KEYWORD,
             KSON_INVALID to HighlighterColors.BAD_CHARACTER,
             KSON_NUMBER to DefaultLanguageHighlighterColors.NUMBER,
             KSON_CONTENT to DefaultLanguageHighlighterColors.STRING,
+            KSON_OBJECT_KEY to DefaultLanguageHighlighterColors.INSTANCE_FIELD,
         )
 
         private val textAttributesMap = keyToColorMap.entries.associate {

--- a/tooling/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/tooling/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -45,5 +45,7 @@
         <enterHandlerDelegate implementation="org.kson.jetbrains.editor.KsonEnterHandlerDelegate"/>
         <lang.foldingBuilder language="kson"
                              implementationClass="org.kson.jetbrains.folding.KsonFoldingBuilder"/>
+        <annotator language="kson"
+                   implementationClass="org.kson.jetbrains.highlighter.KsonAnnotator"/>
     </extensions>
 </idea-plugin>

--- a/tooling/jetbrains/src/main/resources/messages/KsonBundle.properties
+++ b/tooling/jetbrains/src/main/resources/messages/KsonBundle.properties
@@ -15,3 +15,4 @@ kson.syntaxHighlighter.keyword=Keyword
 kson.syntaxHighlighter.invalid=Invalid
 kson.syntaxHighlighter.number=Number
 kson.syntaxHighlighter.content=Content
+kson.syntaxHighlighter.key=Key

--- a/tooling/jetbrains/src/test/kotlin/org/kson/jetbrains/highlighter/KsonAnnotatorTest.kt
+++ b/tooling/jetbrains/src/test/kotlin/org/kson/jetbrains/highlighter/KsonAnnotatorTest.kt
@@ -1,0 +1,18 @@
+package org.kson.jetbrains.highlighter
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class KsonAnnotatorTest : BasePlatformTestCase() {
+    
+    override fun getTestDataPath(): String {
+        return "src/test/resources/testData/annotator"
+    }
+
+    fun testObjectKeys() {
+        myFixture.testHighlighting(false, true, false, "objectKeys.kson")
+    }
+
+    fun testStringValues() {
+        myFixture.testHighlighting(false, true, false, "stringValues.kson")
+    }
+}

--- a/tooling/jetbrains/src/test/resources/testData/annotator/objectKeys.kson
+++ b/tooling/jetbrains/src/test/resources/testData/annotator/objectKeys.kson
@@ -1,0 +1,7 @@
+{
+    <info textAttributesKey="KSON_OBJECT_KEY">simpleKey</info>: "value"
+    <info textAttributesKey="KSON_OBJECT_KEY">"quotedKey"</info>: "another value"
+    <info textAttributesKey="KSON_OBJECT_KEY">nested</info>: {
+        <info textAttributesKey="KSON_OBJECT_KEY">innerKey</info>: true
+    }
+}

--- a/tooling/jetbrains/src/test/resources/testData/annotator/stringValues.kson
+++ b/tooling/jetbrains/src/test/resources/testData/annotator/stringValues.kson
@@ -1,0 +1,4 @@
+{
+    <info textAttributesKey="KSON_OBJECT_KEY">list</info>: ["not a key", "also not a key"]
+    <info textAttributesKey="KSON_OBJECT_KEY">value</info>: "this is a value, not a key"
+}


### PR DESCRIPTION
Our IntelliJ plugin only provided syntax highlighting based off the `Lexer`. However, in that way we couldn't distinguish between strings and object keys, since that information only becomes available after the document is parsed. By implementing an `Annotator` we are able to easily separate strings from object keys.