### PR TITLE
Revisit Exceptions and add `UnexpectedParseException`

### DIFF
--- a/src/commonMain/kotlin/org/kson/KsonValue.kt
+++ b/src/commonMain/kotlin/org/kson/KsonValue.kt
@@ -195,6 +195,6 @@ fun AstNode.toKsonValue(): KsonValue {
         is ListElementNodeImpl -> {
             throw ShouldNotHappenException("these elements are processed above in the ${ListNode::class.simpleName} case")
         }
-        is AstNodeError -> throw ShouldNotHappenException("Cannot create Valid Ast Node from ${this::class.simpleName}")
+        is AstNodeError -> throw UnsupportedOperationException("Cannot create Valid Ast Node from ${this::class.simpleName}")
     }
 }

--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -14,7 +14,6 @@ import org.kson.parser.behavior.StringQuote
 import org.kson.parser.behavior.StringQuote.*
 import org.kson.parser.behavior.StringUnquoted
 import org.kson.parser.behavior.embedblock.EmbedObjectKeys
-import org.kson.stdlibx.exceptions.ShouldNotHappenException
 
 interface AstNode {
     /**
@@ -232,7 +231,7 @@ class ObjectNode(val properties: List<ObjectPropertyNode>, location: Location) :
             val seperator = when(compileTarget) {
                 is Kson -> "\n"
                 is Json -> ",\n"
-                is Yaml -> throw ShouldNotHappenException("We never format YAML objects as delimited")
+                is Yaml -> throw UnsupportedOperationException("We never format YAML objects as delimited")
             }
 
             return """
@@ -438,7 +437,7 @@ class ListNode(
         val seperator = when (compileTarget) {
             is Kson -> "\n"
             is Json -> ",\n"
-            else -> throw ShouldNotHappenException("We never format YAML objects as delimited")
+            else -> throw UnsupportedOperationException("We never format YAML objects as delimited")
         }
 
         // We pad our list bracket with newlines if our list is non-empty
@@ -626,7 +625,7 @@ class UnquotedStringNode(override val stringContent: String, location: Location)
 class NumberNode(stringValue: String, location: Location) : KsonValueNodeImpl(location) {
     val value: ParsedNumber by lazy {
         val parsedNumber = NumberParser(stringValue).parse()
-        parsedNumber.number ?: throw RuntimeException("Hitting this indicates a parser bug: unparseable " +
+        parsedNumber.number ?: throw IllegalStateException("Hitting this indicates a parser bug: unparseable " +
                 "strings should be passed here but we got: " + stringValue)
     }
 
@@ -788,7 +787,7 @@ class EmbedBlockNode(
                         indent.firstLineIndent() + "${EmbedObjectKeys.EMBED_CONTENT.key}: " +
                         renderMultilineYamlString(embedContent, indent.clone(true), indent.next(true))
             }
-            is Kson -> throw ShouldNotHappenException("should not encode embed block as ${compileTarget::class.simpleName}")
+            is Kson -> throw UnsupportedOperationException("should not encode embed block as ${compileTarget::class.simpleName}")
         }
 
     }

--- a/src/commonMain/kotlin/org/kson/parser/KsonBuilder.kt
+++ b/src/commonMain/kotlin/org/kson/parser/KsonBuilder.kt
@@ -32,11 +32,11 @@ class KsonBuilder(private val tokens: List<Token>, private val errorTolerant: Bo
     }
     private var rootMarker = KsonMarker(this, object : MarkerCreator {
         override fun forgetMe(me: KsonMarker): KsonMarker {
-            throw RuntimeException("The root marker has no creator that needs to forget it")
+            throw ShouldNotHappenException("The root marker has no creator that needs to forget it")
         }
 
         override fun dropMe(me: KsonMarker) {
-            throw RuntimeException("The root marker has no creator that needs to drop it")
+            throw ShouldNotHappenException("The root marker has no creator that needs to drop it")
         }
     })
 
@@ -161,7 +161,7 @@ class KsonBuilder(private val tokens: List<Token>, private val errorTolerant: Bo
      */
     private fun toAst(marker: KsonMarker): AstNode {
         if (!marker.isDone()) {
-            throw RuntimeException("Should have a well-formed, all-done marker tree at this point")
+            throw ShouldNotHappenException("Should have a well-formed, all-done marker tree at this point")
         }
 
         return when (marker.element) {
@@ -181,7 +181,7 @@ class KsonBuilder(private val tokens: List<Token>, private val errorTolerant: Bo
                     OBJECT_KEY,
                     ILLEGAL_CHAR,
                     WHITESPACE -> {
-                        throw RuntimeException("These tokens do not generate their own AST nodes")
+                        throw ShouldNotHappenException("These tokens do not generate their own AST nodes")
                     }
                     FALSE -> {
                         FalseNode(marker.getLocation())
@@ -343,7 +343,7 @@ class KsonBuilder(private val tokens: List<Token>, private val errorTolerant: Bo
                         val eofToken = tokens.last()
                         // sanity check this is the expected EOF token
                         if (eofToken.tokenType != EOF) {
-                            throw RuntimeException("Token list must end in EOF")
+                            throw ShouldNotHappenException("Token list must end in EOF")
                         }
 
                         val rootNode = unsafeAstCreate<KsonValueNode>(childMarkers[0]) {
@@ -370,7 +370,7 @@ class KsonBuilder(private val tokens: List<Token>, private val errorTolerant: Bo
                 }
             }
             else -> {
-                throw RuntimeException(
+                throw ShouldNotHappenException(
                     "Unexpected ${ElementType::class.simpleName}.  " +
                             "Should always be one of ${TokenType::class.simpleName} or ${ParsedElementType::class.simpleName}"
                 )
@@ -459,7 +459,7 @@ class KsonBuilder(private val tokens: List<Token>, private val errorTolerant: Bo
                  * If we hit this, we've introduced a bug: unless we're [errorTolerant], we should
                  * never call [buildTree] when [org.kson.parser.messages.Message.Companion.isFatalParseError] is true
                  */
-                throw RuntimeException("Should not find ERROR elements when not `errorTolerant`")
+                throw ShouldNotHappenException("Should not find ERROR elements when not `errorTolerant`")
             }
             return errorNodeGenerator(marker.getRawText())
         }
@@ -626,7 +626,7 @@ private class KsonMarker(private val context: MarkerBuilderContext, private val 
          */
         val lastChild = childMarkers.removeLast()
         if (lastChild != me) {
-            throw RuntimeException(
+            throw ShouldNotHappenException(
                 "Bug: This should be an impossible `forgetMe` call since " +
                         "the order of resolving markers should ensure that calls to `forgetMe` are always " +
                         "on the last added marker"

--- a/src/commonMain/kotlin/org/kson/parser/Lexer.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Lexer.kt
@@ -7,6 +7,7 @@ import org.kson.parser.TokenType.*
 import org.kson.parser.behavior.StringUnquoted
 import org.kson.parser.behavior.embedblock.EmbedDelim.*
 import org.kson.parser.behavior.embedblock.EmbedBlockIndent
+import org.kson.stdlibx.exceptions.ShouldNotHappenException
 
 private val KEYWORDS =
     mapOf(
@@ -77,7 +78,7 @@ private class SourceScanner(private val source: String) {
      */
     fun extractLexeme(): Lexeme {
         if (selectionEndOffset > source.length) {
-            throw RuntimeException("Scanner has been advanced past end of source---missing some needed calls to peek()?")
+            throw ShouldNotHappenException("Scanner has been advanced past end of source---missing some needed calls to peek()?")
         }
 
         val lexeme = Lexeme(
@@ -208,7 +209,7 @@ data class Location(
          */
         fun merge(startLocation: Location, endLocation: Location): Location {
             if (startLocation.startOffset > endLocation.endOffset) {
-                throw RuntimeException("`startLocation` must be before `endLocation`")
+                throw ShouldNotHappenException("`startLocation` must be before `endLocation`")
             }
             return Location(
                 startLocation.start,

--- a/src/commonMain/kotlin/org/kson/parser/NumberParser.kt
+++ b/src/commonMain/kotlin/org/kson/parser/NumberParser.kt
@@ -3,6 +3,7 @@ package org.kson.parser
 import org.kson.parser.NumberParser.ParsedNumber
 import org.kson.parser.messages.Message
 import org.kson.parser.messages.MessageType
+import org.kson.stdlibx.exceptions.ShouldNotHappenException
 
 /**
  * Note that our number parsing closely follows JSON's grammar (see https://www.json.org), with one key difference:
@@ -124,7 +125,7 @@ class NumberParser(private val numberCandidate: String) {
                 /**
                  * A null `error` here indicates a bug in this [NumberParser]
                  */
-                throw RuntimeException("must always set `error` message for a failed parse")
+                throw ShouldNotHappenException("must always set `error` message for a failed parse")
             }
             NumberParseResult(null, error)
         }

--- a/src/commonMain/kotlin/org/kson/parser/Parser.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Parser.kt
@@ -3,7 +3,7 @@ package org.kson.parser
 import org.kson.parser.ParsedElementType.*
 import org.kson.parser.TokenType.*
 import org.kson.parser.messages.MessageType.*
-import org.kson.stdlibx.exceptions.ShouldNotHappenException
+import org.kson.stdlibx.exceptions.UnexpectedParseException
 
 /**
  * Defines the Kson parser, implemented as a recursive descent parser which directly implements
@@ -68,7 +68,7 @@ class Parser(private val builder: AstBuilder, private val maxNestingLevel: Int =
                 /**
                  * [handleUnexpectedTrailingContent] should have ensured that all tokens are handled
                  */
-                throw ShouldNotHappenException("Bug: this parser must consume all tokens in all cases")
+                throw UnexpectedParseException("Bug: this parser must consume all tokens in all cases")
             }
             rootMarker.drop()
         } catch (nestingException: ExcessiveNestingException) {
@@ -623,7 +623,7 @@ class Parser(private val builder: AstBuilder, private val maxNestingLevel: Int =
 
     private fun isValidStringEscape(stringEscapeText: String): Boolean {
         if (!stringEscapeText.startsWith('\\') || stringEscapeText.length > 2) {
-            throw RuntimeException("Should only be asked to validate one-char string escapes, but was passed: $stringEscapeText")
+            throw UnexpectedParseException("Should only be asked to validate one-char string escapes, but was passed: $stringEscapeText")
         }
 
         // detect incomplete escapes (perhaps this escape bumped up against EOF)
@@ -679,7 +679,7 @@ class Parser(private val builder: AstBuilder, private val maxNestingLevel: Int =
 
     private fun isValidUnicodeEscape(unicodeEscapeText: String): Boolean {
         if (!unicodeEscapeText.startsWith("\\u")) {
-            throw RuntimeException("Should only be asked to validate unicode escapes")
+            throw UnexpectedParseException("Should only be asked to validate unicode escapes")
         }
 
         // clip off the `\u` to make this code point easier to inspect

--- a/src/commonMain/kotlin/org/kson/parser/behavior/StringQuote.kt
+++ b/src/commonMain/kotlin/org/kson/parser/behavior/StringQuote.kt
@@ -56,7 +56,7 @@ sealed class StringQuote(private val quoteChar: Char) {
             return when (delimString) {
                 '\'' -> SingleQuote
                 '"' -> DoubleQuote
-                else -> throw RuntimeException("Unknown string delimiter: $delimString")
+                else -> throw UnsupportedOperationException("Unknown string delimiter: $delimString")
             }
         }
     }

--- a/src/commonMain/kotlin/org/kson/parser/behavior/embedblock/EmbedDelim.kt
+++ b/src/commonMain/kotlin/org/kson/parser/behavior/embedblock/EmbedDelim.kt
@@ -105,7 +105,7 @@ sealed class EmbedDelim(val char: Char) {
             return when (delimString) {
                 "%" -> Percent
                 "$" -> Dollar
-                else -> throw RuntimeException("Unknown embed delimiter string: $delimString")
+                else -> throw UnsupportedOperationException("Unknown embed delimiter string: $delimString")
             }
         }
     }

--- a/src/commonMain/kotlin/org/kson/parser/messages/Message.kt
+++ b/src/commonMain/kotlin/org/kson/parser/messages/Message.kt
@@ -215,7 +215,7 @@ enum class MessageType(
         override fun doFormat(parsedArgs: ParsedErrorArgs): String {
             val badControlCharArg = parsedArgs.getArg("Control Character")
             if (badControlCharArg?.length != 1) {
-                throw RuntimeException("Expected arg to be a single control character")
+                throw IllegalArgumentException("Expected arg to be a single control character")
             }
             val badControlChar = badControlCharArg[0]
 
@@ -795,7 +795,7 @@ enum class MessageType(
                 return parsedArgs[argName]
             } else {
                 // someone's asking for an invalid or typo'ed arg name
-                throw RuntimeException(
+                throw IllegalArgumentException(
                     "Invalid arg name \"" + argName + "\" given for " + messageType::class.simpleName
                             + ".  \"" + argName + "\" is not defined in " + messageType::expectedArgs.name
                             + ": " + renderArgList(messageType.expectedArgs())

--- a/src/commonMain/kotlin/org/kson/stdlibx/exceptions/UnexpectedParseException.kt
+++ b/src/commonMain/kotlin/org/kson/stdlibx/exceptions/UnexpectedParseException.kt
@@ -1,0 +1,10 @@
+package org.kson.stdlibx.exceptions
+
+/**
+ * An exception for code paths that are fatal if hit during parsing.
+ *
+ * These exceptions are caught and result in a null-AST
+ *
+ * @param message the reason why we believe that it is unexpected to hit this code path
+ */
+class UnexpectedParseException(message: String) : RuntimeException(message)

--- a/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/folding/KsonFoldingBuilder.kt
+++ b/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/folding/KsonFoldingBuilder.kt
@@ -182,7 +182,7 @@ internal class KsonFoldingBuilder : CustomFoldingBuilder() {
             }
 
             else -> {
-                throw ShouldNotHappenException("did not expect element type ${node.elementType} to be foldable")
+                throw UnsupportedOperationException("did not expect element type ${node.elementType} to be foldable")
             }
         }
     }

--- a/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/psi/KsonEmbedBlock.kt
+++ b/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/psi/KsonEmbedBlock.kt
@@ -22,7 +22,7 @@ class KsonEmbedBlock(node: ASTNode) : KsonPsiElement(node) {
         private fun getDelim(host: KsonEmbedBlock): EmbedDelim {
             val embedDelimText =
                 host.children.find { it.elementType == elem(TokenType.EMBED_OPEN_DELIM) }?.text
-                    ?: throw ShouldNotHappenException("Embed delimiter not found")
+                    ?: throw ShouldNotHappenException("since this element got parsed as embed block we expect an EMBED_OPEN_DELIM")
             return EmbedDelim.fromString(embedDelimText)
         }
     }


### PR DESCRIPTION
Initially, `RuntimeExceptions` were used everywhere in KSON. At some point, `ShouldNotHappenException` was introduced for cases we were convinced should never occur.

After restructuring the parser to include `ErrorNodes` and support formatting on errors, the parser became more complex and not all assumptions still held. During development, we unexpectedly hit `ShouldNotHappenExceptions` multiple times.

With this change, we introduce `UnexpectedParseException` to acknowledge that sometimes the unexpected happens. Instead of crashing, we now gracefully handle these cases by returning a null-AST in `KsonCore`.