### PR TITLE
Introduce `EMBED_PREAMBLE` and `EMBED_METADATA`

### DIFF
--- a/lib-kotlin/src/commonMain/kotlin/org/kson/Kson.kt
+++ b/lib-kotlin/src/commonMain/kotlin/org/kson/Kson.kt
@@ -223,6 +223,8 @@ enum class TokenType {
     EMBED_OPEN_DELIM,
     EMBED_CLOSE_DELIM,
     EMBED_TAG,
+    EMBED_TAG_STOP,
+    EMBED_METADATA,
     EMBED_PREAMBLE_NEWLINE,
     EMBED_CONTENT,
     FALSE,
@@ -390,6 +392,12 @@ private fun convertTokens(internalTokens: List<InternalToken>): List<Token> {
             }
             InternalTokenType.EOF -> {
                 tokens.add(createPublicToken(TokenType.EOF, currentToken))
+            }
+            InternalTokenType.EMBED_METADATA -> {
+                tokens.add(createPublicToken(TokenType.EMBED_METADATA, currentToken))
+            }
+            InternalTokenType.EMBED_TAG_STOP -> {
+                tokens.add(createPublicToken(TokenType.EMBED_TAG_STOP, currentToken))
             }
         }
         i++

--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -656,7 +656,7 @@ class NullNode(location: Location) : KsonValueNodeImpl(location) {
     }
 }
 
-class EmbedBlockNode(val embedTag: String, embedContent: String, embedDelim: EmbedDelim, location: Location) :
+class EmbedBlockNode(val embedTag: String, private val metadataTag: String, embedContent: String, embedDelim: EmbedDelim, location: Location) :
     KsonValueNodeImpl(location) {
 
     val embedContent: String by lazy { embedDelim.unescapeEmbedContent(embedContent) }
@@ -694,17 +694,19 @@ class EmbedBlockNode(val embedTag: String, embedContent: String, embedDelim: Emb
                         chosenDelimiter to chosenDelimiter.escapeEmbedContent(embedContent)
                     }
                 }
