### PR TITLE
Fix bug in IndentValidator

### DIFF
--- a/src/commonMain/kotlin/org/kson/validation/IndentValidator.kt
+++ b/src/commonMain/kotlin/org/kson/validation/IndentValidator.kt
@@ -111,6 +111,7 @@ class IndentValidator {
         for (item in items) {
             // this item is not indented (it's trailing another value), so it has no indent to align
             if (item.location.start.line == prevLine) {
+                prevLine = item.location.end.line
                 continue
             } else {
                 prevLine = item.location.end.line

--- a/src/commonTest/kotlin/org/kson/validation/IndentValidatorTest.kt
+++ b/src/commonTest/kotlin/org/kson/validation/IndentValidatorTest.kt
@@ -385,4 +385,22 @@ class IndentValidatorTest {
             ).messages.isEmpty(), message
         )
     }
+
+    @Test
+    fun testNonLeadingMultilineStrutures() {
+        /**
+         * Regression test for a bug in the validator where alignment tracking was incorrect in the case that
+         * a non-leading item spanned multiple lines, like the `non_leading:` property in this test.  In this
+         * case, we were incorrectly marking `should_not_error:` as a deceptive indent
+         */
+        assertTrue(
+            KsonCore.parseToAst(
+                """
+                    x:y non_leading:{
+                    } should_not_error: 0
+                """.trimIndent()
+            ).messages.isEmpty(),
+            "should never consider a non-leading item on a line to mis-aligned"
+        )
+    }
 }


### PR DESCRIPTION
Fix a bug in the validator where alignment tracking was incorrect in the case that a non-leading item spanned multiple lines.  This was due to a missing update the "previous line" tracking in the validator, leading us to use the stale "previous line" value when validating the next item.