### PR TITLE
Create CircleCI config from KSON through gradle `TranspileKsonToYaml`

### DIFF
--- a/.circleci/config.kson
+++ b/.circleci/config.kson
@@ -1,3 +1,6 @@
+# This file is automatically transpiled to config.yml by the transpileCircleCiConfigTask
+# during any ./gradlew task. ONLY edit this .kson file - the .yml file will be overridden.
+
 version: 2.1
 orbs:
   # Ensure access to browser tools so we can install Chrome below for JS Kotlin tests

--- a/.circleci/config.kson
+++ b/.circleci/config.kson
@@ -1,0 +1,460 @@
+version: 2.1
+orbs:
+  # Ensure access to browser tools so we can install Chrome below for JS Kotlin tests
+  # See https://circleci.com/developer/orbs/orb/circleci/browser-tools for details
+  'browser-tools': 'circleci/browser-tools@1.1'
+  # Windows support for testing Python on Windows
+  windows: 'circleci/windows@5.0'
+  .
+# Reusable command definitions - only for truly cross-platform operations
+commands:
+  'gradle-core-tasks':
+    description: 'Run core Gradle build and verification tasks'
+    steps:
+      - run:
+          name: 'Download dependencies'
+          command: './gradlew --no-daemon dependencies'
+
+      - run:
+          name: 'Verify buildSrc project'
+          command: 'cd buildSrc\n./gradlew --no-daemon check\n'
+
+      - run:
+          name: 'Verify Kson project'
+          command: './gradlew --no-daemon check'
+
+      - run:
+          name: 'Build native kson-lib'
+          command: './gradlew --no-daemon :kson-lib:nativeRelease'
+          .
+        .
+    .
+  'store-native-artifacts':
+    description: 'Store build artifacts in a consistent way'
+    steps:
+      - store_artifacts:
+          path: 'kson-lib/build/bin/nativeKson/releaseShared'
+          destination: 'kson-lib-shared'
+
+      - store_artifacts:
+          path: 'kson-lib/build/bin/nativeKson/releaseStatic'
+          destination: 'kson-lib-static'
+          .
+        .
+    .
+  'restore-gradle-caches':
+    description: 'Restore Gradle and JDK caches'
+    parameters:
+      platform:
+        type: string
+        description: 'Platform identifier for cache keys'
+        .
+      .
+    steps:
+      - restore_cache:
+          keys:
+            - 'v1-<< parameters.platform >>-dependencies-{{ checksum "build.gradle.kts" }}'
+            - 'v1-<< parameters.platform >>-dependencies-'
+            =
+      - restore_cache:
+          keys:
+            - 'v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}'
+            =
+      - restore_cache:
+          keys:
+            - 'v1-<< parameters.platform >>-vscode-tests'
+          .
+        .
+    .
+  'save-gradle-caches':
+    description: 'Save Gradle and JDK caches'
+    parameters:
+      platform:
+        type: string
+        description: 'Platform identifier for cache keys'
+        .
+      .
+    steps:
+      - save_cache:
+          paths:
+            - '~/.gradle'
+          key: 'v1-<< parameters.platform >>-dependencies-{{ checksum "build.gradle.kts" }}'
+
+      - save_cache:
+          paths:
+            - './gradle/jdk'
+            - './buildSrc/gradle/jdk'
+          key: 'v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}'
+
+      - save_cache:
+          paths:
+            - './tooling/lsp-clients/vscode/.vscode-test'
+            - './tooling/lsp-clients/vscode/.vscode-test-web'
+          key: 'v1-<< parameters.platform >>-vscode-tests'
+          .
+        .
+    .
+  'clean-git-config':
+    description: 'Remove erroneous git config across platforms'
+    parameters:
+      shell:
+        type: enum
+        enum:
+          - bash
+          - powershell
+        default: bash
+        .
+      .
+    steps:
+      - when:
+          condition:
+            equal:
+              - '<< parameters.shell >>'
+              - bash
+            .
+          steps:
+            - run:
+                name: 'Clean git config'
+                command: 'rm -rf ~/.gitconfig'
+
+            =
+
+      - when:
+          condition:
+            equal:
+              - '<< parameters.shell >>'
+              - powershell
+            .
+          steps:
+            - run:
+                name: 'Clean git config'
+                command: 'Remove-Item -Path "$env:USERPROFILE\\.gitconfig" -Force -ErrorAction SilentlyContinue\n'
+                shell: 'powershell.exe'
+                .
+              .
+          .
+        .
+    .
+  'setup-python-test':
+    description: 'Common setup for Python sdist testing'
+    parameters:
+      platform:
+        type: string
+        .
+      .
+    steps:
+      - checkout
+      - when:
+          condition:
+            equal:
+              - '<< parameters.platform >>'
+              - windows
+            .
+          steps:
+            - 'clean-git-config':
+                shell: powershell
+            =
+
+      - when:
+          condition:
+            not:
+              equal:
+                - '<< parameters.platform >>'
+                - windows
+              .
+            .
+          steps:
+            - 'clean-git-config':
+                shell: bash
+            =
+
+      - attach_workspace:
+          at: '~/repo'
+          .
+        .
+    .
+  'run-python-tests-unix':
+    description: 'Run Python sdist tests and build wheel for Unix-like systems'
+    steps:
+      - run:
+          name: 'Install kson from sdist'
+          command: 'python3 -m pip install lib-python/dist/kson_lang-*.tar.gz'
+
+      - run:
+          name: 'Install test dependencies'
+          command: 'python3 -m pip install pytest'
+
+      - run:
+          name: 'Run smoke tests on sdist installation'
+          command: 'python3 -m pytest lib-python -v'
+
+      - run:
+          name: 'Build platform-specific wheel'
+          command: './gradlew :lib-python:buildWheel'
+          .
+        .
+    .
+  .
+# Job definitions
+jobs:
+  'build-windows-amd64':
+    resource_class: 'windows.large'
+    machine:
+      image: 'windows-server-2022-gui:current'
+      shell: 'powershell.exe -ExecutionPolicy Bypass'
+      .
+    environment:
+      JVM_OPTS: '-Xmx3200m'
+      .
+    steps:
+      - checkout
+      - 'clean-git-config':
+          shell: powershell
+      # Windows-specific installations
+      # The `browser-tools` orb doesn't support windows, so we install Chrome manually
+      - run:
+          name: 'Install Chrome'
+          command: 'choco install googlechrome --ignore-checksums'
+
+      # We would ideally install libclang through pixi, but after _hours_ of fiddling we
+      # couldn't make the CI happy and decided to add it here instead
+      - run:
+          name: 'Install LLVM'
+          command: 'choco install llvm'
+
+      - 'restore-gradle-caches':
+          platform: 'win-amd64'
+      # Cross-platform Gradle tasks
+      - 'gradle-core-tasks'
+      - 'store-native-artifacts'
+      - 'save-gradle-caches':
+          platform: 'win-amd64'
+          .
+        .
+    .
+  'build-linux-amd64':
+    docker:
+      - image: 'cimg/node:lts-browsers'
+        .
+    working_directory: '~/repo'
+    environment:
+      JVM_OPTS: '-Xmx3200m'
+      TERM: dumb
+      .
+    resource_class: large
+    steps:
+      - 'browser-tools/install-chrome'
+      - checkout
+      - run:
+          name: 'Verify Chrome installation'
+          command: 'google-chrome --version'
+
+      - 'restore-gradle-caches':
+            platform: 'linux-amd64'
+      # Linux-specific installations
+      - run:
+          name: 'Install system dependencies'
+          command: 'sudo apt update\nsudo apt install libncurses-dev\n'
+
+      - 'clean-git-config':
+          shell: bash
+      # Cross-platform Gradle tasks
+      - 'gradle-core-tasks'
+      - 'store-native-artifacts'
+      - 'save-gradle-caches':
+          platform: 'linux-amd64'
+          .
+        .
+    .
+  'build-macos-arm64':
+    macos:
+      xcode: '16.4.0'
+      .
+    resource_class: 'm4pro.medium'
+    working_directory: '~/repo'
+    steps:
+      - run:
+          name: 'Install Chrome'
+          command: 'brew install --cask google-chrome'
+
+      - checkout
+      - run:
+          name: 'Verify Chrome installation'
+          command: '"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --version'
+
+      - 'clean-git-config':
+          shell: bash
+      - 'restore-gradle-caches':
+          platform: 'macos-arm64'
+      # Cross-platform Gradle tasks
+      - 'gradle-core-tasks'
+      - 'store-native-artifacts'
+      - 'save-gradle-caches':
+          platform: 'macos-arm64'
+          .
+        .
+    .
+  'build-python-sdist':
+    docker:
+      - image: 'cimg/python:3.11'
+        .
+    working_directory: '~/repo'
+    steps:
+      - checkout
+      - 'clean-git-config':
+          shell: bash
+      - run:
+          name: 'Build Python source distribution'
+          command: './gradlew :lib-python:createSdistBuildEnvironment'
+
+      - run:
+          name: 'Verify sdist was created'
+          command: 'ls -la lib-python/dist/\ntest -f lib-python/dist/kson_lang-*.tar.gz\n'
+
+      - persist_to_workspace:
+          root: '~/repo'
+          paths:
+            - 'lib-python/dist/*.tar.gz'
+            =
+
+      - store_artifacts:
+          path: 'lib-python/dist'
+          destination: 'python-sdist'
+          .
+        .
+    .
+  'test-python-sdist-linux-amd64':
+    docker:
+      - image: 'cimg/python:3.11'
+        .
+    working_directory: '~/repo'
+    steps:
+      - 'setup-python-test':
+          platform: linux
+      - setup_remote_docker
+      - 'run-python-tests-unix'
+      - store_artifacts:
+          path: 'lib-python/dist'
+          destination: 'python-linux-amd64'
+          .
+        .
+    .
+  'test-python-sdist-macos':
+    macos:
+      xcode: '14.2.0'
+      .
+    working_directory: '~/repo'
+    steps:
+      - 'setup-python-test':
+          platform: macos
+      - 'run-python-tests-unix'
+      - store_artifacts:
+          path: 'lib-python/dist'
+          destination: 'python-macos'
+          .
+        .
+    .
+  'test-python-sdist-windows':
+    executor:
+      name: 'windows/default'
+      size: medium
+      .
+    working_directory: '~/repo'
+    steps:
+      - 'setup-python-test':
+          platform: windows
+      - run:
+          name: 'Check Python version and upgrade if needed'
+          command: 'python --version\npython -m pip install --upgrade pip\n'
+
+      - run:
+          name: 'Install kson from sdist'
+          command: 'python -m pip install (Get-ChildItem lib-python/dist/kson_lang-*.tar.gz).FullName\n'
+          shell: 'powershell.exe'
+
+      - run:
+          name: 'Install test dependencies'
+          command: 'python -m pip install pytest'
+
+      - run:
+          name: 'Run smoke tests on sdist installation'
+          command: 'python -m pytest lib-python -v'
+
+      - run:
+          name: 'Build platform-specific wheel'
+          command: '.\\gradlew.bat :lib-python:buildWheel --no-daemon\n'
+
+      - store_artifacts:
+          path: 'lib-python/dist'
+          destination: 'python-windows'
+          .
+        .
+    .
+  .
+workflows:
+  version: 2
+  # Main build workflow - runs on version tags
+  'build-all':
+    jobs:
+      - 'build-linux-amd64'
+      - 'build-windows-amd64':
+          filters:
+            tags:
+              only: '/^v\\d+\\.\\d+\\.\\d+$/'
+              .
+            branches:
+              ignore: '/.*/'
+
+      - 'build-macos-arm64':
+          filters:
+            tags:
+              only: '/^v\\d+\\.\\d+\\.\\d+$/'
+              .
+            branches:
+              ignore: '/.*/'
+              .
+            .
+          .
+        .
+    .
+  'build-python-and-test':
+    jobs:
+      - 'build-python-sdist':
+          filters:
+            tags:
+              only: '/^v\\d+\\.\\d+\\.\\d+$/'
+              .
+            branches:
+              ignore: '/.*/'
+
+      - 'test-python-sdist-linux-amd64':
+          requires:
+            - 'build-python-sdist'
+          filters:
+            tags:
+              only: '/^v\\d+\\.\\d+\\.\\d+$/'
+              .
+            branches:
+              ignore: '/.*/'
+
+
+      - 'test-python-sdist-macos':
+          requires:
+            - 'build-python-sdist'
+          filters:
+            tags:
+              only: '/^v\\d+\\.\\d+\\.\\d+$/'
+              .
+            branches:
+              ignore: '/.*/'
+
+
+      - 'test-python-sdist-windows':
+          requires:
+            - 'build-python-sdist'
+          filters:
+            tags:
+              only: '/^v\\d+\\.\\d+\\.\\d+$/'
+              .
+            branches:
+              ignore: '/.*/'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,141 @@ orbs:
   # Windows support for testing Python on Windows
   windows: circleci/windows@5.0
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+# Reusable command definitions - only for truly cross-platform operations
+commands:
+  gradle-core-tasks:
+    description: "Run core Gradle build and verification tasks"
+    steps:
+      - run:
+          name: Download dependencies
+          command: ./gradlew --no-daemon dependencies
+      - run:
+          name: Verify buildSrc project
+          command: |
+            cd buildSrc
+            ./gradlew --no-daemon check
+      - run:
+          name: Verify Kson project
+          command: ./gradlew --no-daemon check
+      - run:
+          name: Build native kson-lib
+          command: ./gradlew --no-daemon :kson-lib:nativeRelease
+
+  store-native-artifacts:
+    description: "Store build artifacts in a consistent way"
+    steps:
+      - store_artifacts:
+          path: kson-lib/build/bin/nativeKson/releaseShared
+          destination: kson-lib-shared
+      - store_artifacts:
+          path: kson-lib/build/bin/nativeKson/releaseStatic
+          destination: kson-lib-static
+
+  restore-gradle-caches:
+    description: "Restore Gradle and JDK caches"
+    parameters:
+      platform:
+        type: string
+        description: "Platform identifier for cache keys"
+    steps:
+      - restore_cache:
+          keys:
+            - v1-<< parameters.platform >>-dependencies-{{ checksum "build.gradle.kts" }}
+            - v1-<< parameters.platform >>-dependencies-
+      - restore_cache:
+          keys:
+            - v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}
+      - restore_cache:
+          keys:
+            - v1-<< parameters.platform >>-vscode-tests
+
+  save-gradle-caches:
+    description: "Save Gradle and JDK caches"
+    parameters:
+      platform:
+        type: string
+        description: "Platform identifier for cache keys"
+    steps:
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-<< parameters.platform >>-dependencies-{{ checksum "build.gradle.kts" }}
+      - save_cache:
+          paths:
+            - ./gradle/jdk
+            - ./buildSrc/gradle/jdk
+          key: v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}
+      - save_cache:
+          paths:
+            - ./tooling/lsp-clients/vscode/.vscode-test
+            - ./tooling/lsp-clients/vscode/.vscode-test-web
+          key: v1-<< parameters.platform >>-vscode-tests
+
+  clean-git-config:
+    description: "Remove erroneous git config across platforms"
+    parameters:
+      shell:
+        type: enum
+        enum: [bash, powershell]
+        default: bash
+    steps:
+      - when:
+          condition:
+            equal: [<< parameters.shell >>, bash]
+          steps:
+            - run:
+                name: Clean git config
+                command: rm -rf ~/.gitconfig
+      - when:
+          condition:
+            equal: [<< parameters.shell >>, powershell]
+          steps:
+            - run:
+                name: Clean git config
+                command: |
+                  Remove-Item -Path "$env:USERPROFILE\.gitconfig" -Force -ErrorAction SilentlyContinue
+                shell: powershell.exe
+
+  setup-python-test:
+    description: "Common setup for Python sdist testing"
+    parameters:
+      platform:
+        type: string
+    steps:
+      - checkout
+      - when:
+          condition:
+            equal: [<< parameters.platform >>, windows]
+          steps:
+            - clean-git-config:
+                shell: powershell
+      - when:
+          condition:
+            not:
+              equal: [<< parameters.platform >>, windows]
+          steps:
+            - clean-git-config:
+                shell: bash
+      - attach_workspace:
+          at: ~/repo
+
+  run-python-tests-unix:
+    description: "Run Python sdist tests and build wheel for Unix-like systems"
+    steps:
+      - run:
+          name: Install kson from sdist
+          command: python3 -m pip install lib-python/dist/kson_lang-*.tar.gz
+      - run:
+          name: Install test dependencies
+          command: python3 -m pip install pytest
+      - run:
+          name: Run smoke tests on sdist installation
+          command: python3 -m pytest lib-python -v
+      - run:
+          name: Build platform-specific wheel
+          command: ./gradlew :lib-python:buildWheel
+
+# Job definitions
 jobs:
   build-windows-amd64:
     resource_class: 'windows.large'