+
+                val embedPreamble = embedTag + if(metadataTag.isNotEmpty()) ": $metadataTag" else ""
                 when (compileTarget.formatConfig.formattingStyle){
                     FormattingStyle.PLAIN, FormattingStyle.DELIMITED -> {
                         // Format the embed block
-                        indent.firstLineIndent() + delimiter.openDelimiter + embedTag + "\n" +
+                        indent.firstLineIndent() + delimiter.openDelimiter + embedPreamble + "\n" +
                                 indent.bodyLinesIndent() + content.split("\n")
                             .joinToString("\n${indent.bodyLinesIndent()}") { it } +
                                 delimiter.closeDelimiter
                     }
                     FormattingStyle.COMPACT -> {
                         // Format the embed block
-                        delimiter.openDelimiter + embedTag + "\n" +
+                        delimiter.openDelimiter + embedPreamble + "\n" +
                                 content.split("\n")
                             .joinToString("\n") { it } +
                                 delimiter.closeDelimiter

--- a/src/commonMain/kotlin/org/kson/parser/ElementType.kt
+++ b/src/commonMain/kotlin/org/kson/parser/ElementType.kt
@@ -51,6 +51,14 @@ enum class TokenType : ElementType {
      */
     EMBED_TAG,
     /**
+     * The divider between the [EMBED_TAG] and [EMBED_METADATA]
+     */
+    EMBED_TAG_STOP,
+    /**
+     * The part of the [EMBED_TAG] which can be used as metadata
+     */
+    EMBED_METADATA,
+    /**
      * The newline that ends the "preamble" of an embed block (i.e. the [EMBED_OPEN_DELIM] and possibly an [EMBED_TAG])
      * [EMBED_CONTENT] begins on the line immediately after the [EMBED_PREAMBLE_NEWLINE]
      */

--- a/src/commonMain/kotlin/org/kson/parser/KsonBuilder.kt
+++ b/src/commonMain/kotlin/org/kson/parser/KsonBuilder.kt
@@ -219,10 +219,12 @@ class KsonBuilder(private val tokens: List<Token>, private val errorTolerant: Bo
                         val embedDelimChar = childMarkers.find { it.element == EMBED_OPEN_DELIM }?.getValue()
                             ?: throw ShouldNotHappenException("The parser should have ensured we could find an open delim here")
                         val embedTag = childMarkers.find { it.element == EMBED_TAG }?.getValue() ?: ""
+                        val metadataTag = childMarkers.find { it.element == EMBED_METADATA }?.getValue() ?: ""
                         val embedContent = childMarkers.find { it.element == EMBED_CONTENT }?.getValue() ?: ""
 
                         EmbedBlockNode(
                             embedTag,
+                            metadataTag,
                             embedContent,
                             EmbedDelim.fromString(embedDelimChar),
                             marker.getLocation())

--- a/src/commonMain/kotlin/org/kson/parser/Lexer.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Lexer.kt
@@ -486,10 +486,18 @@ class Lexer(source: String, gapFree: Boolean = false) {
         } else if (sourceScanner.eof()) {
             return
         } else {
+            /**
+             * Our source scanner is still in the embed preamble so long as this condition holds
+             */
+            val stillInEmbedPreamble:(delimChar: Char) -> Boolean = {
+                !sourceScanner.eof()
+                        && !(sourceScanner.peek() == delimChar && sourceScanner.peekNext() == delimChar)
+                        && sourceScanner.peek() != '\n'
+            }
+
             // we have an embed tag, let's scan it
-            while (!sourceScanner.eof()
-                && !(sourceScanner.peek() == delimChar && sourceScanner.peekNext() == delimChar)
-                && sourceScanner.peek() != '\n') {
+            while (stillInEmbedPreamble(delimChar)
+                && sourceScanner.peek() != ':') {
                 sourceScanner.advance()
             }
 
@@ -500,6 +508,24 @@ class Lexer(source: String, gapFree: Boolean = false) {
                 // trim any trailing whitespace from the embed tag's value
                 embedTagLexeme.text.trim()
             )
+
+            if(sourceScanner.peek() == ':') {
+                sourceScanner.advance()
+                addLiteralToken(EMBED_TAG_STOP)
+
+                // scan any metadata given in the preamble
+                while (stillInEmbedPreamble(delimChar)) {
+                    sourceScanner.advance()
+                }
+
+                // extract our embed metadata (note: may be empty, that's supported)
+                val embedMetadataLexeme = sourceScanner.extractLexeme()
+                addToken(
+                    EMBED_METADATA, embedMetadataLexeme,
+                    // trim any trailing whitespace from the embed tag's value
+                    embedMetadataLexeme.text.trim()
+                )
+            }
 
             // lex this premature embed end
             if (sourceScanner.peek() == delimChar && sourceScanner.peekNext() == delimChar) {

--- a/src/commonMain/kotlin/org/kson/parser/Parser.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Parser.kt
@@ -34,7 +34,8 @@ import org.kson.stdlibx.exceptions.ShouldNotHappenException
  * literal -> string | NUMBER | "true" | "false" | "null"
  * keyword -> string ":"
  * string -> (STRING_OPEN_QUOTE STRING_CONTENT STRING_CLOSE_QUOTE) | UNQUOTED_STRING
- * embedBlock -> EMBED_OPEN_DELIM (EMBED_TAG) EMBED_PREAMBLE_NEWLINE CONTENT EMBED_CLOSE_DELIM
+ * embedBlock -> EMBED_OPEN_DELIM EMBED_PREAMBLE EMBED_PREAMBLE_NEWLINE CONTENT EMBED_CLOSE_DELIM
+ * EMBED_PREAMBLE -> EMBED_TAG (":" EMBED_METADATA)?
  * ```
  *
  * See [section 5.1 here](https://craftinginterpreters.com/representing-code.html#context-free-grammars)
@@ -627,6 +628,48 @@ class Parser(private val builder: AstBuilder, private val maxNestingLevel: Int =
         return validStringEscapes.contains(escapedChar)
     }
 
+    /**
+     * EMBED_PREAMBLE -> EMBED_TAG (":" EMBED_METADATA)?
+     *
+     * Note: the preamble may be empty, so this always "succeeds" in parsing its rule
+     * @return the text of the parsed embed preamble (possibly empty)
+     */
+    private fun embedPreamble(): String {
+        val embedTagMark = builder.mark()
+        val embedTag = if (builder.getTokenType() == EMBED_TAG) {
+            val tagText = builder.getTokenText()
+            builder.advanceLexer()
+            embedTagMark.done(EMBED_TAG)
+            
+            // Check for optional meta tag
+            val embedMeta = if (builder.getTokenType() == EMBED_TAG_STOP) {
+                val embedTagDelim = builder.mark()
+                builder.advanceLexer()
+                embedTagDelim.done(EMBED_TAG_STOP)
+
+                val metaTagMark = builder.mark()
+                val metaText = builder.getTokenText()
+                builder.advanceLexer()
+                metaTagMark.done(EMBED_METADATA)
+                metaText
+            } else {
+                ""
+            }
+            
+            // Combine tags if both present
+            if (embedMeta.isNotEmpty()) {
+                "$tagText:$embedMeta"
+            } else {
+                tagText
+            }
+        } else {
+            embedTagMark.drop()
+            ""
+        }
+        
+        return embedTag
+    }
+
     private fun isValidUnicodeEscape(unicodeEscapeText: String): Boolean {
         if (!unicodeEscapeText.startsWith("\\u")) {
             throw RuntimeException("Should only be asked to validate unicode escapes")
@@ -661,18 +704,7 @@ class Parser(private val builder: AstBuilder, private val maxNestingLevel: Int =
             builder.advanceLexer()
             embedBlockStartDelimMark.done(EMBED_OPEN_DELIM)
 
-            val embedTagMark = builder.mark()
-            val embedTagText = if (builder.getTokenType() == EMBED_TAG) {
-                val tagText = builder.getTokenText()
-                // advance past our optional embed tag
-                builder.advanceLexer()
-                embedTagMark.done(EMBED_TAG)
-                tagText
-            } else {
-                // no embed tag
-                embedTagMark.drop()
-                ""
-            }
+            val embedPreambleText = embedPreamble()
 
             val prematureEndMark = builder.mark()
             if (builder.getTokenType() == EMBED_CLOSE_DELIM) {
@@ -681,7 +713,7 @@ class Parser(private val builder: AstBuilder, private val maxNestingLevel: Int =
                  * We are seeing a closing [EMBED_CLOSE_DELIM] before we encountered an [EMBED_PREAMBLE_NEWLINE],
                  * so give an error to help the user fix this construct
                  */
-                prematureEndMark.error(EMBED_BLOCK_NO_NEWLINE.create(embedStartDelimiter, embedTagText))
+                prematureEndMark.error(EMBED_BLOCK_NO_NEWLINE.create(embedStartDelimiter, embedPreambleText))
                 embedBlockMark.done(EMBED_BLOCK)
                 return true
             } else {

--- a/src/commonTest/kotlin/org/kson/KsonCoreTestEmbedBlock.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestEmbedBlock.kt
@@ -46,6 +46,49 @@ class KsonCoreTestEmbedBlock : KsonCoreTest {
                 "    select * from something\n"
             """.trimIndent()
         )
+
+
+        assertParsesTo(
+            """
+                %sql: database
+                    select * from something
+                %%
+            """,
+            """
+                %sql: database
+                    select * from something
+                %%
+            """.trimIndent(),
+            """
+                |2
+                      select * from something
+                  
+            """.trimIndent(),
+            """
+                "    select * from something\n"
+            """.trimIndent()
+        )
+
+        assertParsesTo(
+            """
+                %sql: ::::::::::::database:::::: 
+                    select * from something
+                %%
+            """,
+            """
+                %sql: ::::::::::::database::::::
+                    select * from something
+                %%
+            """.trimIndent(),
+            """
+                |2
+                      select * from something
+                  
+            """.trimIndent(),
+            """
+                "    select * from something\n"
+            """.trimIndent()
+        )
     }
 
     @Test

--- a/src/commonTest/kotlin/org/kson/parser/LexerTest.kt
+++ b/src/commonTest/kotlin/org/kson/parser/LexerTest.kt
@@ -420,6 +420,32 @@ class LexerTest {
             """,
             listOf(EMBED_OPEN_DELIM, EMBED_TAG, EMBED_PREAMBLE_NEWLINE, EMBED_CONTENT, EMBED_CLOSE_DELIM)
         )
+
+        assertTokenizesTo(
+            """
+                %:empty embed tag
+                    select * from something
+                %%
+            """,
+            listOf(EMBED_OPEN_DELIM, EMBED_TAG, EMBED_TAG_STOP, EMBED_METADATA, EMBED_PREAMBLE_NEWLINE, EMBED_CONTENT, EMBED_CLOSE_DELIM)
+        )
+
+        assertTokenizesTo(
+            """
+                %sql: metaTag
+                    select * from something
+                %%
+            """,
+            listOf(EMBED_OPEN_DELIM, EMBED_TAG, EMBED_TAG_STOP, EMBED_METADATA, EMBED_PREAMBLE_NEWLINE, EMBED_CONTENT, EMBED_CLOSE_DELIM)
+        )
+        assertTokenizesTo(
+            """
+                %sql: metaTag
+                    select * from something
+                %%
+            """,
+            listOf(EMBED_OPEN_DELIM, EMBED_TAG, EMBED_TAG_STOP, EMBED_METADATA, EMBED_PREAMBLE_NEWLINE, EMBED_CONTENT, EMBED_CLOSE_DELIM)
+        )
     }
 
     @Test
@@ -570,11 +596,29 @@ class LexerTest {
     fun testComplexEmbedTagWithWhitespace() {
         assertTokenizesTo(
             """
-            %%   this tag has spaces and funky characters ~!@#$%^&*()_+
+            %   this tag has spaces and funky characters ~!@#$%^&*()_+
             some sweet content
             %%
             """,
             listOf(EMBED_OPEN_DELIM, EMBED_TAG, EMBED_PREAMBLE_NEWLINE, EMBED_CONTENT, EMBED_CLOSE_DELIM)
+        )
+
+        assertTokenizesTo(
+            """
+            %   this tag has spaces and funky characters ~!@#$%^&*()_+: followed by a meta tag
+            some sweet content
+            %%
+            """,
+            listOf(EMBED_OPEN_DELIM, EMBED_TAG, EMBED_TAG_STOP, EMBED_METADATA, EMBED_PREAMBLE_NEWLINE, EMBED_CONTENT, EMBED_CLOSE_DELIM)
+        )
+
+        assertTokenizesTo(
+            """
+            % tag: meta with escaped and unescaped: colon \:
+            some sweet content
+            %%
+            """,
+            listOf(EMBED_OPEN_DELIM, EMBED_TAG, EMBED_TAG_STOP, EMBED_METADATA, EMBED_PREAMBLE_NEWLINE, EMBED_CONTENT, EMBED_CLOSE_DELIM)
         )
     }
 

--- a/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/highlighter/KsonSyntaxHighlighter.kt
+++ b/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/highlighter/KsonSyntaxHighlighter.kt
@@ -34,6 +34,8 @@ class KsonSyntaxHighlighter : SyntaxHighlighterBase() {
                 TokenType.EMBED_OPEN_DELIM -> getPackedTextAttributes(KSON_DELIMITER)
                 TokenType.EMBED_CLOSE_DELIM -> getPackedTextAttributes(KSON_DELIMITER)
                 TokenType.EMBED_TAG -> getPackedTextAttributes(KSON_EMBED_TAG)
+                TokenType.EMBED_TAG_STOP -> getPackedTextAttributes(KSON_EMBED_TAG)
+                TokenType.EMBED_METADATA -> getPackedTextAttributes(KSON_EMBED_TAG)
                 TokenType.EMBED_PREAMBLE_NEWLINE -> TextAttributesKey.EMPTY_ARRAY
                 TokenType.EMBED_CONTENT -> getPackedTextAttributes(KSON_CONTENT)
                 TokenType.FALSE -> getPackedTextAttributes(KSON_KEYWORD)


### PR DESCRIPTION
Instead of an Embed Blocks being defined as: 
```
embedBlock -> EMBED_OPEN_DELIM (EMBED_TAG) EMBED_PREAMBLE_NEWLINE CONTENT EMBED_CLOSE_DELIM 
```
This PR introduces the concept of the `EMBED_PREAMBLE` and `EMBED_METADATA`.  Updating the grammar rule for Embed Blocks to: 
```
embedBlock -> EMBED_OPEN_DELIM EMBED_PREAMBLE EMBED_PREAMBLE_NEWLINE CONTENT EMBED_CLOSE_DELIM
EMBED_PREAMBLE -> EMBED_TAG (":" EMBED_METADATA)?
```

The idea behind an optional embed metadata tag (indicated by the first colon, `:`) is that the first part of the preamble is reserved as an indication of the data type of the `EMBED_CONTENT`. Similar to a file extension.

This way tooling can know how to interpret the `EMBED_CONTENT`. The second part of the embed preamble can be used for any kind of metadata.