### PR TITLE
Tag release 0.1.0 and bump versions for development

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,7 +119,7 @@ group = "org.kson"
  *   This version number is both easy to increment and (hopefully) telegraphs well with the strange
  *   versioning that this should not be depended on
  */
-version = "x.1"
+version = "x.2-SNAPSHOT"
 
 kotlin {
     jvm()

--- a/kson-lib/build.gradle.kts
+++ b/kson-lib/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "org.kson"
-version = "0.1.0"
+version = "0.1.1-SNAPSHOT"
 
 tasks {
     val copyHeaderDynamic = register<CopyNativeHeaderTask>("copyNativeHeaderDynamic") {

--- a/lib-python/pyproject.toml
+++ b/lib-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kson"
-version = "0.1.0"
+version = "0.1.1-SNAPSHOT"
 description = "A love letter to the humans maintaining computer configuration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/lib-rust/pixi.toml
+++ b/lib-rust/pixi.toml
@@ -9,7 +9,7 @@ platforms = [
     "osx-64",
     "win-64",
 ]
-version = "0.1.0"
+version = "0.1.1-SNAPSHOT"
 
 [tasks]
 

--- a/tooling/lsp-clients/package.json
+++ b/tooling/lsp-clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kson-lsp-extensions",
-  "version": "0.0.1",
+  "version": "0.1.1-SNAPSHOT",
   "private": true,
   "description": "KSON Language Server Protocol Extensions",
   "workspaces": [


### PR DESCRIPTION
We definitely need better governance on the various versions numbers in the project, and around the process for bumping an tagging them. For this initial public beta release though, we are okay manually managing.