### PR TITLE
Add JSON-like formatting style of KSON document

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,141 @@ orbs:
   # Windows support for testing Python on Windows
   windows: circleci/windows@5.0
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+# Reusable command definitions - only for truly cross-platform operations
+commands:
+  gradle-core-tasks:
+    description: "Run core Gradle build and verification tasks"
+    steps:
+      - run:
+          name: Download dependencies
+          command: ./gradlew --no-daemon dependencies
+      - run:
+          name: Verify buildSrc project
+          command: |
+            cd buildSrc
+            ./gradlew --no-daemon check
+      - run:
+          name: Verify Kson project
+          command: ./gradlew --no-daemon check
+      - run:
+          name: Build native kson-lib
+          command: ./gradlew --no-daemon :kson-lib:nativeRelease
+
+  store-native-artifacts:
+    description: "Store build artifacts in a consistent way"
+    steps:
+      - store_artifacts:
+          path: kson-lib/build/bin/nativeKson/releaseShared
+          destination: kson-lib-shared
+      - store_artifacts:
+          path: kson-lib/build/bin/nativeKson/releaseStatic
+          destination: kson-lib-static
+
+  restore-gradle-caches:
+    description: "Restore Gradle and JDK caches"
+    parameters:
+      platform:
+        type: string
+        description: "Platform identifier for cache keys"
+    steps:
+      - restore_cache:
+          keys:
+            - v1-<< parameters.platform >>-dependencies-{{ checksum "build.gradle.kts" }}
+            - v1-<< parameters.platform >>-dependencies-
+      - restore_cache:
+          keys:
+            - v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}
+      - restore_cache:
+          keys:
+            - v1-<< parameters.platform >>-vscode-tests
+
+  save-gradle-caches:
+    description: "Save Gradle and JDK caches"
+    parameters:
+      platform:
+        type: string
+        description: "Platform identifier for cache keys"
+    steps:
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-<< parameters.platform >>-dependencies-{{ checksum "build.gradle.kts" }}
+      - save_cache:
+          paths:
+            - ./gradle/jdk
+            - ./buildSrc/gradle/jdk
+          key: v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}
+      - save_cache:
+          paths:
+            - ./tooling/lsp-clients/vscode/.vscode-test
+            - ./tooling/lsp-clients/vscode/.vscode-test-web
+          key: v1-<< parameters.platform >>-vscode-tests
+
+  clean-git-config:
+    description: "Remove erroneous git config across platforms"
+    parameters:
+      shell:
+        type: enum
+        enum: [bash, powershell]
+        default: bash
+    steps:
+      - when:
+          condition:
+            equal: [<< parameters.shell >>, bash]
+          steps:
+            - run:
+                name: Clean git config
+                command: rm -rf ~/.gitconfig
+      - when:
+          condition:
+            equal: [<< parameters.shell >>, powershell]
+          steps:
+            - run:
+                name: Clean git config
+                command: |
+                  Remove-Item -Path "$env:USERPROFILE\.gitconfig" -Force -ErrorAction SilentlyContinue
+                shell: powershell.exe
+
+  setup-python-test:
+    description: "Common setup for Python sdist testing"
+    parameters:
+      platform:
+        type: string
+    steps:
+      - checkout
+      - when:
+          condition:
+            equal: [<< parameters.platform >>, windows]
+          steps:
+            - clean-git-config:
+                shell: powershell
+      - when:
+          condition:
+            not:
+              equal: [<< parameters.platform >>, windows]
+          steps:
+            - clean-git-config:
+                shell: bash
+      - attach_workspace:
+          at: ~/repo
+
+  run-python-tests-unix:
+    description: "Run Python sdist tests and build wheel for Unix-like systems"
+    steps:
+      - run:
+          name: Install kson from sdist
+          command: python3 -m pip install lib-python/dist/kson_lang-*.tar.gz
+      - run:
+          name: Install test dependencies
+          command: python3 -m pip install pytest
+      - run:
+          name: Run smoke tests on sdist installation
+          command: python3 -m pytest lib-python -v
+      - run:
+          name: Build platform-specific wheel
+          command: ./gradlew :lib-python:buildWheel
+
+# Job definitions
 jobs:
   build-windows-amd64:
     resource_class: 'windows.large'
@@ -16,165 +149,68 @@ jobs:
       image: 'windows-server-2022-gui:current'
       shell: 'powershell.exe -ExecutionPolicy Bypass'
     environment:
-      # Customize the JVM maximum heap limit
       JVM_OPTS: -Xmx3200m
     steps:
       - checkout
-      - run:
-          name: Get rid of erroneous git config
-          command: |
-            Remove-Item -Path "$env:USERPROFILE\.gitconfig" -Force -ErrorAction SilentlyContinue
+      - clean-git-config:
+          shell: powershell
 
+      # Windows-specific installations
       # The `browser-tools` orb doesn't support windows, so we install Chrome manually
-      - run: choco install googlechrome --ignore-checksums
+      - run:
+          name: Install Chrome
+          command: choco install googlechrome --ignore-checksums
       # We would ideally install libclang through pixi, but after _hours_ of fiddling we
       # couldn't make the CI happy and decided to add it here instead
