### PR TITLE
Retain `EMBED_PREAMBLE` by default

### DIFF
--- a/src/commonMain/kotlin/org/kson/KsonCore.kt
+++ b/src/commonMain/kotlin/org/kson/KsonCore.kt
@@ -247,7 +247,7 @@ sealed class CompileTarget(val coreConfig: CoreCompileConfig) {
      */
     class Yaml(
         override val preserveComments: Boolean = true,
-        val retainEmbedTags: Boolean = false,
+        val retainEmbedTags: Boolean = true,
         coreCompileConfig: CoreCompileConfig = CoreCompileConfig()
     ) : CompileTarget(coreCompileConfig)
 
@@ -258,7 +258,7 @@ sealed class CompileTarget(val coreConfig: CoreCompileConfig) {
      * @param coreCompileConfig the [CoreCompileConfig] for this compile
      */
     class Json(
-        val retainEmbedTags: Boolean = false,
+        val retainEmbedTags: Boolean = true,
         coreCompileConfig: CoreCompileConfig = CoreCompileConfig()
     ) : CompileTarget(coreCompileConfig) {
         // Json does not support comments

--- a/src/commonTest/kotlin/org/kson/KsonCoreTest.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTest.kt
@@ -45,7 +45,10 @@ interface KsonCoreTest {
         expectedYaml: String,
         expectedJson: String,
         message: String? = null,
-        compileSettings: CompileSettings = CompileSettings(),
+        compileSettings: CompileSettings = CompileSettings(
+            jsonSettings = Json(retainEmbedTags = false),
+            yamlSettings = Yaml(retainEmbedTags = false)
+        ),
     ) {
         try {
             validateYaml(expectedYaml)


### PR DESCRIPTION
This supports KSON to make a roundtrip after transpilation to JSON by default.

To prevent redundantly adding tags to all tests I've configured `KsonCoreTest` to not `retainEmbedTags` by default.