### PR TITLE
Configure publishing to Maven Central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ val sharedProps = Properties().apply {
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
+    id("com.vanniktech.maven.publish") version "0.30.0"
 
     // configured by `jvmWrapper` block below
     id("me.filippov.gradle.jvm.wrapper") version "0.14.0"
@@ -112,6 +113,14 @@ tasks {
     }
 }
 
+group = "org.kson"
+/**
+ * We use x.[incrementing number] version here since this in not intended for general consumption.
+ *   This version number is both easy to increment and (hopefully) telegraphs well with the strange
+ *   versioning that this should not be depended on
+ */
+version = "x.1-SNAPSHOT"
+
 kotlin {
     jvm()
     js(IR) {
@@ -176,5 +185,39 @@ kotlin {
         }
         val nativeKsonMain by getting
         val nativeKsonTest by getting
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL, automaticRelease = false)
+    signAllPublications()
+
+    coordinates("org.kson", "kson-internals", version.toString())
+
+    pom {
+        name.set("KSON Internals")
+        description.set("Internal implementation details of KSON. This package is not intended for direct use. Please use the 'org.kson:kson' package instead for the stable public API.")
+        url.set("https://kson.org")
+
+        licenses {
+            license {
+                name.set("Apache-2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("dmarcotte")
+                name.set("Daniel Marcotte")
+                email.set("daniel@kson.org")
+            }
+        }
+
+        scm {
+            connection.set("scm:git:https://github.com/kson-org/kson.git")
+            developerConnection.set("scm:git:git@github.com:kson-org/kson.git")
+            url.set("https://github.com/kson-org/kson")
+        }
     }
 }

--- a/kson-lib/build.gradle.kts
+++ b/kson-lib/build.gradle.kts
@@ -4,8 +4,7 @@ import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.dokka") version "2.0.0"
-    `maven-publish`
+    id("com.vanniktech.maven.publish") version "0.30.0"
 }
 
 repositories {
@@ -82,23 +81,36 @@ kotlin {
     }
 }
 
-publishing {
-    publications {
-        withType<MavenPublication> {
-            artifactId = when (name) {
-                "kotlinMultiplatform" -> "kson"
-                "jvm" -> "kson-jvm"
-                "js" -> "kson-js"
-                "nativeKson" -> "kson-${HostManager.host.family.name.lowercase()}-${HostManager.host.architecture.name.lowercase()}"
-                else -> throw RuntimeException("Unexpected artifact name: $name. Do we need to add a case here?")
-            }
-            pom {
-                name.set("KSON")
-                url.set("https://kson.org")
+mavenPublishing {
+    publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL, automaticRelease = false)
+    signAllPublications()
+
+    coordinates("org.kson", "kson", version.toString())
+
+    pom {
+        name.set("KSON")
+        description.set("A 💌 to the humans maintaining computer configurations")
+        url.set("https://kson.org")
+
+        licenses {
+            license {
+                name.set("Apache-2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
             }
         }
-    }
-    repositories {
-        mavenLocal()
+
+        developers {
+            developer {
+                id.set("dmarcotte")
+                name.set("Daniel Marcotte")
+                email.set("kson@kson.org")
+            }
+        }
+
+        scm {
+            connection.set("scm:git:https://github.com/kson-org/kson.git")
+            developerConnection.set("scm:git:git@github.com:kson-org/kson.git")
+            url.set("https://github.com/kson-org/kson")
+        }
     }
 }


### PR DESCRIPTION
The internal root project KSON "core" code is published as `org.kson:kson-internals` and the public api defined in `kson-lib` is `org.kson:kson`.

The `com.vanniktech.maven.publish` plugin seems to work really well, ensuring that our releases are well formed for Maven Central (which includes gpg signing, checksum calculation, and javadoc generation — which seems to make the Dokka plugin unnecessary, so this commit removes it).