@@ -16,165 +149,68 @@ jobs:
       image: 'windows-server-2022-gui:current'
       shell: 'powershell.exe -ExecutionPolicy Bypass'
     environment:
-      # Customize the JVM maximum heap limit
       JVM_OPTS: -Xmx3200m
     steps:
       - checkout
-      - run:
-          name: Get rid of erroneous git config
-          command: |
-            Remove-Item -Path "$env:USERPROFILE\.gitconfig" -Force -ErrorAction SilentlyContinue
+      - clean-git-config:
+          shell: powershell
 
+      # Windows-specific installations
       # The `browser-tools` orb doesn't support windows, so we install Chrome manually
-      - run: choco install googlechrome --ignore-checksums
+      - run:
+          name: Install Chrome
+          command: choco install googlechrome --ignore-checksums
       # We would ideally install libclang through pixi, but after _hours_ of fiddling we
       # couldn't make the CI happy and decided to add it here instead
-      - run: choco install llvm
-      - restore_cache:
-          keys:
-            - v1-win-amd64-dependencies-{{ checksum "build.gradle.kts" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-win-amd64-dependencies-
-
-      - restore_cache:
-          keys:
-            - v1-win-amd64-jdk-{{ checksum "jdk.properties" }}
-
-      - restore_cache:
-          keys:
-            - v1-win-amd64-vscode-tests
-
-      - run: ./gradlew --no-daemon dependencies
-
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: v1-win-amd64-dependencies-{{ checksum "build.gradle.kts" }}
-
       - run:
-          name: Verify `buildSrc/` project
-          command: |
-            cd buildSrc
-            ./gradlew --no-daemon check
+          name: Install LLVM
+          command: choco install llvm
 
-      - run:
-          name: Verify Kson project
-          command: ./gradlew --no-daemon check
+      - restore-gradle-caches:
+          platform: win-amd64
 
-      - run:
-          name: Build native kson-lib
-          command: ./gradlew --no-daemon :kson-lib:nativeRelease
+      # Cross-platform Gradle tasks
+      - gradle-core-tasks
 
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseShared
-          destination: kson-lib-shared
+      - store-native-artifacts
 
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseStatic
-          destination: kson-lib-static
-
-      - save_cache:
-          paths:
-            - ./tooling/lsp-clients/vscode/.vscode-test
-            - ./tooling/lsp-clients/vscode/.vscode-test-web
-          key: v1-win-amd64-vscode-tests
-
-      - save_cache:
-          paths:
-            - ./gradle/jdk
-            - ./buildSrc/gradle/jdk
-          key: v1-win-amd64-jdk-{{ checksum "jdk.properties" }}
+      - save-gradle-caches:
+          platform: win-amd64
 
   build-linux-amd64:
-    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
     docker:
-      # Choose the `node:lts-browsers` image so that we can install Chrome for testing.  Note that we
-      # do not install a JDK image so that we are always exercising the project's built-in JDK (see jdk.properties for details)
       - image: cimg/node:lts-browsers
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: cimg/postgres:9.4
-
     working_directory: ~/repo
-
     environment:
-      # Customize the JVM maximum heap limit
       JVM_OPTS: -Xmx3200m
       TERM: dumb
-    # Add steps to the job
-    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    resource_class: large
     steps:
-      # Install Chrome according to https://circleci.com/developer/orbs/orb/circleci/browser-tools#usage-install_chrome
       - browser-tools/install-chrome
       - checkout
-      - run: google-chrome --version
-
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "build.gradle.kts" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-      - restore_cache:
-          keys:
-            - v1-jdk-{{ checksum "jdk.properties" }}
-
-      - restore_cache:
-          keys:
-            - v1-vscode-tests
-
-      # installed needed native dependency on Linux
-      - run: sudo apt update
-      - run: sudo apt install libncurses-dev
       - run:
-          name: Get rid of erroneous git config
+          name: Verify Chrome installation
+          command: google-chrome --version
+
+      - restore-gradle-caches:
+          platform: linux-amd64
+
+      # Linux-specific installations
+      - run:
+          name: Install system dependencies
           command: |
-            rm -rf ~/.gitconfig
-      - run: ./gradlew --no-daemon dependencies
+            sudo apt update
+            sudo apt install libncurses-dev
+      - clean-git-config:
+          shell: bash
 
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: v1-dependencies-{{ checksum "build.gradle.kts" }}
+      # Cross-platform Gradle tasks
+      - gradle-core-tasks
 
-      - run:
-          name: Verify `buildSrc/` project
-          command: |
-            cd buildSrc
-            ./gradlew --no-daemon check
+      - store-native-artifacts
 
-      - run:
-          name: Verify Kson project
-          command: ./gradlew --no-daemon check
-
-      - run:
-          name: Build native kson-lib
-          command: ./gradlew --no-daemon :kson-lib:nativeRelease
-
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseShared
-          destination: kson-lib-shared
-
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseStatic
-          destination: kson-lib-static
-
-      - save_cache:
-          paths:
-            - ./tooling/lsp-clients/vscode/.vscode-test
-            - ./tooling/lsp-clients/vscode/.vscode-test-web
-          key: v1-vscode-tests
-
-      - save_cache:
-          paths:
-            - ./gradle/jdk
-            - ./buildSrc/gradle/jdk
-          key: v1-jdk-{{ checksum "jdk.properties" }}
-
-    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
-    resource_class: large
+      - save-gradle-caches:
+          platform: linux-amd64
 
   build-macos-arm64:
     macos:
@@ -182,67 +218,26 @@ jobs:
     resource_class: m4pro.medium
     working_directory: ~/repo
     steps:
-      - run: brew install --cask google-chrome
+      - run:
+          name: Install Chrome
+          command: brew install --cask google-chrome
       - checkout
-      - run: '"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --version'
       - run:
-          name: Get rid of erroneous git config
-          command: |
-            rm -rf ~/.gitconfig
-      - restore_cache:
-          keys:
-            - v1-macos-arm64-dependencies-{{ checksum "build.gradle.kts" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-macos-arm64-dependencies-
+          name: Verify Chrome installation
+          command: '"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --version'
+      - clean-git-config:
+          shell: bash
 
-      - restore_cache:
-          keys:
-            - v1-macos-arm64-jdk-{{ checksum "jdk.properties" }}
+      - restore-gradle-caches:
+          platform: macos-arm64
 
-      - restore_cache:
-          keys:
-            - v1-macos-arm64-vscode-tests
+      # Cross-platform Gradle tasks
+      - gradle-core-tasks
 
-      - run: ./gradlew --no-daemon dependencies
+      - store-native-artifacts
 
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: v1-macos-arm64-dependencies-{{ checksum "build.gradle.kts" }}
-
-      - run:
-          name: Verify `buildSrc/` project
-          command: |
-            cd buildSrc
-            ./gradlew --no-daemon check
-
-      - run:
-          name: Verify Kson project
-          command: ./gradlew --no-daemon check
-
-      - run:
-          name: Build native kson-lib
-          command: ./gradlew --no-daemon :kson-lib:nativeRelease
-
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseShared
-          destination: kson-lib-shared
-
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseStatic
-          destination: kson-lib-static
-
-      - save_cache:
-          paths:
-            - ./tooling/lsp-clients/vscode/.vscode-test
-            - ./tooling/lsp-clients/vscode/.vscode-test-web
-          key: v1-macos-arm64-vscode-tests
-
-      - save_cache:
-          paths:
-            - ./gradle/jdk
-            - ./buildSrc/gradle/jdk
-          key: v1-macos-arm64-jdk-{{ checksum "jdk.properties" }}
+      - save-gradle-caches:
+          platform: macos-arm64
 
   build-python-sdist:
     docker:
@@ -250,14 +245,11 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run:
-          name: Get rid of erroneous git config
-          command: |
-            rm -rf ~/.gitconfig
+      - clean-git-config:
+          shell: bash
       - run:
           name: Build Python source distribution
-          command: |
-            ./gradlew :lib-python:createSdistBuildEnvironment
+          command: ./gradlew :lib-python:createSdistBuildEnvironment
       - run:
           name: Verify sdist was created
           command: |
@@ -276,30 +268,10 @@ jobs:
       - image: cimg/python:3.11
     working_directory: ~/repo
     steps:
-      - checkout
+      - setup-python-test:
+          platform: linux
       - setup_remote_docker
-      - run:
-          name: Get rid of erroneous git config
-          command: |
-            rm -rf ~/.gitconfig
-      - attach_workspace:
-          at: ~/repo
-      - run:
-          name: Install kson from sdist
-          command: |
-            python3 -m pip install lib-python/dist/kson_lang-*.tar.gz
-      - run:
-          name: Install test dependencies
-          command: |
-            python3 -m pip install pytest
-      - run:
-          name: Run smoke tests on sdist installation
-          command: |
-            python3 -m pytest lib-python -v
-      - run:
-          name: Build platform-specific wheel
-          command: |
-            ./gradlew :lib-python:buildWheel
+      - run-python-tests-unix
       - store_artifacts:
           path: lib-python/dist
           destination: python-linux-amd64
@@ -309,29 +281,9 @@ jobs:
       xcode: 14.2.0
     working_directory: ~/repo
     steps:
-      - checkout
-      - run:
-          name: Get rid of erroneous git config
-          command: |
-            rm -rf ~/.gitconfig
-      - attach_workspace:
-          at: ~/repo
-      - run:
-          name: Install kson from sdist
-          command: |
-            python3 -m pip install lib-python/dist/kson_lang-*.tar.gz
-      - run:
-          name: Install test dependencies
-          command: |
-            python3 -m pip install pytest
-      - run:
-          name: Run smoke tests on sdist installation
-          command: |
-            python3 -m pytest lib-python -v
-      - run:
-          name: Build platform-specific wheel
-          command: |
-            ./gradlew :lib-python:buildWheel
+      - setup-python-test:
+          platform: macos
+      - run-python-tests-unix
       - store_artifacts:
           path: lib-python/dist
           destination: python-macos
@@ -342,14 +294,8 @@ jobs:
       size: medium
     working_directory: ~/repo
     steps:
-      - checkout
-      - run:
-          name: Get rid of erroneous git config
-          command: |
-            Remove-Item -Path "$env:USERPROFILE\.gitconfig" -Force -ErrorAction SilentlyContinue
-          shell: powershell.exe
-      - attach_workspace:
-          at: ~/repo
+      - setup-python-test:
+          platform: windows
       - run:
           name: Check Python version and upgrade if needed
           command: |
@@ -362,12 +308,10 @@ jobs:
           shell: powershell.exe
       - run:
           name: Install test dependencies
-          command: |
-            python -m pip install pytest
+          command: python -m pip install pytest
       - run:
           name: Run smoke tests on sdist installation
-          command: |
-            python -m pytest lib-python -v
+          command: python -m pytest lib-python -v
       - run:
           name: Build platform-specific wheel
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,5 @@
+# This file is automatically transpiled to config.yml by the transpileCircleCiConfigTask
+# during any ./gradlew task. ONLY edit this .kson file - the .yml file will be overridden.
 version: 2.1
 orbs:
   # Ensure access to browser tools so we can install Chrome below for JS Kotlin tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,108 +1,126 @@
 version: 2.1
-
 orbs:
   # Ensure access to browser tools so we can install Chrome below for JS Kotlin tests
   # See https://circleci.com/developer/orbs/orb/circleci/browser-tools for details
-  browser-tools: circleci/browser-tools@1.1
+  "browser-tools": "circleci/browser-tools@1.1"
   # Windows support for testing Python on Windows
-  windows: circleci/windows@5.0
+  windows: "circleci/windows@5.0"
 
 # Reusable command definitions - only for truly cross-platform operations
 commands:
-  gradle-core-tasks:
+  "gradle-core-tasks":
     description: "Run core Gradle build and verification tasks"
     steps:
       - run:
-          name: Download dependencies
-          command: ./gradlew --no-daemon dependencies
-      - run:
-          name: Verify buildSrc project
-          command: |
-            cd buildSrc
-            ./gradlew --no-daemon check
-      - run:
-          name: Verify Kson project
-          command: ./gradlew --no-daemon check
-      - run:
-          name: Build native kson-lib
-          command: ./gradlew --no-daemon :kson-lib:nativeRelease
+          name: "Download dependencies"
+          command: "./gradlew --no-daemon dependencies"
 
-  store-native-artifacts:
+      - run:
+          name: "Verify buildSrc project"
+          command: "cd buildSrc\n./gradlew --no-daemon check\n"
+
+      - run:
+          name: "Verify Kson project"
+          command: "./gradlew --no-daemon check"
+
+      - run:
+          name: "Build native kson-lib"
+          command: "./gradlew --no-daemon :kson-lib:nativeRelease"
+
+
+  "store-native-artifacts":
     description: "Store build artifacts in a consistent way"
     steps:
       - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseShared
-          destination: kson-lib-shared
-      - store_artifacts:
-          path: kson-lib/build/bin/nativeKson/releaseStatic
-          destination: kson-lib-static
+          path: "kson-lib/build/bin/nativeKson/releaseShared"
+          destination: "kson-lib-shared"
 
-  restore-gradle-caches:
+      - store_artifacts:
+          path: "kson-lib/build/bin/nativeKson/releaseStatic"
+          destination: "kson-lib-static"
+
+
+  "restore-gradle-caches":
     description: "Restore Gradle and JDK caches"
     parameters:
       platform:
         type: string
         description: "Platform identifier for cache keys"
+
     steps:
       - restore_cache:
           keys:
-            - v1-<< parameters.platform >>-dependencies-{{ checksum "build.gradle.kts" }}
-            - v1-<< parameters.platform >>-dependencies-
+            - "v1-<< parameters.platform >>-dependencies-{{ checksum \"build.gradle.kts\" }}"
+            - "v1-<< parameters.platform >>-dependencies-"
       - restore_cache:
           keys:
-            - v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}
+            - "v1-<< parameters.platform >>-jdk-{{ checksum \"jdk.properties\" }}"
       - restore_cache:
           keys:
-            - v1-<< parameters.platform >>-vscode-tests
+            - "v1-<< parameters.platform >>-vscode-tests"
 
-  save-gradle-caches:
+  "save-gradle-caches":
     description: "Save Gradle and JDK caches"
     parameters:
       platform:
         type: string
         description: "Platform identifier for cache keys"
+
     steps:
       - save_cache:
           paths:
-            - ~/.gradle
-          key: v1-<< parameters.platform >>-dependencies-{{ checksum "build.gradle.kts" }}
-      - save_cache:
-          paths:
-            - ./gradle/jdk
-            - ./buildSrc/gradle/jdk
-          key: v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}
-      - save_cache:
-          paths:
-            - ./tooling/lsp-clients/vscode/.vscode-test
-            - ./tooling/lsp-clients/vscode/.vscode-test-web
-          key: v1-<< parameters.platform >>-vscode-tests
+            - "~/.gradle"
+          key: "v1-<< parameters.platform >>-dependencies-{{ checksum \"build.gradle.kts\" }}"
 
-  clean-git-config:
+      - save_cache:
+          paths:
+            - "./gradle/jdk"
+            - "./buildSrc/gradle/jdk"
+          key: "v1-<< parameters.platform >>-jdk-{{ checksum \"jdk.properties\" }}"
+
+      - save_cache:
+          paths:
+            - "./tooling/lsp-clients/vscode/.vscode-test"
+            - "./tooling/lsp-clients/vscode/.vscode-test-web"
+          key: "v1-<< parameters.platform >>-vscode-tests"
+
+
+  "clean-git-config":
     description: "Remove erroneous git config across platforms"
     parameters:
       shell:
         type: enum
-        enum: [bash, powershell]
+        enum:
+          - bash
+          - powershell
         default: bash
+
     steps:
       - when:
           condition:
-            equal: [<< parameters.shell >>, bash]
+            equal:
+              - "<< parameters.shell >>"
+              - bash
           steps:
             - run:
-                name: Clean git config
-                command: rm -rf ~/.gitconfig
+                name: "Clean git config"
+                command: "rm -rf ~/.gitconfig"
+
+
       - when:
           condition:
-            equal: [<< parameters.shell >>, powershell]
+            equal:
+              - "<< parameters.shell >>"
+              - powershell
           steps:
             - run:
-                name: Clean git config
-                command: |
-                  Remove-Item -Path "$env:USERPROFILE\.gitconfig" -Force -ErrorAction SilentlyContinue
-                shell: powershell.exe
+                name: "Clean git config"
+                command: "Remove-Item -Path \"$env:USERPROFILE\\.gitconfig\" -Force -ErrorAction SilentlyContinue\n"
+                shell: "powershell.exe"
 
-  setup-python-test:
+
+
+  "setup-python-test":
     description: "Common setup for Python sdist testing"
     parameters:
       platform:
@@ -111,245 +129,280 @@ commands:
       - checkout
       - when:
           condition:
-            equal: [<< parameters.platform >>, windows]
+            equal:
+              - "<< parameters.platform >>"
+              - windows
           steps:
-            - clean-git-config:
+            - "clean-git-config":
                 shell: powershell
+
       - when:
           condition:
             not:
-              equal: [<< parameters.platform >>, windows]
+              equal:
+                - "<< parameters.platform >>"
+                - windows
           steps:
-            - clean-git-config:
+            - "clean-git-config":
                 shell: bash
-      - attach_workspace:
-          at: ~/repo
 
-  run-python-tests-unix:
+      - attach_workspace:
+          at: "~/repo"
+
+  "run-python-tests-unix":
     description: "Run Python sdist tests and build wheel for Unix-like systems"
     steps:
       - run:
-          name: Install kson from sdist
-          command: python3 -m pip install lib-python/dist/kson_lang-*.tar.gz
+          name: "Install kson from sdist"
+          command: "python3 -m pip install lib-python/dist/kson_lang-*.tar.gz"
+
       - run:
-          name: Install test dependencies
-          command: python3 -m pip install pytest
+          name: "Install test dependencies"
+          command: "python3 -m pip install pytest"
+
       - run:
-          name: Run smoke tests on sdist installation
-          command: python3 -m pytest lib-python -v
+          name: "Run smoke tests on sdist installation"
+          command: "python3 -m pytest lib-python -v"
+
       - run:
-          name: Build platform-specific wheel
-          command: ./gradlew :lib-python:buildWheel
+          name: "Build platform-specific wheel"
+          command: "./gradlew :lib-python:buildWheel"
+
+
 
 # Job definitions
 jobs:
-  build-windows-amd64:
-    resource_class: 'windows.large'
+  "build-windows-amd64":
+    resource_class: "windows.large"
     machine:
-      image: 'windows-server-2022-gui:current'
-      shell: 'powershell.exe -ExecutionPolicy Bypass'
+      image: "windows-server-2022-gui:current"
+      shell: "powershell.exe -ExecutionPolicy Bypass"
+
     environment:
-      JVM_OPTS: -Xmx3200m
+      JVM_OPTS: "-Xmx3200m"
     steps:
       - checkout
-      - clean-git-config:
+      - "clean-git-config":
           shell: powershell
-
       # Windows-specific installations
       # The `browser-tools` orb doesn't support windows, so we install Chrome manually
       - run:
-          name: Install Chrome
-          command: choco install googlechrome --ignore-checksums
+          name: "Install Chrome"
+          command: "choco install googlechrome --ignore-checksums"
+
       # We would ideally install libclang through pixi, but after _hours_ of fiddling we
       # couldn't make the CI happy and decided to add it here instead
       - run:
-          name: Install LLVM
-          command: choco install llvm
+          name: "Install LLVM"
+          command: "choco install llvm"
 
-      - restore-gradle-caches:
-          platform: win-amd64
-
+      - "restore-gradle-caches":
+          platform: "win-amd64"
       # Cross-platform Gradle tasks
-      - gradle-core-tasks
+      - "gradle-core-tasks"
+      - "store-native-artifacts"
+      - "save-gradle-caches":
+          platform: "win-amd64"
 
-      - store-native-artifacts
-
-      - save-gradle-caches:
-          platform: win-amd64
-
-  build-linux-amd64:
+  "build-linux-amd64":
     docker:
-      - image: cimg/node:lts-browsers
-    working_directory: ~/repo
+      - image: "cimg/node:lts-browsers"
+    working_directory: "~/repo"
     environment:
-      JVM_OPTS: -Xmx3200m
+      JVM_OPTS: "-Xmx3200m"
       TERM: dumb
+
     resource_class: large
     steps:
-      - browser-tools/install-chrome
+      - "browser-tools/install-chrome"
       - checkout
       - run:
-          name: Verify Chrome installation
-          command: google-chrome --version
+          name: "Verify Chrome installation"
+          command: "google-chrome --version"
 
-      - restore-gradle-caches:
-          platform: linux-amd64
-
+      - "restore-gradle-caches":
+          platform: "linux-amd64"
       # Linux-specific installations
       - run:
-          name: Install system dependencies
-          command: |
-            sudo apt update
-            sudo apt install libncurses-dev
-      - clean-git-config:
+          name: "Install system dependencies"
+          command: "sudo apt update\nsudo apt install libncurses-dev\n"
+
+      - "clean-git-config":
           shell: bash
-
       # Cross-platform Gradle tasks
-      - gradle-core-tasks
+      - "gradle-core-tasks"
+      - "store-native-artifacts"
+      - "save-gradle-caches":
+          platform: "linux-amd64"
 
-      - store-native-artifacts
-
-      - save-gradle-caches:
-          platform: linux-amd64
-
-  build-macos-arm64:
+  "build-macos-arm64":
     macos:
-      xcode: 16.4.0
-    resource_class: m4pro.medium
-    working_directory: ~/repo
+      xcode: "16.4.0"
+    resource_class: "m4pro.medium"
+    working_directory: "~/repo"
     steps:
       - run:
-          name: Install Chrome
-          command: brew install --cask google-chrome
+          name: "Install Chrome"
+          command: "brew install --cask google-chrome"
+
       - checkout
       - run:
-          name: Verify Chrome installation
-          command: '"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --version'
-      - clean-git-config:
+          name: "Verify Chrome installation"
+          command: "\"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome\" --version"
+
+      - "clean-git-config":
           shell: bash
-
-      - restore-gradle-caches:
-          platform: macos-arm64
-
+      - "restore-gradle-caches":
+          platform: "macos-arm64"
       # Cross-platform Gradle tasks
-      - gradle-core-tasks
+      - "gradle-core-tasks"
+      - "store-native-artifacts"
+      - "save-gradle-caches":
+          platform: "macos-arm64"
 
-      - store-native-artifacts
-
-      - save-gradle-caches:
-          platform: macos-arm64
-
-  build-python-sdist:
+  "build-python-sdist":
     docker:
-      - image: cimg/python:3.11
-    working_directory: ~/repo
+      - image: "cimg/python:3.11"
+    working_directory: "~/repo"
     steps:
       - checkout
-      - clean-git-config:
+      - "clean-git-config":
           shell: bash
       - run:
-          name: Build Python source distribution
-          command: ./gradlew :lib-python:createSdistBuildEnvironment
-      - run:
-          name: Verify sdist was created
-          command: |
-            ls -la lib-python/dist/
-            test -f lib-python/dist/kson_lang-*.tar.gz
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
-            - lib-python/dist/*.tar.gz
-      - store_artifacts:
-          path: lib-python/dist
-          destination: python-sdist
+          name: "Build Python source distribution"
+          command: "./gradlew :lib-python:createSdistBuildEnvironment"
 
-  test-python-sdist-linux-amd64:
+      - run:
+          name: "Verify sdist was created"
+          command: "ls -la lib-python/dist/\ntest -f lib-python/dist/kson_lang-*.tar.gz\n"
+
+      - persist_to_workspace:
+          root: "~/repo"
+          paths:
+            - "lib-python/dist/*.tar.gz"
+
+      - store_artifacts:
+          path: "lib-python/dist"
+          destination: "python-sdist"
+
+
+  "test-python-sdist-linux-amd64":
     docker:
-      - image: cimg/python:3.11
-    working_directory: ~/repo
+      - image: "cimg/python:3.11"
+    working_directory: "~/repo"
     steps:
-      - setup-python-test:
+      - "setup-python-test":
           platform: linux
       - setup_remote_docker
-      - run-python-tests-unix
+      - "run-python-tests-unix"
       - store_artifacts:
-          path: lib-python/dist
-          destination: python-linux-amd64
+          path: "lib-python/dist"
+          destination: "python-linux-amd64"
 
-  test-python-sdist-macos:
+
+  "test-python-sdist-macos":
     macos:
-      xcode: 14.2.0
-    working_directory: ~/repo
+      xcode: "14.2.0"
+    working_directory: "~/repo"
     steps:
-      - setup-python-test:
+      - "setup-python-test":
           platform: macos
-      - run-python-tests-unix
+      - "run-python-tests-unix"
       - store_artifacts:
-          path: lib-python/dist
-          destination: python-macos
+          path: "lib-python/dist"
+          destination: "python-macos"
 
-  test-python-sdist-windows:
+
+  "test-python-sdist-windows":
     executor:
-      name: windows/default
+      name: "windows/default"
       size: medium
-    working_directory: ~/repo
+
+    working_directory: "~/repo"
     steps:
-      - setup-python-test:
+      - "setup-python-test":
           platform: windows
       - run:
-          name: Check Python version and upgrade if needed
-          command: |
-            python --version
-            python -m pip install --upgrade pip
+          name: "Check Python version and upgrade if needed"
+          command: "python --version\npython -m pip install --upgrade pip\n"
+
       - run:
-          name: Install kson from sdist
-          command: |
-            python -m pip install (Get-ChildItem lib-python/dist/kson_lang-*.tar.gz).FullName
-          shell: powershell.exe
+          name: "Install kson from sdist"
+          command: "python -m pip install (Get-ChildItem lib-python/dist/kson_lang-*.tar.gz).FullName\n"
+          shell: "powershell.exe"
+
       - run:
-          name: Install test dependencies
-          command: python -m pip install pytest
+          name: "Install test dependencies"
+          command: "python -m pip install pytest"
+
       - run:
-          name: Run smoke tests on sdist installation
-          command: python -m pytest lib-python -v
+          name: "Run smoke tests on sdist installation"
+          command: "python -m pytest lib-python -v"
+
       - run:
-          name: Build platform-specific wheel
-          command: |
-            .\gradlew.bat :lib-python:buildWheel --no-daemon
+          name: "Build platform-specific wheel"
+          command: ".\\gradlew.bat :lib-python:buildWheel --no-daemon\n"
+
       - store_artifacts:
-          path: lib-python/dist
-          destination: python-windows
+          path: "lib-python/dist"
+          destination: "python-windows"
+
+
 
 workflows:
   version: 2
-
   # Main build workflow - runs on version tags
-  build-all:
+  "build-all":
     jobs:
-      - build-linux-amd64
-      - build-windows-amd64:
-          filters: &version-tag-filter
+      - "build-linux-amd64"
+      - "build-windows-amd64":
+          filters:
             tags:
-              only: /^v\d+\.\d+\.\d+$/
+              only: "/^v\\d+\\.\\d+\\.\\d+$/"
             branches:
-              ignore: /.*/
-      - build-macos-arm64:
-          filters: *version-tag-filter
+              ignore: "/.*/"
 
-  # Python package workflow - also runs on version tags
-  build-python-and-test:
+      - "build-macos-arm64":
+          filters:
+            tags:
+              only: "/^v\\d+\\.\\d+\\.\\d+$/"
+            branches:
+              ignore: "/.*/"
+
+  "build-python-and-test":
     jobs:
-      - build-python-sdist:
-          filters: *version-tag-filter
-      - test-python-sdist-linux-amd64:
+      - "build-python-sdist":
+          filters:
+            tags:
+              only: "/^v\\d+\\.\\d+\\.\\d+$/"
+            branches:
+              ignore: "/.*/"
+
+      - "test-python-sdist-linux-amd64":
           requires:
-            - build-python-sdist
-          filters: *version-tag-filter
-      - test-python-sdist-macos:
+            - "build-python-sdist"
+          filters:
+            tags:
+              only: "/^v\\d+\\.\\d+\\.\\d+$/"
+            branches:
+              ignore: "/.*/"
+
+
+      - "test-python-sdist-macos":
           requires:
-            - build-python-sdist
-          filters: *version-tag-filter
-      - test-python-sdist-windows:
+            - "build-python-sdist"
+          filters:
+            tags:
+              only: "/^v\\d+\\.\\d+\\.\\d+$/"
+            branches:
+              ignore: "/.*/"
+
+
+      - "test-python-sdist-windows":
           requires:
-            - build-python-sdist
-          filters: *version-tag-filter
+            - "build-python-sdist"
+          filters:
+            tags:
+              only: "/^v\\d+\\.\\d+\\.\\d+$/"
+            branches:
+              ignore: "/.*/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,40 +322,34 @@ jobs:
 
 workflows:
   version: 2
+
+  # Main build workflow - runs on version tags
   build-all:
     jobs:
       - build-linux-amd64
-      - build-windows-amd64
-      - build-macos-arm64
+      - build-windows-amd64:
+          filters: &version-tag-filter
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
+      - build-macos-arm64:
+          filters: *version-tag-filter
+
+  # Python package workflow - also runs on version tags
   build-python-and-test:
     jobs:
       - build-python-sdist:
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
+          filters: *version-tag-filter
       - test-python-sdist-linux-amd64:
           requires:
             - build-python-sdist
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
+          filters: *version-tag-filter
       - test-python-sdist-macos:
           requires:
             - build-python-sdist
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
+          filters: *version-tag-filter
       - test-python-sdist-windows:
           requires:
             - build-python-sdist
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
+          filters: *version-tag-filter

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,16 +38,19 @@ repositories {
     mavenCentral()
 }
 
-val generateJsonTestSuiteTask = "generateJsonTestSuite"
-
 tasks {
-    register<GenerateJsonTestSuiteTask>(generateJsonTestSuiteTask)
+    val generateJsonTestSuiteTask by register<GenerateJsonTestSuiteTask>("generateJsonTestSuite")
+
+    val transpileCircleCiConfigTask by register<TranspileKsonToYaml>("transpileCircleCiConfigTask") {
+        ksonFile.set(project.file(".circleci/config.kson"))
+        yamlFile.set(project.file(".circleci/config.yml"))
+    }
 
     withType<Task> {
-        // make every task except itself depend on generateJsonTestSuiteTask to
+        // make every task except itself depend on generateJsonTestSuiteTask and transpileCircleCIConfigTask to
         // ensure it's always up-to-date before any other build steps
-        if (name != generateJsonTestSuiteTask) {
-            dependsOn(generateJsonTestSuiteTask)
+        if (name != generateJsonTestSuiteTask.name && name != transpileCircleCiConfigTask.name ) {
+            dependsOn(generateJsonTestSuiteTask, transpileCircleCiConfigTask)
         }
     }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -108,4 +108,6 @@ dependencies {
     
     // Add Kotlin Gradle Plugin for multiplatform configuration
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.10")
+
+    implementation("org.kson:kson:0.1.1")
 }

--- a/buildSrc/src/main/kotlin/TranspileKsonToYaml.kt
+++ b/buildSrc/src/main/kotlin/TranspileKsonToYaml.kt
@@ -1,3 +1,4 @@
+import org.eclipse.jgit.api.Git
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.RegularFileProperty
@@ -6,6 +7,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.kson.Kson
 import org.kson.Result
+import java.io.File
 
 /**
  * Gradle task that transpiles KSON files to YAML format.
@@ -33,8 +35,8 @@ abstract class TranspileKsonToYaml : DefaultTask() {
     abstract val yamlFile: RegularFileProperty
 
     init {
-        group = "circleci"
-        description = "Transpile .circleci/config.kson to .circleci/config.yml"
+        group = "kson-transpilation"
+        description = "Transpile KSON to YAML file"
     }
 
     /**
@@ -43,7 +45,11 @@ abstract class TranspileKsonToYaml : DefaultTask() {
      * Reads the input KSON file, transpiles it using [Kson.toYaml] with embed tags
      * removed, and writes the result to the output YAML file.
      *
-     * @throws GradleException if the input file does not exist or transpilation fails
+     * Before overwriting, checks if the YAML file has uncommitted changes in git that
+     * don't match what the KSON would generate, preventing accidental data loss.
+     *
+     * @throws GradleException if the input file does not exist, transpilation fails,
+     *         or the YAML file has uncommitted manual changes
      */
     @TaskAction
     fun transpile() {
@@ -60,7 +66,15 @@ abstract class TranspileKsonToYaml : DefaultTask() {
 
         when (val result = Kson.toYaml(ksonContent, retainEmbedTags = false)) {
             is Result.Success -> {
-                yamlOutput.writeText(result.output)
+                val newYamlContent = result.output
+
+                // Check for uncommitted changes before overwriting
+                if (yamlOutput.exists()) {
+                    checkForUncommittedChanges(yamlOutput, newYamlContent)
+                    checkFilesAreInSync(yamlOutput, newYamlContent)
+                }
+
+                yamlOutput.writeText(newYamlContent)
                 logger.lifecycle("Successfully transpiled to ${yamlOutput.name}")
             }
             is Result.Failure -> {
@@ -70,5 +84,224 @@ abstract class TranspileKsonToYaml : DefaultTask() {
                 throw GradleException("Failed to transpile KSON to YAML:\n$errorMessages")
             }
         }
+    }
+
+    /**
+     * Checks if the YAML file has uncommitted changes that would be lost.
+     *
+     * Uses jgit to check if:
+     * 1. The file has uncommitted changes (modified or staged)
+     * 2. The current content differs from what we're about to write
+     *
+     * If both conditions are true, throws an exception to prevent data loss.
+     *
+     * @param yamlFile The YAML output file to check
+     * @param newContent The new content that would be written
+     * @throws GradleException if uncommitted changes would be lost
+     */
+    internal fun checkForUncommittedChanges(yamlFile: File, newContent: String) {
+        val gitDir = findGitDirectory(yamlFile)
+        if (gitDir == null) {
+            logger.debug("Not in a git repository, skipping uncommitted changes check")
+            return
+        }
+
+        try {
+            val git = Git.open(gitDir)
+            val status = git.status().call()
+
+            // Get relative path from git root
+            val relativePath = yamlFile.absolutePath.removePrefix(gitDir.absolutePath + File.separator)
+
+            // Check if file has uncommitted changes
+            // - modified: working tree changes not staged
+            // - changed: changes staged for commit
+            // - added: new file staged for commit
+            // - removed: file staged for removal
+            val hasUncommittedChanges = status.modified.contains(relativePath) ||
+                    status.added.contains(relativePath) ||
+                    status.changed.contains(relativePath) ||
+                    status.removed.contains(relativePath)
+
+            if (!hasUncommittedChanges) {
+                logger.debug("No uncommitted changes in ${yamlFile.name}")
+                return
+            }
+
+            // File has uncommitted changes - check if current content matches what we'd generate
+            val currentContent = yamlFile.readText()
+            if (currentContent != newContent) {
+                throw GradleException(
+                    """
+                    |The YAML file ${yamlFile.absolutePath} has uncommitted changes that differ from
+                    |what would be generated from ${ksonFile.get().asFile.name}.
+                    |
+                    |This suggests the YAML file was manually edited. To prevent accidental data loss:
+                    |1. Review the changes: git diff ${relativePath}
+                    |2. If you want to keep the manual changes:
+                    |   - Commit them first, OR
+                    |   - Port them to the .kson file, OR
+                    |   - Stash them: git stash
+                    |3. If you want to discard the manual changes and use KSON:
+                    |   - Revert them: git checkout -- ${relativePath}
+                    |   - Then run this task again
+                    """.trimMargin()
+                )
+            }
+        } catch (e: GradleException) {
+            // Re-throw our own exceptions
+            throw e
+        } catch (e: Exception) {
+            // If jgit fails for any other reason, log and continue
+            logger.debug("Failed to check git status: ${e.message}")
+        }
+    }
+
+    /**
+     * Checks if the committed KSON and YAML files are in sync.
+     *
+     * Verifies that the committed version of the KSON file, when transpiled, produces
+     * the committed version of the YAML file. This ensures the files are synchronized
+     * in the git repository before allowing any transpilation.
+     *
+     * This check runs on committed (clean) files only and will fail even if both files
+     * have no uncommitted changes, if the committed versions are out of sync.
+     *
+     * @param yamlFile The YAML output file to check
+     * @param newContent The content that would be generated from the current KSON file
+     * @throws GradleException if committed files are not in sync
+     */
+    internal fun checkFilesAreInSync(yamlFile: File, newContent: String) {
+        val gitDir = findGitDirectory(yamlFile)
+        if (gitDir == null) {
+            logger.debug("Not in a git repository, skipping sync check")
+            return
+        }
+
+        try {
+            val git = Git.open(gitDir)
+            val repository = git.repository
+            val status = git.status().call()
+
+            // Get relative paths from git root
+            val yamlRelativePath = yamlFile.absolutePath.removePrefix(gitDir.absolutePath + File.separator)
+            val ksonRelativePath = ksonFile.get().asFile.absolutePath.removePrefix(gitDir.absolutePath + File.separator)
+
+            // Check if files have uncommitted changes
+            val ksonHasChanges = status.modified.contains(ksonRelativePath) ||
+                    status.added.contains(ksonRelativePath) ||
+                    status.changed.contains(ksonRelativePath)
+            val yamlHasChanges = status.modified.contains(yamlRelativePath) ||
+                    status.added.contains(yamlRelativePath) ||
+                    status.changed.contains(yamlRelativePath)
+
+            // If either file has uncommitted changes, we can't check sync of committed versions
+            if (ksonHasChanges || yamlHasChanges) {
+                val changedFiles = mutableListOf<String>()
+                if (ksonHasChanges) changedFiles.add(ksonRelativePath)
+                if (yamlHasChanges) changedFiles.add(yamlRelativePath)
+
+                throw GradleException(
+                    """
+                    |Cannot verify sync: Files must be committed before checking if KSON and YAML are in sync.
+                    |
+                    |Files with uncommitted changes: ${changedFiles.joinToString(", ")}
+                    |
+                    |This task requires both files to be committed so it can verify that:
+                    |  - The committed KSON file generates the committed YAML file
+                    |
+                    |To fix this:
+                    |1. Review your changes: git diff
+                    |2. If the changes are intentional:
+                    |   - Commit both files: git add ${changedFiles.joinToString(" ")} && git commit -m "Update config"
+                    |3. If you want to discard changes:
+                    |   - Revert changes: git checkout -- ${changedFiles.joinToString(" ")}
+                    """.trimMargin()
+                )
+            }
+
+            // Both files are clean - now check if committed versions are in sync
+            // Get committed content of KSON file
+            val headId = repository.resolve("HEAD")
+            if (headId == null) {
+                logger.debug("No HEAD commit found, skipping sync check")
+                return
+            }
+
+            val treeWalk = org.eclipse.jgit.treewalk.TreeWalk.forPath(repository, ksonRelativePath,
+                repository.parseCommit(headId).tree)
+            if (treeWalk == null) {
+                logger.debug("KSON file not found in HEAD commit, skipping sync check")
+                return
+            }
+
+            val ksonBlobId = treeWalk.getObjectId(0)
+            val ksonCommittedContent = String(repository.open(ksonBlobId).bytes, Charsets.UTF_8)
+
+            // Transpile committed KSON content
+            val committedYamlResult = Kson.toYaml(ksonCommittedContent, retainEmbedTags = false)
+            if (committedYamlResult !is Result.Success) {
+                logger.debug("Failed to transpile committed KSON, skipping sync check")
+                return
+            }
+
+            // Get committed content of YAML file
+            val yamlTreeWalk = org.eclipse.jgit.treewalk.TreeWalk.forPath(repository, yamlRelativePath,
+                repository.parseCommit(headId).tree)
+            if (yamlTreeWalk == null) {
+                logger.debug("YAML file not found in HEAD commit, skipping sync check")
+                return
+            }
+
+            val yamlBlobId = yamlTreeWalk.getObjectId(0)
+            val yamlCommittedContent = String(repository.open(yamlBlobId).bytes, Charsets.UTF_8)
+
+            // Compare committed YAML with what committed KSON would generate
+            if (committedYamlResult.output != yamlCommittedContent) {
+                throw GradleException(
+                    """
+                    |Cannot transpile: Committed KSON and YAML files are out of sync!
+                    |
+                    |The committed version of ${ksonRelativePath} does NOT generate the
+                    |committed version of ${yamlRelativePath}.
+                    |
+                    |This means the files were committed in an inconsistent state. The task cannot
+                    |proceed because it cannot determine which file represents the source of truth.
+                    |
+                    |To fix this:
+                    |1. Decide which file is correct:
+                    |   - If KSON is correct: Run this task to regenerate YAML, then commit both
+                    |   - If YAML is correct: Update KSON to match, then commit both
+                    |2. OR manually synchronize the files and commit both together
+                    """.trimMargin()
+                )
+            }
+
+            logger.debug("Committed KSON and YAML files are in sync")
+        } catch (e: GradleException) {
+            // Re-throw our own exceptions
+            throw e
+        } catch (e: Exception) {
+            // If jgit fails for any other reason, log and continue
+            logger.debug("Failed to check file sync status: ${e.message}")
+        }
+    }
+
+    /**
+     * Finds the git directory for the given file by walking up the directory tree.
+     *
+     * @param file The file to find the git directory for
+     * @return The git directory, or null if not in a git repository
+     */
+    internal fun findGitDirectory(file: File): File? {
+        var current = file.absoluteFile.parentFile
+        while (current != null) {
+            val gitDir = File(current, ".git")
+            if (gitDir.exists() && gitDir.isDirectory) {
+                return current
+            }
+            current = current.parentFile
+        }
+        return null
     }
 }

--- a/buildSrc/src/main/kotlin/TranspileKsonToYaml.kt
+++ b/buildSrc/src/main/kotlin/TranspileKsonToYaml.kt
@@ -1,0 +1,74 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.kson.Kson
+import org.kson.Result
+
+/**
+ * Gradle task that transpiles KSON files to YAML format.
+ *
+ * This task reads a KSON input file, transpiles it to YAML using the Kson library,
+ * and writes the result to an output file. The task is configured with input/output
+ * file tracking for Gradle's up-to-date checking.
+ *
+ * @property ksonFile The input KSON file to transpile
+ * @property yamlFile The output YAML file to write the transpiled result to
+ *
+ * @throws GradleException if the input file does not exist or transpilation fails
+ */
+abstract class TranspileKsonToYaml : DefaultTask() {
+    /**
+     * The input KSON file to transpile.
+     */
+    @get:InputFile
+    abstract val ksonFile: RegularFileProperty
+
+    /**
+     * The output YAML file to write the transpiled result to.
+     */
+    @get:OutputFile
+    abstract val yamlFile: RegularFileProperty
+
+    init {
+        group = "circleci"
+        description = "Transpile .circleci/config.kson to .circleci/config.yml"
+    }
+
+    /**
+     * Performs the transpilation from KSON to YAML.
+     *
+     * Reads the input KSON file, transpiles it using [Kson.toYaml] with embed tags
+     * removed, and writes the result to the output YAML file.
+     *
+     * @throws GradleException if the input file does not exist or transpilation fails
+     */
+    @TaskAction
+    fun transpile() {
+        val ksonInput = ksonFile.get().asFile
+        val yamlOutput = yamlFile.get().asFile
+
+        if (!ksonInput.exists()) {
+            throw GradleException("KSON input file does not exist: ${ksonInput.absolutePath}")
+        }
+
+        logger.lifecycle("Transpiling ${ksonInput.name} to ${yamlOutput.name}...")
+
+        val ksonContent = ksonInput.readText()
+
+        when (val result = Kson.toYaml(ksonContent, retainEmbedTags = false)) {
+            is Result.Success -> {
+                yamlOutput.writeText(result.output)
+                logger.lifecycle("Successfully transpiled to ${yamlOutput.name}")
+            }
+            is Result.Failure -> {
+                val errorMessages = result.errors.joinToString("\n") { error ->
+                    "  [${error.severity}] Line ${error.start.line + 1}, Column ${error.start.column + 1}: ${error.message}"
+                }
+                throw GradleException("Failed to transpile KSON to YAML:\n$errorMessages")
+            }
+        }
+    }
+}

--- a/buildSrc/src/test/kotlin/TranspileKsonToYamlTest.kt
+++ b/buildSrc/src/test/kotlin/TranspileKsonToYamlTest.kt
@@ -1,0 +1,423 @@
+import org.eclipse.jgit.api.Git
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TranspileKsonToYamlTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun `sanity check task`() {
+        val project = ProjectBuilder.builder().build()
+        project.tasks.register("transpileKsonToYaml", TranspileKsonToYaml::class.java)
+        val task = project.getTasksByName("transpileKsonToYaml", false)
+            .iterator().next()
+        assertTrue(task is TranspileKsonToYaml)
+    }
+
+    @Test
+    fun `transpile simple KSON to YAML`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val ksonFile = tempFolder.newFile("test.kson")
+        ksonFile.writeText("key: value\n")
+
+        val yamlFile = File(tempFolder.root, "test.yml")
+
+        task.ksonFile.set(ksonFile)
+        task.yamlFile.set(yamlFile)
+
+        task.transpile()
+
+        assertTrue(yamlFile.exists())
+        assertEquals("key: value", yamlFile.readText())
+    }
+
+    @Test
+    fun `throws exception when KSON file does not exist`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val ksonFile = File(tempFolder.root, "nonexistent.kson")
+        val yamlFile = File(tempFolder.root, "test.yml")
+
+        task.ksonFile.set(ksonFile)
+        task.yamlFile.set(yamlFile)
+
+        val exception = assertFailsWith<GradleException> {
+            task.transpile()
+        }
+        assertTrue(exception.message!!.contains("does not exist"))
+    }
+
+    @Test
+    fun `throws exception on invalid KSON`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val ksonFile = tempFolder.newFile("invalid.kson")
+        ksonFile.writeText("invalid: [unclosed bracket\n")
+
+        val yamlFile = File(tempFolder.root, "test.yml")
+
+        task.ksonFile.set(ksonFile)
+        task.yamlFile.set(yamlFile)
+
+        val exception = assertFailsWith<GradleException> {
+            task.transpile()
+        }
+        assertTrue(exception.message!!.contains("Failed to transpile"))
+    }
+
+    @Test
+    fun `findGitDirectory returns null when not in git repo`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val file = tempFolder.newFile("test.txt")
+
+        assertNull(task.findGitDirectory(file))
+    }
+
+    @Test
+    fun `findGitDirectory finds git directory`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val gitDir = tempFolder.newFolder(".git")
+        val file = File(tempFolder.root, "test.txt")
+        file.createNewFile()
+
+        assertEquals(tempFolder.root, task.findGitDirectory(file))
+    }
+
+    @Test
+    fun `checkForUncommittedChanges does nothing when not in git repo`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val yamlFile = tempFolder.newFile("test.yml")
+        yamlFile.writeText("old content")
+
+        // Should not throw
+        task.checkForUncommittedChanges(yamlFile, "new content")
+    }
+
+    @Test
+    fun `checkForUncommittedChanges allows overwrite when no uncommitted changes`() {
+        val gitRepo = tempFolder.newFolder("repo")
+        Git.init().setDirectory(gitRepo).call()
+
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val yamlFile = File(gitRepo, "test.yml")
+        yamlFile.writeText("initial content")
+
+        // Add and commit the file
+        val git = Git.open(gitRepo)
+        git.add().addFilepattern("test.yml").call()
+        git.commit()
+            .setMessage("Initial commit")
+            .setAuthor("Test", "test@example.com")
+            .call()
+
+        // Should not throw - file has no uncommitted changes
+        task.checkForUncommittedChanges(yamlFile, "new content")
+    }
+
+    @Test
+    fun `checkForUncommittedChanges allows overwrite when uncommitted changes match new content`() {
+        val gitRepo = tempFolder.newFolder("repo")
+        Git.init().setDirectory(gitRepo).call()
+
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val yamlFile = File(gitRepo, "test.yml")
+        yamlFile.writeText("initial content")
+
+        val git = Git.open(gitRepo)
+        git.add().addFilepattern("test.yml").call()
+        git.commit()
+            .setMessage("Initial commit")
+            .setAuthor("Test", "test@example.com")
+            .call()
+
+        // Modify the file
+        yamlFile.writeText("modified content")
+
+        // Should not throw - uncommitted changes match what we'd write
+        task.checkForUncommittedChanges(yamlFile, "modified content")
+    }
+
+    @Test
+    fun `checkForUncommittedChanges throws when uncommitted changes differ from new content`() {
+        val gitRepo = tempFolder.newFolder("repo")
+        Git.init().setDirectory(gitRepo).call()
+
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val ksonFile = File(gitRepo, "test.kson")
+        ksonFile.writeText("key: value")
+        val yamlFile = File(gitRepo, "test.yml")
+        yamlFile.writeText("initial content")
+
+        task.ksonFile.set(ksonFile)
+        task.yamlFile.set(yamlFile)
+
+        val git = Git.open(gitRepo)
+        git.add().addFilepattern("test.yml").call()
+        git.add().addFilepattern("test.kson").call()
+        git.commit()
+            .setMessage("Initial commit")
+            .setAuthor("Test", "test@example.com")
+            .call()
+
+        // Modify the YAML file manually
+        yamlFile.writeText("manually modified content")
+
+        // Should throw - uncommitted changes differ from what we'd generate
+        val exception = assertFailsWith<GradleException> {
+            task.checkForUncommittedChanges(yamlFile, "different content from kson")
+        }
+        assertTrue(exception.message!!.contains("uncommitted changes"))
+        assertTrue(exception.message!!.contains("manually edited"))
+    }
+
+    @Test
+    fun `transpile prevents overwriting uncommitted manual changes`() {
+        val gitRepo = tempFolder.newFolder("repo")
+        Git.init().setDirectory(gitRepo).call()
+
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val ksonFile = File(gitRepo, "test.kson")
+        ksonFile.writeText("key: newvalue")
+        val yamlFile = File(gitRepo, "test.yml")
+        yamlFile.writeText("key: oldvalue\n")
+
+        task.ksonFile.set(ksonFile)
+        task.yamlFile.set(yamlFile)
+
+        val git = Git.open(gitRepo)
+        git.add().addFilepattern("test.yml").call()
+        git.add().addFilepattern("test.kson").call()
+        git.commit()
+            .setMessage("Initial commit")
+            .setAuthor("Test", "test@example.com")
+            .call()
+
+        // Manually modify YAML
+        yamlFile.writeText("key: manualchange\n")
+
+        // Should throw when trying to transpile
+        val exception = assertFailsWith<GradleException> {
+            task.transpile()
+        }
+        assertTrue(exception.message!!.contains("uncommitted changes"))
+    }
+
+    @Test
+    fun `transpile succeeds when YAML file does not exist`() {
+        val gitRepo = tempFolder.newFolder("repo")
+        Git.init().setDirectory(gitRepo).call()
+
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val ksonFile = File(gitRepo, "test.kson")
+        ksonFile.writeText("key: value")
+        val yamlFile = File(gitRepo, "test.yml")
+
+        task.ksonFile.set(ksonFile)
+        task.yamlFile.set(yamlFile)
+
+        val git = Git.open(gitRepo)
+        git.add().addFilepattern("test.kson").call()
+        git.commit()
+            .setMessage("Initial commit")
+            .setAuthor("Test", "test@example.com")
+            .call()
+
+        // Should succeed - YAML file doesn't exist yet
+        task.transpile()
+
+        assertTrue(yamlFile.exists())
+        assertEquals("key: value", yamlFile.readText())
+    }
+
+    @Test
+    fun `checkFilesAreInSync throws when KSON and YAML file are committed out of sync`() {
+        val gitRepo = tempFolder.newFolder("repo")
+        Git.init().setDirectory(gitRepo).call()
+
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val ksonFile = File(gitRepo, "test.kson")
+        ksonFile.writeText("key: value")
+        val yamlFile = File(gitRepo, "test.yml")
+        yamlFile.writeText("key: value")
+
+        task.ksonFile.set(ksonFile)
+        task.yamlFile.set(yamlFile)
+
+        val git = Git.open(gitRepo)
+        git.add().addFilepattern("test.yml").call()
+        git.add().addFilepattern("test.kson").call()
+        git.commit()
+            .setMessage("Initial commit")
+            .setAuthor("Test", "test@example.com")
+            .call()
+
+        // Modify KSON file
+        ksonFile.writeText("key: newvalue")
+
+        // Should throw - KSON file has uncommitted changes
+        val exception = assertFailsWith<GradleException> {
+            task.checkFilesAreInSync(yamlFile, "key: value")
+        }
+        assertTrue(exception.message!!.contains("verify sync"))
+        assertTrue(exception.message!!.contains("test.kson"))
+    }
+
+    @Test
+    fun `checkFilesAreInSync throws when committed out of sync`() {
+        val gitRepo = tempFolder.newFolder("repo")
+        Git.init().setDirectory(gitRepo).call()
+
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val ksonFile = File(gitRepo, "test.kson")
+        ksonFile.writeText("key: value")
+        val yamlFile = File(gitRepo, "test.yml")
+        yamlFile.writeText("key: value")
+
+        task.ksonFile.set(ksonFile)
+        task.yamlFile.set(yamlFile)
+
+        val git = Git.open(gitRepo)
+        git.add().addFilepattern("test.yml").call()
+        git.add().addFilepattern("test.kson").call()
+        git.commit()
+            .setMessage("Initial commit")
+            .setAuthor("Test", "test@example.com")
+            .call()
+
+        // Modify YAML file
+        yamlFile.writeText("key: newvalue")
+
+        // Should throw - YAML file has uncommitted changes
+        val exception = assertFailsWith<GradleException> {
+            task.checkFilesAreInSync(yamlFile, "key: value")
+        }
+        assertTrue(exception.message!!.contains("verify sync"))
+        assertTrue(exception.message!!.contains("test.yml"))
+    }
+
+    @Test
+    fun `checkFilesAreInSync succeeds when both files are committed and in sync`() {
+        val gitRepo = tempFolder.newFolder("repo")
+        Git.init().setDirectory(gitRepo).call()
+
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val ksonFile = File(gitRepo, "test.kson")
+        ksonFile.writeText("key: value")
+        val yamlFile = File(gitRepo, "test.yml")
+        yamlFile.writeText("key: value")
+
+        task.ksonFile.set(ksonFile)
+        task.yamlFile.set(yamlFile)
+
+        val git = Git.open(gitRepo)
+        git.add().addFilepattern("test.yml").call()
+        git.add().addFilepattern("test.kson").call()
+        git.commit()
+            .setMessage("Initial commit")
+            .setAuthor("Test", "test@example.com")
+            .call()
+
+        // Should not throw - both files are committed and in sync
+        task.checkFilesAreInSync(yamlFile, "key: value")
+    }
+
+    @Test
+    fun `checkFilesAreInSync throws when committed files are out of sync`() {
+        val gitRepo = tempFolder.newFolder("repo")
+        Git.init().setDirectory(gitRepo).call()
+
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val ksonFile = File(gitRepo, "test.kson")
+        ksonFile.writeText("key: value")
+        val yamlFile = File(gitRepo, "test.yml")
+        yamlFile.writeText("key: wrongvalue")  // YAML doesn't match what KSON would generate
+
+        task.ksonFile.set(ksonFile)
+        task.yamlFile.set(yamlFile)
+
+        val git = Git.open(gitRepo)
+        git.add().addFilepattern("test.yml").call()
+        git.add().addFilepattern("test.kson").call()
+        git.commit()
+            .setMessage("Initial commit with out-of-sync files")
+            .setAuthor("Test", "test@example.com")
+            .call()
+
+        // Should throw - committed files are out of sync
+        val exception = assertFailsWith<GradleException> {
+            task.checkFilesAreInSync(yamlFile, "key: value")
+        }
+        assertTrue(exception.message!!.contains("out of sync"))
+    }
+
+    @Test
+    fun `transpile fails when files are not in sync`() {
+        val gitRepo = tempFolder.newFolder("repo")
+        Git.init().setDirectory(gitRepo).call()
+
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("transpile", TranspileKsonToYaml::class.java)
+
+        val ksonFile = File(gitRepo, "test.kson")
+        ksonFile.writeText("key: value")
+        val yamlFile = File(gitRepo, "test.yml")
+        yamlFile.writeText("key: value")
+
+        task.ksonFile.set(ksonFile)
+        task.yamlFile.set(yamlFile)
+
+        val git = Git.open(gitRepo)
+        git.add().addFilepattern("test.yml").call()
+        git.add().addFilepattern("test.kson").call()
+        git.commit()
+            .setMessage("Initial commit")
+            .setAuthor("Test", "test@example.com")
+            .call()
+
+        // Modify KSON file
+        ksonFile.writeText("key: newvalue")
+
+        // Should throw when trying to transpile
+        val exception = assertFailsWith<GradleException> {
+            task.transpile()
+        }
+        assertTrue(exception.message!!.contains("verify sync"))
+    }
+}


### PR DESCRIPTION
This PR adds a `TranspileKsonToYaml` gradle-task that can take any file and output it to YAML. It's applied to the existing `./.circleci/config.yml` file.

Commit d9af3542df903a544573b477d4d70058ccef2612 implements this quite naively. We just take the KSON file and output the YAML file. However, it's always a possibility that someone edits the YAML file and accidentally overwrites the changes during tranpsilation. In commit d7ed0eb857672916119b21eba2b1ec9eb971c03d I've safeguards that 'prevent' this from happening. 
The three safeguards are: 
1. The transpilation can ONLY happen if the files have been committed in sync.
2. The transpilation can ONLY happen if there are no uncommitted changes in the YAML file, that are different than what we'd transpile too. So adding the same manual changes in both KSON and YAML is possible. 
3. Comment on top of the file



