### PR TITLE
Configure publishing to maven local

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ val sharedProps = Properties().apply {
 plugins {
     kotlin("multiplatform") version "2.1.21"
     kotlin("plugin.serialization") version "2.1.21"
+    `maven-publish`
 
     // configured by `jvmWrapper` block below
     id("me.filippov.gradle.jvm.wrapper") version "0.14.0"
@@ -189,5 +190,24 @@ kotlin {
         }
         val nativeKsonMain by getting
         val nativeKsonTest by getting
+    }
+}
+
+publishing {
+    publications {
+        withType<MavenPublication> {
+            // ensure our artifacts for each platform have a unique name
+            artifactId = when (name) {
+                "kotlinMultiplatform" -> "kson"
+                else -> "kson-$name"
+            }
+            pom {
+                name.set("KSON")
+                url.set("https://kson.org")
+            }
+        }
+    }
+    repositories {
+        mavenLocal()
     }
 }


### PR DESCRIPTION
Small prep step towards the initial public publish of our artifacts: we can now perform the standard `./gradlew publishToMavenLocal` to publish our artifacts to the local maven repo, from which other local project may depend on these items