### PR TITLE
Prohibit commas in plainObjects

### DIFF
--- a/src/commonTest/kotlin/org/kson/KsonCoreTestComment.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestComment.kt
@@ -307,12 +307,14 @@ class KsonCoreTestComment : KsonCoreTest {
     fun testCommentsPreservationOnCommas() {
         assertParsesTo(
             """
-                key1:val1
-                # this comment should be preserved on this property
-                ,
-                key2:val2
-                # as should this one
-                ,
+                {
+                    key1:val1
+                    # this comment should be preserved on this property
+                    ,
+                    key2:val2
+                    # as should this one
+                    ,
+                }
             """,
             """
                 # this comment should be preserved on this property

--- a/src/commonTest/kotlin/org/kson/KsonCoreTestGeneralError.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestGeneralError.kt
@@ -50,22 +50,17 @@ class KsonCoreTestGeneralError: KsonCoreTestError {
     fun testEmptyCommas() {
         assertParserRejectsSource("[,]", listOf(EMPTY_COMMAS))
         assertParserRejectsSource("{,}", listOf(EMPTY_COMMAS))
-        assertParserRejectsSource(",", listOf(EMPTY_COMMAS))
 
         assertParserRejectsSource("[,,]", listOf(EMPTY_COMMAS, EMPTY_COMMAS))
         assertParserRejectsSource("{,,}", listOf(EMPTY_COMMAS, EMPTY_COMMAS))
-        assertParserRejectsSource(",,", listOf(EMPTY_COMMAS, EMPTY_COMMAS))
 
         assertParserRejectsSource("[1,,3]", listOf(EMPTY_COMMAS))
         assertParserRejectsSource("{one: 1 ,, three: 3}", listOf(EMPTY_COMMAS))
-        assertParserRejectsSource("one: 1 ,, three: 3", listOf(EMPTY_COMMAS))
 
         assertParserRejectsSource("[1,2,3,,,,,,]", listOf(EMPTY_COMMAS))
         assertParserRejectsSource("{one: 1, two: 2, three: 3,,,,,,}", listOf(EMPTY_COMMAS))
-        assertParserRejectsSource("one: 1 ,two: 2, three: 3,,,,,,", listOf(EMPTY_COMMAS))
 
         assertParserRejectsSource("[,,,, x ,, y ,,,,,,, z ,,,,]", listOf(EMPTY_COMMAS, EMPTY_COMMAS, EMPTY_COMMAS, EMPTY_COMMAS))
-        assertParserRejectsSource(",,,, x:1 ,, y:2 ,,,,,,, z:3 ,,,,", listOf(EMPTY_COMMAS, EMPTY_COMMAS, EMPTY_COMMAS, EMPTY_COMMAS))
     }
 
     @Test

--- a/src/commonTest/kotlin/org/kson/KsonCoreTestGeneralValue.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestGeneralValue.kt
@@ -27,7 +27,7 @@ class KsonCoreTestGeneralValue : KsonCoreTest {
                   2,
                   3
                 ]
-              },
+              }
             "test_key": "value"
             """.trimIndent(), compileSettings)
 

--- a/src/commonTest/kotlin/org/kson/KsonCoreTestObject.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestObject.kt
@@ -74,8 +74,6 @@ class KsonCoreTestObject : KsonCoreTest {
                     nested1:v,
                     nested2:v,
                     nested3:v,
-                    .,
-                    alsoNested:v,
                   ],
                   ObjA3: 3,
                   
@@ -86,45 +84,44 @@ class KsonCoreTestObject : KsonCoreTest {
             """.trimIndent(),
             """
                 - ObjA1: 1
-                  ObjA2:
+                - ObjA2:
                     - nested1: v
-                      nested2: v
-                      nested3: v
-                
-                    - alsoNested: v
-                      .
-                  ObjA3: 3
-
+                    - nested2: v
+                    - nested3: v
+                    =
+                - ObjA3: 3
                 - 'A string'
                 - ObjB4: 4
             """.trimIndent(),
             """
                 - ObjA1: 1
-                  ObjA2:
+                - ObjA2:
                     - nested1: v
-                      nested2: v
-                      nested3: v
-                
-                    - alsoNested: v
-                  ObjA3: 3
-
+                    - nested2: v
+                    - nested3: v
+                - ObjA3: 3
                 - "A string"
                 - ObjB4: 4
             """.trimIndent(),
             """
                 [
                   {
-                    "ObjA1": 1,
+                    "ObjA1": 1
+                  },
+                  {
                     "ObjA2": [
                       {
-                        "nested1": "v",
-                        "nested2": "v",
-                        "nested3": "v"
+                        "nested1": "v"
                       },
                       {
-                        "alsoNested": "v"
+                        "nested2": "v"
+                      },
+                      {
+                        "nested3": "v"
                       }
-                    ],
+                    ]
+                  },
+                  {
                     "ObjA3": 3
                   },
                   "A string",
@@ -247,28 +244,6 @@ class KsonCoreTestObject : KsonCoreTest {
                }
             """.trimIndent(),
             "should parse object ignoring optional commas, even trailing"
-        )
-
-        assertParsesTo(
-            """
-                key: val
-                "string key": 66.3,
-                hello: "y'all"
-            """,
-            expectKsonForRootObjectAst,
-            """
-               key: val
-               "string key": 66.3
-               hello: "y'all"
-            """.trimIndent(),
-            """
-               {
-                 "key": "val",
-                 "string key": 66.3,
-                 "hello": "y'all"
-               }
-            """.trimIndent(),
-            "should parse ignoring optional commas, even in brace-free root objects"
         )
     }
 

--- a/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
+++ b/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
@@ -1457,7 +1457,7 @@ class FormatterTest {
     fun testCompactFormattingStyleSimpleObject() {
         assertFormatting(
             """
-                "type": "object",
+                "type": "object"
                 "properties": {
                 x: w
                 }


### PR DESCRIPTION
It seemed intuitive to apply the same rules for plain objects as the internals of delimited objects, but in practice this created unneeded complexity and ambiguity.  In https://github.com/kson-org/kson/pull/137, we tried to disambiguate who "owns" a comma in a plainObject inside a bracketList by embracing plainObjects having higher precedence in the existing code. However, plain KSON is very similar to YAML, and YAML would give the comma to the bracket list in this case.

With this change, KSON and YAML both agree that, for instance:

```
[
  one: 1,
  two: 2
]
```

parses to a list of two objects of size one:

```
- one: 1
- two: 2
```

Additionally, plain objects are now symmetric with dash lists, just with a `keyword` denoting a ksonValue rather than a `LIST_DASH`, making the core/default KSON syntax more consistent, as we can see from these two KSON grammar rules:

```
* dashList    -> (LIST_DASH ksonValue)+ "="?
* plainObject -> (keyword   ksonValue)+ "."?