-      - run: choco install llvm
-      - restore_cache:
-          keys:
-            - v1-win-amd64-dependencies-{{ checksum "build.gradle.kts" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-win-amd64-dependencies-
-
-      - restore_cache:
-          keys:
-            - v1-win-amd64-jdk-{{ checksum "jdk.properties" }}
-
-      - restore_cache:
-          keys:
-            - v1-win-amd64-vscode-tests
-
-      - run: ./gradlew --no-daemon dependencies
-
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: v1-win-amd64-dependencies-{{ checksum "build.gradle.kts" }}
-
       - run:
-          name: Verify `buildSrc/` project
-          command: |
-            cd buildSrc
-            ./gradlew --no-daemon check
+          name: Install LLVM
+          command: choco install llvm
 
-      - run:
-          name: Verify Kson project
-          command: ./gradlew --no-daemon check
+      - restore-gradle-caches:
+          platform: win-amd64
 
-      - run:
-          name: Build native kson-lib
-          command: ./gradlew --no-daemon :kson-lib:nativeRelease
+      # Cross-platform Gradle tasks
+      - gradle-core-tasks
 
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseShared
-          destination: kson-lib-shared
+      - store-native-artifacts
 
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseStatic
-          destination: kson-lib-static
-
-      - save_cache:
-          paths:
-            - ./tooling/lsp-clients/vscode/.vscode-test
-            - ./tooling/lsp-clients/vscode/.vscode-test-web
-          key: v1-win-amd64-vscode-tests
-
-      - save_cache:
-          paths:
-            - ./gradle/jdk
-            - ./buildSrc/gradle/jdk
-          key: v1-win-amd64-jdk-{{ checksum "jdk.properties" }}
+      - save-gradle-caches:
+          platform: win-amd64
 
   build-linux-amd64:
-    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
     docker:
-      # Choose the `node:lts-browsers` image so that we can install Chrome for testing.  Note that we
-      # do not install a JDK image so that we are always exercising the project's built-in JDK (see jdk.properties for details)
       - image: cimg/node:lts-browsers
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: cimg/postgres:9.4
-
     working_directory: ~/repo
-
     environment:
-      # Customize the JVM maximum heap limit
       JVM_OPTS: -Xmx3200m
       TERM: dumb
-    # Add steps to the job
-    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    resource_class: large
     steps:
-      # Install Chrome according to https://circleci.com/developer/orbs/orb/circleci/browser-tools#usage-install_chrome
       - browser-tools/install-chrome
       - checkout
-      - run: google-chrome --version
-
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "build.gradle.kts" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-      - restore_cache:
-          keys:
-            - v1-jdk-{{ checksum "jdk.properties" }}
-
-      - restore_cache:
-          keys:
-            - v1-vscode-tests
-
-      # installed needed native dependency on Linux
-      - run: sudo apt update
-      - run: sudo apt install libncurses-dev
       - run:
-          name: Get rid of erroneous git config
+          name: Verify Chrome installation
+          command: google-chrome --version
+
+      - restore-gradle-caches:
+          platform: linux-amd64
+
+      # Linux-specific installations
+      - run:
+          name: Install system dependencies
           command: |
-            rm -rf ~/.gitconfig
-      - run: ./gradlew --no-daemon dependencies
+            sudo apt update
+            sudo apt install libncurses-dev
+      - clean-git-config:
+          shell: bash
 
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: v1-dependencies-{{ checksum "build.gradle.kts" }}
+      # Cross-platform Gradle tasks
+      - gradle-core-tasks
 
-      - run:
-          name: Verify `buildSrc/` project
-          command: |
-            cd buildSrc
-            ./gradlew --no-daemon check
+      - store-native-artifacts
 
-      - run:
-          name: Verify Kson project
-          command: ./gradlew --no-daemon check
-
-      - run:
-          name: Build native kson-lib
-          command: ./gradlew --no-daemon :kson-lib:nativeRelease
-
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseShared
-          destination: kson-lib-shared
-
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseStatic
-          destination: kson-lib-static
-
-      - save_cache:
-          paths:
-            - ./tooling/lsp-clients/vscode/.vscode-test
-            - ./tooling/lsp-clients/vscode/.vscode-test-web
-          key: v1-vscode-tests
-
-      - save_cache:
-          paths:
-            - ./gradle/jdk
-            - ./buildSrc/gradle/jdk
-          key: v1-jdk-{{ checksum "jdk.properties" }}
-
-    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
-    resource_class: large
+      - save-gradle-caches:
+          platform: linux-amd64
 
   build-macos-arm64:
     macos:
@@ -182,67 +218,26 @@ jobs:
     resource_class: m4pro.medium
     working_directory: ~/repo
     steps:
-      - run: brew install --cask google-chrome
+      - run:
+          name: Install Chrome
+          command: brew install --cask google-chrome
       - checkout
-      - run: '"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --version'
       - run:
-          name: Get rid of erroneous git config
-          command: |
-            rm -rf ~/.gitconfig
-      - restore_cache:
-          keys:
-            - v1-macos-arm64-dependencies-{{ checksum "build.gradle.kts" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-macos-arm64-dependencies-
+          name: Verify Chrome installation
+          command: '"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --version'
+      - clean-git-config:
+          shell: bash
 
-      - restore_cache:
-          keys:
-            - v1-macos-arm64-jdk-{{ checksum "jdk.properties" }}
+      - restore-gradle-caches:
+          platform: macos-arm64
 
-      - restore_cache:
-          keys:
-            - v1-macos-arm64-vscode-tests
+      # Cross-platform Gradle tasks
+      - gradle-core-tasks
 
-      - run: ./gradlew --no-daemon dependencies
+      - store-native-artifacts
 
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: v1-macos-arm64-dependencies-{{ checksum "build.gradle.kts" }}
-
-      - run:
-          name: Verify `buildSrc/` project
-          command: |
-            cd buildSrc
-            ./gradlew --no-daemon check
-
-      - run:
-          name: Verify Kson project
-          command: ./gradlew --no-daemon check
-
-      - run:
-          name: Build native kson-lib
-          command: ./gradlew --no-daemon :kson-lib:nativeRelease
-
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseShared
-          destination: kson-lib-shared
-
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseStatic
-          destination: kson-lib-static
-
-      - save_cache:
-          paths:
-            - ./tooling/lsp-clients/vscode/.vscode-test
-            - ./tooling/lsp-clients/vscode/.vscode-test-web
-          key: v1-macos-arm64-vscode-tests
-
-      - save_cache:
-          paths:
-            - ./gradle/jdk
-            - ./buildSrc/gradle/jdk
-          key: v1-macos-arm64-jdk-{{ checksum "jdk.properties" }}
+      - save-gradle-caches:
+          platform: macos-arm64
 
   build-python-sdist:
     docker:
@@ -250,14 +245,11 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run:
-          name: Get rid of erroneous git config
-          command: |
-            rm -rf ~/.gitconfig
+      - clean-git-config:
+          shell: bash
       - run:
           name: Build Python source distribution
-          command: |
-            ./gradlew :lib-python:createSdistBuildEnvironment
+          command: ./gradlew :lib-python:createSdistBuildEnvironment
       - run:
           name: Verify sdist was created
           command: |
@@ -276,30 +268,10 @@ jobs:
       - image: cimg/python:3.11
     working_directory: ~/repo
     steps:
-      - checkout
+      - setup-python-test:
+          platform: linux
       - setup_remote_docker
-      - run:
-          name: Get rid of erroneous git config
-          command: |
-            rm -rf ~/.gitconfig
-      - attach_workspace:
-          at: ~/repo
-      - run:
-          name: Install kson from sdist
-          command: |
-            python3 -m pip install lib-python/dist/kson_lang-*.tar.gz
-      - run:
-          name: Install test dependencies
-          command: |
-            python3 -m pip install pytest
-      - run:
-          name: Run smoke tests on sdist installation
-          command: |
-            python3 -m pytest lib-python -v
-      - run:
-          name: Build platform-specific wheel
-          command: |
-            ./gradlew :lib-python:buildWheel
+      - run-python-tests-unix
       - store_artifacts:
           path: lib-python/dist
           destination: python-linux-amd64
@@ -309,29 +281,9 @@ jobs:
       xcode: 14.2.0
     working_directory: ~/repo
     steps:
-      - checkout
-      - run:
-          name: Get rid of erroneous git config
-          command: |
-            rm -rf ~/.gitconfig
-      - attach_workspace:
-          at: ~/repo
-      - run:
-          name: Install kson from sdist
-          command: |
-            python3 -m pip install lib-python/dist/kson_lang-*.tar.gz
-      - run:
-          name: Install test dependencies
-          command: |
-            python3 -m pip install pytest
-      - run:
-          name: Run smoke tests on sdist installation
-          command: |
-            python3 -m pytest lib-python -v
-      - run:
-          name: Build platform-specific wheel
-          command: |
-            ./gradlew :lib-python:buildWheel
+      - setup-python-test:
+          platform: macos
+      - run-python-tests-unix
       - store_artifacts:
           path: lib-python/dist
           destination: python-macos
@@ -342,14 +294,8 @@ jobs:
       size: medium
     working_directory: ~/repo
     steps:
-      - checkout
-      - run:
-          name: Get rid of erroneous git config
-          command: |
-            Remove-Item -Path "$env:USERPROFILE\.gitconfig" -Force -ErrorAction SilentlyContinue
-          shell: powershell.exe
-      - attach_workspace:
-          at: ~/repo
+      - setup-python-test:
+          platform: windows
       - run:
           name: Check Python version and upgrade if needed
           command: |
@@ -362,12 +308,10 @@ jobs:
           shell: powershell.exe
       - run:
           name: Install test dependencies
-          command: |
-            python -m pip install pytest
+          command: python -m pip install pytest
       - run:
           name: Run smoke tests on sdist installation
-          command: |
-            python -m pytest lib-python -v
+          command: python -m pytest lib-python -v
       - run:
           name: Build platform-specific wheel
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,40 +322,34 @@ jobs:
 
 workflows:
   version: 2
+
+  # Main build workflow - runs on version tags
   build-all:
     jobs:
       - build-linux-amd64
-      - build-windows-amd64
-      - build-macos-arm64
+      - build-windows-amd64:
+          filters: &version-tag-filter
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
+      - build-macos-arm64:
+          filters: *version-tag-filter
+
+  # Python package workflow - also runs on version tags
   build-python-and-test:
     jobs:
       - build-python-sdist:
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
+          filters: *version-tag-filter
       - test-python-sdist-linux-amd64:
           requires:
             - build-python-sdist
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
+          filters: *version-tag-filter
       - test-python-sdist-macos:
           requires:
             - build-python-sdist
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
+          filters: *version-tag-filter
       - test-python-sdist-windows:
           requires:
             - build-python-sdist
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
+          filters: *version-tag-filter

--- a/kson-lib/src/commonMain/kotlin/org/kson/Kson.kt
+++ b/kson-lib/src/commonMain/kotlin/org/kson/Kson.kt
@@ -182,6 +182,7 @@ data class FormatOptions(
             FormattingStyle.PLAIN -> InternalFormattingStyle.PLAIN
             FormattingStyle.DELIMITED -> InternalFormattingStyle.DELIMITED
             FormattingStyle.COMPACT -> InternalFormattingStyle.COMPACT
+            FormattingStyle.CLASSIC -> InternalFormattingStyle.CLASSIC
         }
         return KsonFormatterConfig(indentType = indentType, formattingStyle)
     }
@@ -196,7 +197,8 @@ enum class FormattingStyle{
      */
     PLAIN,
     DELIMITED,
-    COMPACT
+    COMPACT,
+    CLASSIC
 }
 
 /**

--- a/lib-python/src/kson/__init__.py
+++ b/lib-python/src/kson/__init__.py
@@ -392,10 +392,15 @@ class FormattingStyle(Enum):
                 result = symbols.kotlin.root.org.kson.FormattingStyle.COMPACT.get()
                 result.pinned = ffi.gc(result.pinned, symbols.DisposeStablePointer)
                 return result
+            case FormattingStyle.CLASSIC:
+                result = symbols.kotlin.root.org.kson.FormattingStyle.CLASSIC.get()
+                result.pinned = ffi.gc(result.pinned, symbols.DisposeStablePointer)
+                return result
 
     PLAIN = 0
     DELIMITED = 1
     COMPACT = 2
+    CLASSIC = 3
 
 
 class FormatOptions:

--- a/lib-python/tests/smoke_test.py
+++ b/lib-python/tests/smoke_test.py
@@ -32,6 +32,27 @@ def test_kson_format():
     )
 
 
+def test_kson_formatting_classic():
+    indent = IndentType.Spaces(2)
+    formatting = FormattingStyle.CLASSIC
+    result = Kson.format(
+        "key: [1, 2, 3, 4]",
+        FormatOptions(indent, formatting),
+    )
+
+    assert (
+        result
+        == """{
+  "key": [
+    1,
+    2,
+    3,
+    4
+  ]
+}"""
+    )
+
+
 def test_kson_to_json_success():
     result = Kson.to_json("key: [1, 2, 3, 4]")
     assert isinstance(result, Success)

--- a/lib-rust/kson/src/lib.rs
+++ b/lib-rust/kson/src/lib.rs
@@ -684,6 +684,7 @@ pub enum FormattingStyle {
     Plain,
     Delimited,
     Compact,
+    Classic,
 }
 
 impl_kotlin_object_for_c_enum!(
@@ -691,6 +692,7 @@ impl_kotlin_object_for_c_enum!(
     0 = FormattingStyle::Plain = KSON_SYMBOLS.kotlin.root.org.kson.FormattingStyle.PLAIN,
     1 = FormattingStyle::Delimited = KSON_SYMBOLS.kotlin.root.org.kson.FormattingStyle.DELIMITED,
     2 = FormattingStyle::Compact = KSON_SYMBOLS.kotlin.root.org.kson.FormattingStyle.COMPACT,
+    3 = FormattingStyle::Classic = KSON_SYMBOLS.kotlin.root.org.kson.FormattingStyle.CLASSIC,
 );
 
 impl FormattingStyle {

--- a/lib-rust/kson/src/test.rs
+++ b/lib-rust/kson/src/test.rs
@@ -17,6 +17,25 @@ fn test_kson_format() {
 }
 
 #[test]
+fn test_kson_format_classic() {
+    let indent = IndentType::Spaces(IndentTypeSpaces::new(2));
+    let result = Kson::format(
+        "key: [1, 2, 3, 4]",
+        &FormatOptions::new(&indent, &FormattingStyle::Classic),
+    );
+    insta::assert_snapshot!(result, @r#"
+      {
+        "key": [
+          1,
+          2,
+          3,
+          4
+        ]
+      }
+      "#);
+}
+
+#[test]
 fn test_kson_to_json_success() {
     let result = Kson::to_json("key: [1, 2, 3, 4]");
     match result {

--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -55,7 +55,7 @@ interface AstNode {
         /**
          * Constructs an initial/default indent
          */
-        constructor() : this(IndentType.Space(2),0, false)
+        constructor() : this(IndentType.Space(2), 0, false)
 
         private val indentString = indentType.indentString
 
@@ -184,7 +184,7 @@ class KsonRootImpl(
                 }
 
                 // remove any trailing newlines
-                while(ksonDocument.endsWith("\n")) {
+                while (ksonDocument.endsWith("\n")) {
                     ksonDocument = ksonDocument.removeSuffix("\n")
                 }
 
@@ -194,9 +194,9 @@ class KsonRootImpl(
                         // endComments are already embedded in the document, likely as part of a trailing error
                         ""
                     } else {
-                        if(compileTarget is Kson && compileTarget.formatConfig.formattingStyle == FormattingStyle.COMPACT){
+                        if (compileTarget is Kson && compileTarget.formatConfig.formattingStyle == FormattingStyle.COMPACT) {
                             "\n" + endComments
-                        }else{
+                        } else {
                             "\n\n" + endComments
                         }
                     }
@@ -222,31 +222,40 @@ class ObjectNode(val properties: List<ObjectPropertyNode>, location: Location) :
                     FormattingStyle.COMPACT -> formatCompactObject(indent, nextNode, compileTarget)
                 }
             }
+
             is Yaml -> formatUndelimitedObject(indent, nextNode, compileTarget)
             is Json -> formatDelimitedObject(indent, nextNode, compileTarget)
         }
     }
 
     private fun formatDelimitedObject(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
-            val seperator = when(compileTarget) {
-                is Kson -> "\n"
-                is Json -> ",\n"
-                is Yaml -> throw UnsupportedOperationException("We never format YAML objects as delimited")
+        val seperator = when (compileTarget) {
+            is Kson -> {
+                when (compileTarget.formatConfig.formattingStyle) {
+                    FormattingStyle.CLASSIC -> ",\n"
+                    else -> "\n"
+                }
             }
+
+            is Json -> ",\n"
+            is Yaml -> throw UnsupportedOperationException("We never format YAML objects as delimited")
+        }
 
             return """
             |${indent.firstLineIndent()}{
-            |${properties.withIndex().joinToString(seperator) { (index, property) ->
+            |${
+            properties.withIndex().joinToString(seperator) { (index, property) ->
                 val nodeAfterThisChild = properties.getOrNull(index + 1) ?: nextNode
-                property.toSourceWithNext(indent.next(false), nodeAfterThisChild, compileTarget) }
+                property.toSourceWithNext(indent.next(false), nodeAfterThisChild, compileTarget)
             }
+        }
             |${indent.bodyLinesIndent()}}
             """.trimMargin()
 
     }
 
-    private fun formatCompactObject(indent: Indent , nextNode: AstNode?, compileTarget: CompileTarget): String {
-        val outputObject = properties.withIndex().joinToString(""){ (index, property) ->
+    private fun formatCompactObject(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
+        val outputObject = properties.withIndex().joinToString("") { (index, property) ->
             val nodeAfterThisChild = properties.getOrNull(index + 1) ?: nextNode
             val result = property.toSourceWithNext(indent, nodeAfterThisChild, compileTarget)
 
@@ -258,11 +267,13 @@ class ObjectNode(val properties: List<ObjectPropertyNode>, location: Location) :
                         is QuotedStringNode -> {
                             StringUnquoted.isUnquotable(property.value.stringContent)
                         }
+
                         is UnquotedStringNode,
                         is NumberNode,
                         is TrueNode,
                         is FalseNode,
                         is NullNode -> true
+
                         else -> false
                     }
 
@@ -271,7 +282,7 @@ class ObjectNode(val properties: List<ObjectPropertyNode>, location: Location) :
         return if (nextNode is ObjectPropertyNode) {
             // If the last property is a number we need to add whitespace before the '.' to prevent it becoming a number
             val needsSpace = (properties.last() as ObjectPropertyNodeImpl).value is NumberNode
-            outputObject + if(needsSpace) " ." else "."
+            outputObject + if (needsSpace) " ." else "."
         } else outputObject
     }
 
@@ -322,21 +333,23 @@ class ObjectPropertyNodeImpl(
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
             is Kson -> {
-                when (compileTarget.formatConfig.formattingStyle){
+                when (compileTarget.formatConfig.formattingStyle) {
                     FormattingStyle.DELIMITED -> delimitedObjectProperty(indent, nextNode, compileTarget)
-                    FormattingStyle.COMPACT  -> compactObjectProperty(indent, nextNode, compileTarget)
+                    FormattingStyle.COMPACT -> compactObjectProperty(indent, nextNode, compileTarget)
                     FormattingStyle.PLAIN -> undelimitedObjectProperty(indent, nextNode, compileTarget)
                 }
             }
+
             is Yaml -> undelimitedObjectProperty(indent, nextNode, compileTarget)
             is Json -> delimitedObjectProperty(indent, nextNode, compileTarget)
         }
     }
 
-    private fun delimitedObjectProperty(indent:Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
+    private fun delimitedObjectProperty(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         val delimitedPropertyIndent = if (value is ListNode || value is ObjectNode ||
             // check if we're compiling an embed block to an object
-            (compileTarget is Json && value is EmbedBlockNode && compileTarget.retainEmbedTags)) {
+            (compileTarget is Json && value is EmbedBlockNode && compileTarget.retainEmbedTags)
+        ) {
             // For delimited lists and objects, don't increase their indent here - they provide their own indent nest
             indent.clone(true)
         } else {
@@ -344,15 +357,16 @@ class ObjectPropertyNodeImpl(
             indent.next(true)
         }
         return key.toSourceWithNext(indent, value, compileTarget) + " " +
-                    value.toSourceWithNext(delimitedPropertyIndent, nextNode, compileTarget)
+                value.toSourceWithNext(delimitedPropertyIndent, nextNode, compileTarget)
     }
 
-    private fun undelimitedObjectProperty(indent:Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
+    private fun undelimitedObjectProperty(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return if (
             (value is ListNode && value.elements.isNotEmpty()) ||
             (value is ObjectNode && value.properties.isNotEmpty()) ||
             // check if we're compiling an embed block to an object
-            (compileTarget is Yaml && value is EmbedBlockNode && compileTarget.retainEmbedTags)) {
+            (compileTarget is Yaml && value is EmbedBlockNode && compileTarget.retainEmbedTags)
+        ) {
             // For non-empty lists and objects, put the value on the next line
             key.toSourceWithNext(indent, value, compileTarget) + "\n" +
                     value.toSourceWithNext(indent.next(false), nextNode, compileTarget)
@@ -368,7 +382,7 @@ class ObjectPropertyNodeImpl(
         val firstPropertyHasComments = if (value !is ObjectNode) {
             false
         } else {
-            when (val firstProperty = value.properties.firstOrNull()){
+            when (val firstProperty = value.properties.firstOrNull()) {
                 is ObjectPropertyNodeImpl -> firstProperty.comments.isNotEmpty()
                 null -> false
                 else -> false
@@ -391,9 +405,9 @@ class ListNode(
     val elements: List<ListElementNode>,
     location: Location
 ) : KsonValueNodeImpl(location) {
-    private sealed class ListDelimiters(val open: Char, val close: Char){
+    private sealed class ListDelimiters(val open: Char, val close: Char) {
         data object AngleBrackets : ListDelimiters('<', '>')
-        data object SquareBrackets: ListDelimiters('[', ']')
+        data object SquareBrackets : ListDelimiters('[', ']')
     }
 
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
@@ -406,7 +420,7 @@ class ListNode(
         }
         return when (compileTarget) {
             is Kson -> {
-                when(compileTarget.formatConfig.formattingStyle) {
+                when (compileTarget.formatConfig.formattingStyle) {
                     FormattingStyle.PLAIN -> {
                         val outputList = formatUndelimitedList(indent, nextNode, compileTarget)
                         /**
@@ -419,10 +433,23 @@ class ListNode(
                             outputList
                         }
                     }
-                    FormattingStyle.DELIMITED -> formatDelimitedList(indent, nextNode, compileTarget, listDelimiter)
-                    FormattingStyle.COMPACT -> formatCompactList(indent, nextNode, compileTarget, ListDelimiters.SquareBrackets)
+
+                    FormattingStyle.DELIMITED, FormattingStyle.CLASSIC -> formatDelimitedList(
+                        indent,
+                        nextNode,
+                        compileTarget,
+                        listDelimiter
+                    )
+
+                    FormattingStyle.COMPACT -> formatCompactList(
+                        indent,
+                        nextNode,
+                        compileTarget,
+                        ListDelimiters.SquareBrackets
+                    )
                 }
             }
+
             is Yaml -> formatUndelimitedList(indent, nextNode, compileTarget)
             is Json -> formatDelimitedList(indent, nextNode, compileTarget, listDelimiter)
         }
@@ -451,7 +478,12 @@ class ListNode(
                 indent.bodyLinesIndent() + listDelimiters.close
     }
 
-    private fun formatCompactList(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget, listDelimiters: ListDelimiters): String {
+    private fun formatCompactList(
+        indent: Indent,
+        nextNode: AstNode?,
+        compileTarget: CompileTarget,
+        listDelimiters: ListDelimiters
+    ): String {
         return elements.withIndex().joinToString(
             "",
             prefix = listDelimiters.open.toString(),
@@ -466,7 +498,7 @@ class ListNode(
 
 
             val isNotLastElement = index < elements.size - 1
-            
+
             // Extract current and next element values for type checking
             val currentValue = (element as? ListElementNodeImpl)?.value
             val currentIsObject = currentValue is ObjectNode
@@ -497,8 +529,8 @@ class ListNode(
 
 interface ListElementNode : AstNode
 class ListElementNodeError(content: String, location: Location) : AstNodeError(content, location), ListElementNode
-class ListElementNodeImpl(val value: KsonValueNode, override val comments: List<String>, location: Location)
-    : ListElementNode, AstNodeImpl(location), Documented {
+class ListElementNodeImpl(val value: KsonValueNode, override val comments: List<String>, location: Location) :
+    ListElementNode, AstNodeImpl(location), Documented {
 
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
@@ -552,9 +584,11 @@ abstract class StringNodeImpl(location: Location) : StringNode, KsonValueNodeImp
  *   including all escapes, but excluding the outer quotes.  A [Kson] string is escaped identically to a Json string,
  *   except that [Kson] allows raw whitespace to be embedded in strings
  */
-open class QuotedStringNode(private val ksonEscapedStringContent: String,
-                            private val stringQuote: StringQuote,
-                            location: Location) : StringNodeImpl(location) {
+open class QuotedStringNode(
+    private val ksonEscapedStringContent: String,
+    private val stringQuote: StringQuote,
+    location: Location
+) : StringNodeImpl(location) {
 
     /**
      * An "unquoted" Kson string: i.e. a valid Kson string with all escapes intact except for quote escapes.
@@ -625,13 +659,15 @@ class UnquotedStringNode(override val stringContent: String, location: Location)
 class NumberNode(stringValue: String, location: Location) : KsonValueNodeImpl(location) {
     val value: ParsedNumber by lazy {
         val parsedNumber = NumberParser(stringValue).parse()
-        parsedNumber.number ?: throw IllegalStateException("Hitting this indicates a parser bug: unparseable " +
-                "strings should be passed here but we got: " + stringValue)
+        parsedNumber.number ?: throw IllegalStateException(
+            "Hitting this indicates a parser bug: unparseable " +
+                    "strings should be passed here but we got: " + stringValue
+        )
     }
 
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
-            is Kson, is Yaml, is Json-> {
+            is Kson, is Yaml, is Json -> {
                 indent.firstLineIndent() + value.asString
             }
         }
@@ -651,7 +687,7 @@ class TrueNode(location: Location) : KsonValueNodeImpl(location) {
 class FalseNode(location: Location) : KsonValueNodeImpl(location) {
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
-            is Kson, is Yaml, is Json-> {
+            is Kson, is Yaml, is Json -> {
                 indent.firstLineIndent() + "false"
             }
         }
@@ -695,11 +731,11 @@ class EmbedBlockNode(
                     // without any escaping needed
                     percentCount == 0 ->
                         EmbedDelim.Percent to embedContent
-                    
+
                     // Otherwise, check if we can use the alternate delimiter without escaping
                     dollarCount == 0 ->
                         EmbedDelim.Dollar to EmbedDelim.Dollar.escapeEmbedContent(embedContent)
-                    
+
                     // We'll choose the delimiter that requires less escaping
                     else -> {
                         val chosenDelimiter = if (dollarCount < percentCount) EmbedDelim.Dollar else EmbedDelim.Percent
@@ -707,20 +743,21 @@ class EmbedBlockNode(
                     }
                 }
 
-                val embedPreamble = embedTag + if(metadataTag.isNotEmpty()) ": $metadataTag" else ""
-                when (compileTarget.formatConfig.formattingStyle){
-                    FormattingStyle.PLAIN, FormattingStyle.DELIMITED -> {
+                val embedPreamble = embedTag + if (metadataTag.isNotEmpty()) ": $metadataTag" else ""
+                when (compileTarget.formatConfig.formattingStyle) {
+                    FormattingStyle.PLAIN, FormattingStyle.DELIMITED, FormattingStyle.CLASSIC -> {
                         // Format the embed block
                         indent.firstLineIndent() + delimiter.openDelimiter + embedPreamble + "\n" +
                                 indent.bodyLinesIndent() + content.lines()
                             .joinToString("\n${indent.bodyLinesIndent()}") { it } +
                                 delimiter.closeDelimiter
                     }
+
                     FormattingStyle.COMPACT -> {
                         // Format the embed block
                         delimiter.openDelimiter + embedPreamble + "\n" +
                                 content.lines()
-                            .joinToString("\n") { it } +
+                                    .joinToString("\n") { it } +
                                 delimiter.closeDelimiter
                     }
                 }
@@ -733,6 +770,7 @@ class EmbedBlockNode(
                     encodeEmbedBlock(compileTarget, indent)
                 }
             }
+
             is Json -> {
                 if (!compileTarget.retainEmbedTags) {
                     indent.firstLineIndent() + "\"${renderForJsonString(embedContent)}\""
@@ -787,6 +825,7 @@ class EmbedBlockNode(
                         indent.firstLineIndent() + "${EmbedObjectKeys.EMBED_CONTENT.key}: " +
                         renderMultilineYamlString(embedContent, indent.clone(true), indent.next(true))
             }
+
             is Kson -> throw UnsupportedOperationException("should not encode embed block as ${compileTarget::class.simpleName}")
         }
 

--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -220,6 +220,7 @@ class ObjectNode(val properties: List<ObjectPropertyNode>, location: Location) :
                     FormattingStyle.DELIMITED -> formatDelimitedObject(indent, nextNode, compileTarget)
                     FormattingStyle.PLAIN -> formatUndelimitedObject(indent, nextNode, compileTarget)
                     FormattingStyle.COMPACT -> formatCompactObject(indent, nextNode, compileTarget)
+                    FormattingStyle.CLASSIC -> formatDelimitedObject(indent, nextNode, compileTarget)
                 }
             }
 
@@ -241,7 +242,7 @@ class ObjectNode(val properties: List<ObjectPropertyNode>, location: Location) :
             is Yaml -> throw UnsupportedOperationException("We never format YAML objects as delimited")
         }
 
-            return """
+        return """
             |${indent.firstLineIndent()}{
             |${
             properties.withIndex().joinToString(seperator) { (index, property) ->
@@ -337,6 +338,7 @@ class ObjectPropertyNodeImpl(
                     FormattingStyle.DELIMITED -> delimitedObjectProperty(indent, nextNode, compileTarget)
                     FormattingStyle.COMPACT -> compactObjectProperty(indent, nextNode, compileTarget)
                     FormattingStyle.PLAIN -> undelimitedObjectProperty(indent, nextNode, compileTarget)
+                    FormattingStyle.CLASSIC -> delimitedObjectProperty(indent, nextNode, compileTarget)
                 }
             }
 
@@ -412,9 +414,15 @@ class ListNode(
 
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         val listDelimiter = when (compileTarget) {
-                is Kson -> ListDelimiters.AngleBrackets
-                is Yaml, is Json -> ListDelimiters.SquareBrackets
+            is Kson -> {
+                when (compileTarget.formatConfig.formattingStyle) {
+                    FormattingStyle.CLASSIC -> ListDelimiters.SquareBrackets
+                    else -> ListDelimiters.AngleBrackets
+                }
             }
+
+            is Yaml, is Json -> ListDelimiters.SquareBrackets
+        }
         if (elements.isEmpty()) {
             return "${indent.firstLineIndent()}${listDelimiter.open}${listDelimiter.close}"
         }
@@ -462,7 +470,11 @@ class ListNode(
         listDelimiters: ListDelimiters
     ): String {
         val seperator = when (compileTarget) {
-            is Kson -> "\n"
+            is Kson -> when (compileTarget.formatConfig.formattingStyle) {
+                FormattingStyle.CLASSIC -> ",\n"
+                else -> "\n"
+            }
+
             is Json -> ",\n"
             else -> throw UnsupportedOperationException("We never format YAML objects as delimited")
         }
@@ -538,7 +550,11 @@ class ListElementNodeImpl(val value: KsonValueNode, override val comments: List<
                 when (compileTarget.formatConfig.formattingStyle) {
                     FormattingStyle.PLAIN -> formatWithDash(indent, nextNode, compileTarget)
                     FormattingStyle.DELIMITED -> formatWithDash(indent, nextNode, compileTarget, isDelimited = true)
-                    FormattingStyle.COMPACT -> value.toSourceWithNext(indent, nextNode, compileTarget)
+                    FormattingStyle.COMPACT, FormattingStyle.CLASSIC -> value.toSourceWithNext(
+                        indent,
+                        nextNode,
+                        compileTarget
+                    )
                 }
             }
 
@@ -606,25 +622,36 @@ open class QuotedStringNode(
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
             is Kson -> {
-                // Check if we can use this string unquoted
-                val isSimple = StringUnquoted.isUnquotable(unquotedString)
+                when (compileTarget.formatConfig.formattingStyle) {
+                    FormattingStyle.CLASSIC -> indent.firstLineIndent() + "\"${
+                        DoubleQuote.escapeQuotes(
+                            unquotedString
+                        )
 
-                indent.firstLineIndent() +
-                    if (isSimple) {
-                        unquotedString
-                    } else {
-                        val singleQuoteCount = SingleQuote.countDelimiterOccurrences(unquotedString)
-                        val doubleQuoteCount = DoubleQuote.countDelimiterOccurrences(unquotedString)
+                    }\""
 
-                        // prefer single-quotes unless double-quotes would require less escaping
-                        val chosenDelimiter = if (doubleQuoteCount < singleQuoteCount) {
-                            DoubleQuote
-                        } else {
-                            SingleQuote
-                        }
+                    else -> {
+                        // Check if we can use this string unquoted
+                        val isSimple = StringUnquoted.isUnquotable(unquotedString)
 
-                    val escapedContent = chosenDelimiter.escapeQuotes(unquotedString)
-                    "${chosenDelimiter}$escapedContent${chosenDelimiter}"
+                        indent.firstLineIndent() +
+                                if (isSimple) {
+                                    unquotedString
+                                } else {
+                                    val singleQuoteCount = SingleQuote.countDelimiterOccurrences(unquotedString)
+                                    val doubleQuoteCount = DoubleQuote.countDelimiterOccurrences(unquotedString)
+
+                                    // prefer single-quotes unless double-quotes would require less escaping
+                                    val chosenDelimiter = if (doubleQuoteCount < singleQuoteCount) {
+                                        DoubleQuote
+                                    } else {
+                                        SingleQuote
+                                    }
+
+                                    val escapedContent = chosenDelimiter.escapeQuotes(unquotedString)
+                                    "${chosenDelimiter}$escapedContent${chosenDelimiter}"
+                                }
+                    }
                 }
             }
 
@@ -642,7 +669,19 @@ open class QuotedStringNode(
 class UnquotedStringNode(override val stringContent: String, location: Location) : StringNodeImpl(location) {
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
-            is Kson, is Yaml -> {
+            is Kson -> {
+                when (compileTarget.formatConfig.formattingStyle) {
+                    FormattingStyle.CLASSIC -> {
+                        indent.firstLineIndent() + "\"${renderForJsonString(stringContent)}\""
+                    }
+
+                    else -> {
+                        indent.firstLineIndent() + stringContent
+                    }
+                }
+            }
+
+            is Yaml -> {
                 indent.firstLineIndent() + stringContent
             }
 

--- a/src/commonMain/kotlin/org/kson/tools/Formatter.kt
+++ b/src/commonMain/kotlin/org/kson/tools/Formatter.kt
@@ -60,8 +60,10 @@ class IndentFormatter(
      *   should assume the snippet itself is already indented nested to a level of [snippetNestingLevel].
      * @return The indented KSON source code
      */
-    @Deprecated("This formatter is no long a good general purpose formatter. " +
-            "See the TODO in this class's doc for details")
+    @Deprecated(
+        "This formatter is no long a good general purpose formatter. " +
+                "See the TODO in this class's doc for details"
+    )
     private fun indent(source: String, snippetNestingLevel: Int? = null): String {
         if (source.isBlank() && snippetNestingLevel == null) return ""
         val tokens = Lexer(source, gapFree = true).tokenize()
@@ -104,7 +106,7 @@ class IndentFormatter(
                      * carefully preserved
                      */
                     EMBED_CONTENT -> {
-                        val embedContentIndent = if (line.subList(0,tokenIndex + 1).any {
+                        val embedContentIndent = if (line.subList(0, tokenIndex + 1).any {
                                 it.tokenType == COLON
                             }) {
                             /**
@@ -131,6 +133,7 @@ class IndentFormatter(
                         lineContent.clear()
                         break
                     }
+
                     COLON -> {
                         // if we're currently nested in a COLON, consider that nest closed on this line
                         // since we're starting a new object property
@@ -145,20 +148,22 @@ class IndentFormatter(
                         }
                         lineContent.add(token.lexeme.text)
                     }
+
                     in OPENING_DELIMITERS -> {
                         // register the indent from this opening delim
                         nextNests.add(token.tokenType)
                         lineContent.add(token.lexeme.text)
                     }
+
                     in CLOSING_DELIMITERS -> {
                         /**
                          * [CLOSING_DELIMITERS] that are part of a leading line of leading close delimiters
                          * on a line may trigger an immediate un-nest
                          */
                         if (line.subList(0, tokenIndex + 1).all {
-                            CLOSING_DELIMITERS.contains(it.tokenType)
-                                    || it.tokenType == WHITESPACE
-                        }) {
+                                CLOSING_DELIMITERS.contains(it.tokenType)
+                                        || it.tokenType == WHITESPACE
+                            }) {
                             if (nesting.lastOrNull() == COLON) {
                                 /**
                                  * If we spot a [COLON] nest as we're closing things, that must be closed too:
@@ -176,6 +181,7 @@ class IndentFormatter(
                         }
                         lineContent.add(token.lexeme.text)
                     }
+
                     else -> {
                         lineContent.add(token.lexeme.text)
                     }
@@ -265,7 +271,7 @@ class IndentFormatter(
         while (startIndex < tokens.size && tokens[startIndex].tokenType == WHITESPACE) {
             startIndex++
         }
-        
+
         var index = startIndex
         while (index < tokens.size) {
             val token = tokens[index]
@@ -288,12 +294,13 @@ class IndentFormatter(
                 val nextToken = tokens.getOrNull(index + 1)
                 if (nextToken?.tokenType == COMMENT) {
                     var commentToken: Token = nextToken
-                    while(commentToken.tokenType == COMMENT
-                        || (commentToken.tokenType == WHITESPACE && commentToken.lexeme.text.contains('\n'))) {
+                    while (commentToken.tokenType == COMMENT
+                        || (commentToken.tokenType == WHITESPACE && commentToken.lexeme.text.contains('\n'))
+                    ) {
                         index++
                         if (commentToken.tokenType == WHITESPACE) {
                             val numNewlines = commentToken.lexeme.text.count { it == '\n' }
-                            repeat (numNewlines) {
+                            repeat(numNewlines) {
                                 currentLine.add(commentToken.copy(lexeme = commentToken.lexeme.copy(text = "\n")))
                             }
                         } else {

--- a/src/commonMain/kotlin/org/kson/tools/Formatter.kt
+++ b/src/commonMain/kotlin/org/kson/tools/Formatter.kt
@@ -25,7 +25,8 @@ fun format(ksonSource: String, formatterConfig: KsonFormatterConfig = KsonFormat
 enum class FormattingStyle {
     PLAIN,
     DELIMITED,
-    COMPACT
+    COMPACT,
+    CLASSIC
 }
 
 data class KsonFormatterConfig(

--- a/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
+++ b/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
@@ -21,9 +21,9 @@ class FormatterTest {
         /**
          * TODO There are two test cases that currently can't roundtrip. After we handled these corner cases we should
          * roundtrip for every test.
-        **/
+         **/
         var roundtripKson = formattedKson
-        if(roundTrip){
+        if (roundTrip) {
             FormattingStyle.entries.filter { it != formattingStyle }.forEach { intermediateStyle ->
                 roundtripKson = format(roundtripKson, KsonFormatterConfig(indentType, intermediateStyle))
             }
@@ -45,7 +45,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testColonWithWhitespace(){
+    fun testColonWithWhitespace() {
         assertFormatting(
             """
             {
@@ -435,7 +435,8 @@ class FormatterTest {
               # comment
               # comment
               y: 12
-            """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     @Test
@@ -472,7 +473,7 @@ class FormatterTest {
         )
 
     }
-    
+
     @Test
     fun testEmbedBlocksAtDifferentNestingLevels() {
         assertFormatting(
@@ -746,7 +747,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testFormattingMixedUnnesting(){
+    fun testFormattingMixedUnnesting() {
         assertFormatting(
             """
             outer_key1: {
@@ -1014,149 +1015,237 @@ class FormatterTest {
     fun testGetCurrentLineIndentLevel() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("{"),
-            "should indent one level after opening brace")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("  {"),
-            "should indent one level after opening brace with existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("{"),
+            "should indent one level after opening brace"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("  {"),
+            "should indent one level after opening brace with existing indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("key:"),
-            "should indent one level after colon")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("  key:"),
-            "should indent one level after colon with existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("key:"),
+            "should indent one level after colon"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("  key:"),
+            "should indent one level after colon with existing indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("<"),
-            "should indent one level after opening angle bracket")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("  <"),
-            "should indent one level after opening angle bracket with existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("<"),
+            "should indent one level after opening angle bracket"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("  <"),
+            "should indent one level after opening angle bracket with existing indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  - item"),
-            "should maintain indent after dash in list")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  - item"),
+            "should maintain indent after dash in list"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  }"),
-            "should match closing brace indent")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    }"),
-            "should match closing brace indent with higher existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  }"),
+            "should match closing brace indent"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    }"),
+            "should match closing brace indent with higher existing indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  >"),
-            "should match closing angle bracket indent")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    >"),
-            "should match closing angle bracket indent with higher existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  >"),
+            "should match closing angle bracket indent"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    >"),
+            "should match closing angle bracket indent with higher existing indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  some text"),
-            "should maintain indent for normal lines")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    other text"),
-            "should maintain indent for normal lines with higher existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  some text"),
+            "should maintain indent for normal lines"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    other text"),
+            "should maintain indent for normal lines with higher existing indent"
+        )
     }
 
     @Test
     fun testEmptyLineIndentLevel() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  "),
-            "should maintain previous indent for empty lines")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    "),
-            "should maintain previous indent for empty lines with higher existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  "),
+            "should maintain previous indent for empty lines"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    "),
+            "should maintain previous indent for empty lines with higher existing indent"
+        )
     }
 
     @Test
     fun testGetCurrentLineIndentLevelWithTabs() {
         val formatter = IndentFormatter(IndentType.Tab())
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("{"),
-            "should indent one level after opening brace with tab indentation")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("\t{"),
-            "should indent one level after opening brace with existing tab indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("{"),
+            "should indent one level after opening brace with tab indentation"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("\t{"),
+            "should indent one level after opening brace with existing tab indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("key:"),
-            "should indent one level after colon with tab indentation")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("\tkey:"),
-            "should indent one level after colon with existing tab indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("key:"),
+            "should indent one level after colon with tab indentation"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("\tkey:"),
+            "should indent one level after colon with existing tab indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("\tsome text"),
-            "should maintain indent for normal lines with tab indentation")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("\t\tother text"),
-            "should maintain indent for normal lines with higher existing tab indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("\tsome text"),
+            "should maintain indent for normal lines with tab indentation"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("\t\tother text"),
+            "should maintain indent for normal lines with higher existing tab indent"
+        )
     }
 
     @Test
     fun testGetCurrentLineIndentLevelWithEmbedBlocks() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(0, formatter.getCurrentLineIndentLevel("%%sql"),
-            "should not change indent for embed block start")
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  %%sql"),
-            "should not change indent for embed block start with existing indent")
+        assertEquals(
+            0, formatter.getCurrentLineIndentLevel("%%sql"),
+            "should not change indent for embed block start"
+        )
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  %%sql"),
+            "should not change indent for embed block start with existing indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  SELECT *"),
-            "should maintain indent inside embed block")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  SELECT *"),
+            "should maintain indent inside embed block"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  %%"),
-            "should decrease indent after embed block end")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    %%"),
-            "should decrease indent after embed block end with higher existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  %%"),
+            "should decrease indent after embed block end"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    %%"),
+            "should decrease indent after embed block end with higher existing indent"
+        )
     }
 
     @Test
     fun testGetCurrentLineIndentLevelWithMixedStructures() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("{"),
-            "should properly indent for nested structures")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("  nested: {"),
-            "should properly indent for nested object properties")
-        assertEquals(3, formatter.getCurrentLineIndentLevel("    items: <"),
-            "should properly indent for nested angle brackets")
-        assertEquals(3, formatter.getCurrentLineIndentLevel("    - {"),
-            "should properly indent for nested list items")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("{"),
+            "should properly indent for nested structures"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("  nested: {"),
+            "should properly indent for nested object properties"
+        )
+        assertEquals(
+            3, formatter.getCurrentLineIndentLevel("    items: <"),
+            "should properly indent for nested angle brackets"
+        )
+        assertEquals(
+            3, formatter.getCurrentLineIndentLevel("    - {"),
+            "should properly indent for nested list items"
+        )
 
-        assertEquals(3, formatter.getCurrentLineIndentLevel("      }"),
-            "should properly indent after closing nested delimiters")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    >"),
-            "should properly indent after closing angle brackets")
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  }"),
-            "should properly indent after closing outer brace")
+        assertEquals(
+            3, formatter.getCurrentLineIndentLevel("      }"),
+            "should properly indent after closing nested delimiters"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    >"),
+            "should properly indent after closing angle brackets"
+        )
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  }"),
+            "should properly indent after closing outer brace"
+        )
     }
 
     @Test
     fun testGetCurrentLineIndentLevelWithMultipleChanges() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(2, formatter.getCurrentLineIndentLevel("{ {"),
-            "should increase indent by more than 1 for multiple opening delimiters on one line")
-        assertEquals(3, formatter.getCurrentLineIndentLevel("{ { {"),
-            "should increase indent by multiple levels for three opening delimiters")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("key: {nested: {"),
-            "should increase indent by more than 1 for nested properties")
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("{ {"),
+            "should increase indent by more than 1 for multiple opening delimiters on one line"
+        )
+        assertEquals(
+            3, formatter.getCurrentLineIndentLevel("{ { {"),
+            "should increase indent by multiple levels for three opening delimiters"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("key: {nested: {"),
+            "should increase indent by more than 1 for nested properties"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  } }"),
-            "should have no effect on the next line for multiple closing delimiters as they unindent their own line")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    } } }"),
-            "should maintain existing indent levels for multiple closing delimiters")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  } }"),
+            "should have no effect on the next line for multiple closing delimiters as they unindent their own line"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    } } }"),
+            "should maintain existing indent levels for multiple closing delimiters"
+        )
     }
 
     @Test
     fun testGetCurrentLineIndentLevelWithDeferredClosures() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(0, formatter.getCurrentLineIndentLevel("key:val }}}"),
-            "should trigger an unindent on the next line, not their own line, for non-leading close delimiters")
-        assertEquals(4, formatter.getCurrentLineIndentLevel("              key:val }}}"),
-            "should maintain existing indent for trailing delimiters with leading spaces")
+        assertEquals(
+            0, formatter.getCurrentLineIndentLevel("key:val }}}"),
+            "should trigger an unindent on the next line, not their own line, for non-leading close delimiters"
+        )
+        assertEquals(
+            4, formatter.getCurrentLineIndentLevel("              key:val }}}"),
+            "should maintain existing indent for trailing delimiters with leading spaces"
+        )
     }
 
     @Test
     fun testGetCurrentLineIndentLevelWithNestedClosures() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    }}"),
-            "should handle multiple nested structures closing at once")
-        assertEquals(3, formatter.getCurrentLineIndentLevel("      }}}"),
-            "should handle three nested structures closing at once")
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    }}"),
+            "should handle multiple nested structures closing at once"
+        )
+        assertEquals(
+            3, formatter.getCurrentLineIndentLevel("      }}}"),
+            "should handle three nested structures closing at once"
+        )
 
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    }>"),
-            "should work with mixed bracket types")
-        assertEquals(3, formatter.getCurrentLineIndentLevel("      ]}>"),
-            "should work with multiple mixed bracket types")
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    }>"),
+            "should work with mixed bracket types"
+        )
+        assertEquals(
+            3, formatter.getCurrentLineIndentLevel("      ]}>"),
+            "should work with multiple mixed bracket types"
+        )
     }
 
     @Test
@@ -1359,7 +1448,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testDelimitedFormattingStyleLists(){
+    fun testDelimitedFormattingStyleLists() {
         assertFormatting(
             """
                 list: [1,2,3]
@@ -1711,7 +1800,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testPlainFormattingEmptyObject(){
+    fun testPlainFormattingEmptyObject() {
         assertFormatting(
             """
                 key:
@@ -1725,7 +1814,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testDelimitedFormattingEmptyObject(){
+    fun testDelimitedFormattingEmptyObject() {
         assertFormatting(
             """
                 key:
@@ -1741,7 +1830,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testCompactFormattingEmptyObject(){
+    fun testCompactFormattingEmptyObject() {
         assertFormatting(
             """
                 key: {}
@@ -1754,7 +1843,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testPlainFormattingEmptyList(){
+    fun testPlainFormattingEmptyList() {
         assertFormatting(
             """
                 key:
@@ -1768,7 +1857,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testDelimitedFormattingEmptyList(){
+    fun testDelimitedFormattingEmptyList() {
         assertFormatting(
             """
                 key:
@@ -1784,7 +1873,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testCompactFormattingEmptyList(){
+    fun testCompactFormattingEmptyList() {
         assertFormatting(
             """
                 key: <>

--- a/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
+++ b/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
@@ -1921,4 +1921,223 @@ class FormatterTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun testClassicFormattingStyleSimpleObject() {
+        assertFormatting(
+            """
+                key: value
+            """.trimIndent(),
+            """
+                {
+                  "key": "value"
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.CLASSIC
+        )
+
+        assertFormatting(
+            """
+                {
+                  key1: value1
+                  key2: value2
+                }
+            """.trimIndent(),
+            """
+                {
+                  "key1": "value1",
+                  "key2": "value2"
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.CLASSIC
+        )
+    }
+
+    @Test
+    fun testClassicFormattingStyleEmbedBlock() {
+        assertFormatting(
+            """
+                key: %tag
+                content
+                %%
+            """.trimIndent(),
+            """
+                {
+                  "key": %tag
+                    content
+                    %%
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.CLASSIC
+        )
+    }
+
+    @Test
+    fun testClassicFormattingStyleWithComments() {
+        assertFormatting(
+            """
+                # Header comment
+                
+                  key: value
+                
+            """.trimIndent(),
+            """
+                {
+                  # Header comment
+                  "key": "value"
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.CLASSIC
+        )
+
+        assertFormatting(
+            """
+                {
+                  # Property comment
+                  key: value
+                  # Another comment
+                  key2: value2
+                }
+            """.trimIndent(),
+            """
+                {
+                  # Property comment
+                  "key": "value",
+                  # Another comment
+                  "key2": "value2"
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.CLASSIC
+        )
+    }
+
+    @Test
+    fun testClassicFormattingStyleNestedObjects() {
+        assertFormatting(
+            """
+                outer:
+                  inner: value
+            """.trimIndent(),
+            """
+                {
+                  "outer": {
+                    "inner": "value"
+                  }
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.CLASSIC
+        )
+
+        assertFormatting(
+            """
+                {
+                  level1: {
+                    level2: {
+                      level3: value
+                    }
+                  }
+                }
+            """.trimIndent(),
+            """
+                {
+                  "level1": {
+                    "level2": {
+                      "level3": "value"
+                    }
+                  }
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.CLASSIC
+        )
+    }
+
+    @Test
+    fun testClassicFormattingStyleLists() {
+        assertFormatting(
+            """
+                - 1
+                - 2
+                - 3
+            """.trimIndent(),
+            """
+                [
+                  1,
+                  2,
+                  3
+                ]
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.CLASSIC
+        )
+
+        assertFormatting(
+            """
+                items: [1, 2, 3]
+            """.trimIndent(),
+            """
+                {
+                  "items": [
+                    1,
+                    2,
+                    3
+                  ]
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.CLASSIC
+        )
+    }
+
+    @Test
+    fun testClassicFormattingStyleMixedStructures() {
+        assertFormatting(
+            """
+                users:
+                  - name: Alice
+                    age: 30
+                  - name: Bob
+                    age: 25
+            """.trimIndent(),
+            """
+                {
+                  "users": [
+                    {
+                      "name": "Alice",
+                      "age": 30
+                    },
+                    {
+                      "name": "Bob",
+                      "age": 25
+                    }
+                  ]
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.CLASSIC
+        )
+    }
+
+    @Test
+    fun testClassicFormattingStyleEmptyStructures() {
+        assertFormatting(
+            """
+                "key": {}
+            """.trimIndent(),
+            """
+                {
+                  "key": {}
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.CLASSIC
+        )
+
+        assertFormatting(
+            """
+                key: []
+            """.trimIndent(),
+            """
+                {
+                  "key": []
+                }
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.CLASSIC
+        )
+    }
 }

--- a/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/KsonFormatCommand.kt
+++ b/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/KsonFormatCommand.kt
@@ -43,7 +43,7 @@ class KsonFormatCommand : BaseKsonCommand(name = "format") {
     ).single().default(IndentType.Spaces(2))
 
     private val style by option("--style", help = "Formatting style")
-        .choice("plain", "delimited", "compact")
+        .choice("plain", "delimited", "compact", "classic")
         .default("plain")
 
     override fun run() {
@@ -70,6 +70,7 @@ class KsonFormatCommand : BaseKsonCommand(name = "format") {
             "plain" -> FormattingStyle.PLAIN
             "delimited" -> FormattingStyle.DELIMITED
             "compact" -> FormattingStyle.COMPACT
+            "classic" -> FormattingStyle.CLASSIC
             else -> FormattingStyle.PLAIN
         }
 

--- a/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
+++ b/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
@@ -230,6 +230,28 @@ class CommandLineInterfaceTest {
     }
 
     @Test
+    fun testTranspileToKsonWithClassicStyle() {
+        assertCommand(
+            subCommand = SubCommands.FORMAT,
+            input = """
+                key: value
+                list: [1,2,3]
+            """.trimIndent(),
+            expectedOutput = OutputExpectation.Success("""
+                {
+                  "key": "value",
+                  "list": [
+                    1,
+                    2,
+                    3
+                  ]
+                }
+            """.trimIndent()),
+            "--style", "classic"
+        )
+    }
+
+    @Test
     fun testTranspileToKsonWithDelimitedStyle() {
         assertCommand(
             subCommand = SubCommands.FORMAT,

--- a/tooling/language-server-protocol/src/core/commands/CommandExecutor.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandExecutor.ts
@@ -54,7 +54,8 @@ export class CommandExecutor {
         switch (command) {
             case CommandType.PLAIN_FORMAT:
             case CommandType.DELIMITED_FORMAT:
-            case CommandType.COMPACT_FORMAT: {
+            case CommandType.COMPACT_FORMAT:
+            case CommandType.CLASSIC_FORMAT: {
                 const indentType = this.getConfiguration().kson.formatOptions.indentType;
 
                 return this.executeFormat(commandArgs.documentUri, document, new FormatOptions(

--- a/tooling/language-server-protocol/src/core/commands/CommandParameters.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandParameters.ts
@@ -18,6 +18,10 @@ export interface CommandParameters {
         documentUri: string;
         formattingStyle: FormattingStyle;
     };
+    [CommandType.CLASSIC_FORMAT]: {
+        documentUri: string;
+        formattingStyle: FormattingStyle;
+    };
 }
 
 /**

--- a/tooling/language-server-protocol/src/core/commands/CommandType.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandType.ts
@@ -15,7 +15,12 @@ export enum CommandType {
     /**
      * Format the document as compact Kson
      */
-    COMPACT_FORMAT = 'kson.compactFormat'
+    COMPACT_FORMAT = 'kson.compactFormat',
+
+     /**
+     * Format the document as classic Kson
+     */
+    CLASSIC_FORMAT = 'kson.classicFormat'
 }
 
 /**

--- a/tooling/language-server-protocol/src/core/features/CodeLensService.ts
+++ b/tooling/language-server-protocol/src/core/features/CodeLensService.ts
@@ -31,6 +31,12 @@ export class CodeLensService {
             { documentUri: document.uri, formattingStyle: FormattingStyle.COMPACT }
         );
 
+        const classicFormatCommand = createTypedCommand(
+            CommandType.CLASSIC_FORMAT,
+            'classic',
+            { documentUri: document.uri, formattingStyle: FormattingStyle.CLASSIC }
+        );
+
         // Place both lenses at the start of the document
         const range = {
             start: { line: 0, character: 0 },
@@ -45,6 +51,10 @@ export class CodeLensService {
             {
                 range,
                 command: delimitedFormatCommand
+            },
+            {
+                range,
+                command: classicFormatCommand
             },
             {
                 range,

--- a/tooling/language-server-protocol/src/test/core/commands/CommandExecutor.test.ts
+++ b/tooling/language-server-protocol/src/test/core/commands/CommandExecutor.test.ts
@@ -148,4 +148,18 @@ describe('KSON Command Executor', () => {
         await executeAndAssertCommand(content, expected, commandParams);
     });
 
+    it('should execute classic formatting', async () => {
+        const content = '{"x" : 1, "y" : 2}';
+        const expectedContent = [
+            '{',
+            '  "x": 1,',
+            '  "y": 2',
+            '}'
+        ].join('\n');
+        const expected = buildWorkspaceEdit(TEST_URI, Range.create(0, 0, 0, 18), expectedContent);
+        const commandParams = buildCommandParams(CommandType.CLASSIC_FORMAT, TEST_URI, FormattingStyle.CLASSIC);
+
+        await executeAndAssertCommand(content, expected, commandParams);
+    });
+
 });

--- a/tooling/language-server-protocol/src/test/core/features/CodeLensService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/CodeLensService.test.ts
@@ -10,7 +10,7 @@ import {FormattingStyle} from 'kson'
 describe('CodeLensService', () => {
     const service = new CodeLensService();
 
-    it('should return two code lenses at the top of the document', () => {
+    it('should return code lenses at the top of the document', () => {
         const content = '{ "name": "test" }';
         const textDocument = TextDocument.create('file:///test.kson', 'kson', 1, content);
         const analysisResult = Kson.getInstance().analyze(content);
@@ -18,7 +18,7 @@ describe('CodeLensService', () => {
 
         const lenses = service.getCodeLenses(document);
 
-        assert.strictEqual(lenses.length, 3);
+        assert.strictEqual(lenses.length, 4);
 
         // First lens should be "plain"
         assert.strictEqual(lenses[0].command?.title, 'plain');
@@ -40,14 +40,24 @@ describe('CodeLensService', () => {
         assert.deepStrictEqual(lenses[1].range.start, { line: 0, character: 0 });
         assert.deepStrictEqual(lenses[1].range.end, { line: 0, character: 0 });
 
-        // Second lens should be "compact"
-        assert.strictEqual(lenses[2].command?.title, 'compact');
-        assert.strictEqual(lenses[2].command?.command, CommandType.COMPACT_FORMAT);
+        // Third lens should be "classic"
+        assert.strictEqual(lenses[2].command?.title, 'classic');
+        assert.strictEqual(lenses[2].command?.command, CommandType.CLASSIC_FORMAT);
         assert.deepStrictEqual(lenses[2].command?.arguments, [{
             documentUri: 'file:///test.kson',
-            formattingStyle: FormattingStyle.COMPACT
+            formattingStyle: FormattingStyle.CLASSIC
         }]);
         assert.deepStrictEqual(lenses[2].range.start, { line: 0, character: 0 });
         assert.deepStrictEqual(lenses[2].range.end, { line: 0, character: 0 });
+
+        // Fourth lens should be "compact"
+        assert.strictEqual(lenses[3].command?.title, 'compact');
+        assert.strictEqual(lenses[3].command?.command, CommandType.COMPACT_FORMAT);
+        assert.deepStrictEqual(lenses[3].command?.arguments, [{
+            documentUri: 'file:///test.kson',
+            formattingStyle: FormattingStyle.COMPACT
+        }]);
+        assert.deepStrictEqual(lenses[3].range.start, { line: 0, character: 0 });
+        assert.deepStrictEqual(lenses[3].range.end, { line: 0, character: 0 });
     });
 });


### PR DESCRIPTION
Add a classic formatting style, this formatting style formats KSON as a JSON document, but with the comments preserved.
So this plainly formatted document:
```
person:
  name: 'Leonardo Bonacci'
  favorite_books:
    - title: Symposium
      author: Plato
      .
  favorite_numbers:
    - '(1 + √.5)/2'
    - π
  # A comment above the embed block
  favorite_function: %typescript
    const fib = (n: number): number => n <= 1 ? n : fib(n-1) + fib(n-2);%%
```
becomes: 
```
{
  "person": {
    "name": "Leonardo Bonacci",
    "favorite_books": [
      {
        "title": "Symposium",
        "author": "Plato"
      }
    ],
    "favorite_numbers": [
      "(1 + √.5)/2",
      "π"
    ],
    # A comment above the embed block
    "favorite_function": %typescript
      const fib = (n: number): number => n <= 1 ? n : fib(n-1) + fib(n-2);%%
  }
}
```