### PR TITLE
Fix KsonValue comparisons

### DIFF
--- a/src/commonMain/kotlin/org/kson/schema/validators/ConstValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/ConstValidator.kt
@@ -7,7 +7,7 @@ import org.kson.schema.JsonSchemaValidator
 
 class ConstValidator(private val const: KsonValue) : JsonSchemaValidator {
     override fun validate(ksonValue: KsonValue, messageSink: MessageSink) {
-        if (ksonValue != const) {
+        if (!ksonValue.dataEquals(const)) {
             messageSink.error(ksonValue.location, MessageType.SCHEMA_VALUE_NOT_EQUAL_TO_CONST.create())
         }
     }

--- a/src/commonMain/kotlin/org/kson/schema/validators/EnumValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/EnumValidator.kt
@@ -8,8 +8,10 @@ import org.kson.schema.JsonSchemaValidator
 
 class EnumValidator(private val enum: KsonList) : JsonSchemaValidator {
     override fun validate(ksonValue: KsonValue, messageSink: MessageSink) {
-        val enumValues = enum.elements
-        if (!enumValues.contains(ksonValue)) {
+        val enumMatch = enum.elements.any {
+            it.dataEquals(ksonValue)
+        }
+        if (!enumMatch) {
             messageSink.error(ksonValue.location, MessageType.SCHEMA_ENUM_VALUE_NOT_ALLOWED.create())
         }
     }

--- a/src/commonMain/kotlin/org/kson/schema/validators/UniqueItemsValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/UniqueItemsValidator.kt
@@ -19,7 +19,7 @@ class UniqueItemsValidator(private val uniqueItems: Boolean) : JsonArrayValidato
     private fun areItemsUnique(elements: List<KsonValue>): Boolean {
         for (i in elements.indices) {
             for (j in i + 1 until elements.size) {
-                if (elements[i] == elements[j]) {
+                if (elements[i].dataEquals(elements[j])) {
                     return false
                 }
             }


### PR DESCRIPTION
Move the incomplete implementations of `equals` in our KsonValues (they neglected to include `location` in their comparison) into the more-honest `dataEquals` method and update our callers (who all want a data comparison, not a full object comparison).