### PR TITLE
Improve formatting for empty lists and objects

### DIFF
--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -349,10 +349,12 @@ class ObjectPropertyNodeImpl(
     }
 
     private fun undelimitedObjectProperty(indent:Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
-        return if (value is ListNode || value is ObjectNode ||
+        return if (
+            (value is ListNode && value.elements.isNotEmpty()) ||
+            (value is ObjectNode && value.properties.isNotEmpty()) ||
             // check if we're compiling an embed block to an object
             (compileTarget is Yaml && value is EmbedBlockNode && compileTarget.retainEmbedTags)) {
-            // For lists and objects, put the value on the next line
+            // For non-empty lists and objects, put the value on the next line
             key.toSourceWithNext(indent, value, compileTarget) + "\n" +
                     value.toSourceWithNext(indent.next(false), nextNode, compileTarget)
         } else {
@@ -521,7 +523,7 @@ class ListElementNodeImpl(val value: KsonValueNode, override val comments: List<
         compileTarget: CompileTarget,
         isDelimited: Boolean = false
     ): String {
-        return if (value is ListNode && !isDelimited) {
+        return if ((value is ListNode && value.elements.isNotEmpty()) && !isDelimited) {
             indent.bodyLinesIndent() + "- \n" + value.toSourceWithNext(
                 indent.next(false),
                 nextNode,

--- a/src/commonTest/kotlin/org/kson/KsonCoreTestList.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestList.kt
@@ -226,13 +226,11 @@ class KsonCoreTestList : KsonCoreTest {
         """.trimIndent(),
             """
                - 
-                 - 
-                   <>
+                 - <>
             """.trimIndent(),
             """
                - 
-                 - 
-                   []
+                 - []
             """.trimIndent(),
             """
                [

--- a/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
+++ b/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
@@ -1711,6 +1711,36 @@ class FormatterTest {
     }
 
     @Test
+    fun testPlainFormattingEmptyObject(){
+        assertFormatting(
+            """
+                key:
+                {}
+            """.trimIndent(),
+            """
+                key: {}
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.PLAIN
+        )
+    }
+
+    @Test
+    fun testDelimitedFormattingEmptyObject(){
+        assertFormatting(
+            """
+                key:
+                {}
+            """.trimIndent(),
+            """
+                {
+                  key: {}
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.DELIMITED
+        )
+    }
+
+    @Test
     fun testCompactFormattingEmptyObject(){
         assertFormatting(
             """
@@ -1720,6 +1750,62 @@ class FormatterTest {
                 key:{}
             """.trimIndent(),
             formattingStyle = FormattingStyle.COMPACT
+        )
+    }
+
+    @Test
+    fun testPlainFormattingEmptyList(){
+        assertFormatting(
+            """
+                key:
+                <>
+            """.trimIndent(),
+            """
+                key: <>
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.PLAIN
+        )
+    }
+
+    @Test
+    fun testDelimitedFormattingEmptyList(){
+        assertFormatting(
+            """
+                key:
+                <>
+            """.trimIndent(),
+            """
+                {
+                  key: <>
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.DELIMITED
+        )
+    }
+
+    @Test
+    fun testCompactFormattingEmptyList(){
+        assertFormatting(
+            """
+                key: <>
+            """.trimIndent(),
+            """
+                key:<>
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.COMPACT
+        )
+    }
+
+    @Test
+    fun testFormatEmptyNestedList() {
+        assertFormatting(
+            """
+                -
+                  <>
+            """.trimIndent(),
+            """
+                - <>
+            """.trimIndent()
         )
     }
 

--- a/tooling/language-server-protocol/src/test/core/features/FormattingService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/FormattingService.test.ts
@@ -62,10 +62,8 @@ describe('KSON Formatter', () => {
     it('should format an object with no properties', () => {
         const content = '{"x" : {    },  "y" : {}}';
         const expected = [
-            'x:',
-            '  {}',
-            'y:',
-            '  {}'
+            'x: {}',
+            'y: {}'
         ].join('\n');
         assertFormatting(content, expected);
     });
@@ -75,8 +73,7 @@ describe('KSON Formatter', () => {
         const expected = [
             'x:',
             '  y:',
-            '    z:',
-            '      {}',
+            '    z: {}',
             '    .',
             '  a: true'
         ].join('\n');
@@ -111,8 +108,7 @@ describe('KSON Formatter', () => {
     it('should handle nested arrays', () => {
         const content = '[ [], [ [ {} ], "a" ]  ]';
         const expected = [
-            '- ',
-            '  <>',
+            '- <>',
             '- ',
             '  - ',
             '    - {}',


### PR DESCRIPTION
For object properties, update the formatter to keep empty lists and objects on the same line as their property key, so for instance we now format to this:
```
empty_obj: {}
```
rather than this:
```
empty_obj:
  {}
```