### PR TITLE
Bugfix: escape handling in decoding of `EmbedBlock`s

### DIFF
--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -55,7 +55,7 @@ interface AstNode {
         /**
          * Constructs an initial/default indent
          */
-        constructor() : this(IndentType.Space(2),0, false)
+        constructor() : this(IndentType.Space(2), 0, false)
 
         private val indentString = indentType.indentString
 
@@ -184,7 +184,7 @@ class KsonRootImpl(
                 }
 
                 // remove any trailing newlines
-                while(ksonDocument.endsWith("\n")) {
+                while (ksonDocument.endsWith("\n")) {
                     ksonDocument = ksonDocument.removeSuffix("\n")
                 }
 
@@ -194,9 +194,9 @@ class KsonRootImpl(
                         // endComments are already embedded in the document, likely as part of a trailing error
                         ""
                     } else {
-                        if(compileTarget is Kson && compileTarget.formatConfig.formattingStyle == FormattingStyle.COMPACT){
+                        if (compileTarget is Kson && compileTarget.formatConfig.formattingStyle == FormattingStyle.COMPACT) {
                             "\n" + endComments
-                        }else{
+                        } else {
                             "\n\n" + endComments
                         }
                     }
@@ -222,31 +222,34 @@ class ObjectNode(val properties: List<ObjectPropertyNode>, location: Location) :
                     FormattingStyle.COMPACT -> formatCompactObject(indent, nextNode, compileTarget)
                 }
             }
+
             is Yaml -> formatUndelimitedObject(indent, nextNode, compileTarget)
             is Json -> formatDelimitedObject(indent, nextNode, compileTarget)
         }
     }
 
     private fun formatDelimitedObject(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
-            val seperator = when(compileTarget) {
-                is Kson -> "\n"
-                is Json -> ",\n"
-                is Yaml -> throw UnsupportedOperationException("We never format YAML objects as delimited")
-            }
+        val seperator = when (compileTarget) {
+            is Kson -> "\n"
+            is Json -> ",\n"
+            is Yaml -> throw UnsupportedOperationException("We never format YAML objects as delimited")
+        }
 
-            return """
+        return """
             |${indent.firstLineIndent()}{
-            |${properties.withIndex().joinToString(seperator) { (index, property) ->
+            |${
+            properties.withIndex().joinToString(seperator) { (index, property) ->
                 val nodeAfterThisChild = properties.getOrNull(index + 1) ?: nextNode
-                property.toSourceWithNext(indent.next(false), nodeAfterThisChild, compileTarget) }
+                property.toSourceWithNext(indent.next(false), nodeAfterThisChild, compileTarget)
             }
+        }
             |${indent.bodyLinesIndent()}}
             """.trimMargin()
 
     }
 
-    private fun formatCompactObject(indent: Indent , nextNode: AstNode?, compileTarget: CompileTarget): String {
-        val outputObject = properties.withIndex().joinToString(""){ (index, property) ->
+    private fun formatCompactObject(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
+        val outputObject = properties.withIndex().joinToString("") { (index, property) ->
             val nodeAfterThisChild = properties.getOrNull(index + 1) ?: nextNode
             val result = property.toSourceWithNext(indent, nodeAfterThisChild, compileTarget)
 
@@ -258,11 +261,13 @@ class ObjectNode(val properties: List<ObjectPropertyNode>, location: Location) :
                         is QuotedStringNode -> {
                             StringUnquoted.isUnquotable(property.value.stringContent)
                         }
+
                         is UnquotedStringNode,
                         is NumberNode,
                         is TrueNode,
                         is FalseNode,
                         is NullNode -> true
+
                         else -> false
                     }
 
@@ -271,7 +276,7 @@ class ObjectNode(val properties: List<ObjectPropertyNode>, location: Location) :
         return if (nextNode is ObjectPropertyNode) {
             // If the last property is a number we need to add whitespace before the '.' to prevent it becoming a number
             val needsSpace = (properties.last() as ObjectPropertyNodeImpl).value is NumberNode
-            outputObject + if(needsSpace) " ." else "."
+            outputObject + if (needsSpace) " ." else "."
         } else outputObject
     }
 
@@ -322,21 +327,23 @@ class ObjectPropertyNodeImpl(
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
             is Kson -> {
-                when (compileTarget.formatConfig.formattingStyle){
+                when (compileTarget.formatConfig.formattingStyle) {
                     FormattingStyle.DELIMITED -> delimitedObjectProperty(indent, nextNode, compileTarget)
-                    FormattingStyle.COMPACT  -> compactObjectProperty(indent, nextNode, compileTarget)
+                    FormattingStyle.COMPACT -> compactObjectProperty(indent, nextNode, compileTarget)
                     FormattingStyle.PLAIN -> undelimitedObjectProperty(indent, nextNode, compileTarget)
                 }
             }
+
             is Yaml -> undelimitedObjectProperty(indent, nextNode, compileTarget)
             is Json -> delimitedObjectProperty(indent, nextNode, compileTarget)
         }
     }
 
-    private fun delimitedObjectProperty(indent:Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
+    private fun delimitedObjectProperty(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         val delimitedPropertyIndent = if (value is ListNode || value is ObjectNode ||
             // check if we're compiling an embed block to an object
-            (compileTarget is Json && value is EmbedBlockNode && compileTarget.retainEmbedTags)) {
+            (compileTarget is Json && value is EmbedBlockNode && compileTarget.retainEmbedTags)
+        ) {
             // For delimited lists and objects, don't increase their indent here - they provide their own indent nest
             indent.clone(true)
         } else {
@@ -344,15 +351,16 @@ class ObjectPropertyNodeImpl(
             indent.next(true)
         }
         return key.toSourceWithNext(indent, value, compileTarget) + " " +
-                    value.toSourceWithNext(delimitedPropertyIndent, nextNode, compileTarget)
+                value.toSourceWithNext(delimitedPropertyIndent, nextNode, compileTarget)
     }
 
-    private fun undelimitedObjectProperty(indent:Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
+    private fun undelimitedObjectProperty(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return if (
             (value is ListNode && value.elements.isNotEmpty()) ||
             (value is ObjectNode && value.properties.isNotEmpty()) ||
             // check if we're compiling an embed block to an object
-            (compileTarget is Yaml && value is EmbedBlockNode && compileTarget.retainEmbedTags)) {
+            (compileTarget is Yaml && value is EmbedBlockNode && compileTarget.retainEmbedTags)
+        ) {
             // For non-empty lists and objects, put the value on the next line
             key.toSourceWithNext(indent, value, compileTarget) + "\n" +
                     value.toSourceWithNext(indent.next(false), nextNode, compileTarget)
@@ -368,7 +376,7 @@ class ObjectPropertyNodeImpl(
         val firstPropertyHasComments = if (value !is ObjectNode) {
             false
         } else {
-            when (val firstProperty = value.properties.firstOrNull()){
+            when (val firstProperty = value.properties.firstOrNull()) {
                 is ObjectPropertyNodeImpl -> firstProperty.comments.isNotEmpty()
                 null -> false
                 else -> false
@@ -391,22 +399,22 @@ class ListNode(
     val elements: List<ListElementNode>,
     location: Location
 ) : KsonValueNodeImpl(location) {
-    private sealed class ListDelimiters(val open: Char, val close: Char){
+    private sealed class ListDelimiters(val open: Char, val close: Char) {
         data object AngleBrackets : ListDelimiters('<', '>')
-        data object SquareBrackets: ListDelimiters('[', ']')
+        data object SquareBrackets : ListDelimiters('[', ']')
     }
 
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         val listDelimiter = when (compileTarget) {
-                is Kson -> ListDelimiters.AngleBrackets
-                is Yaml, is Json -> ListDelimiters.SquareBrackets
-            }
+            is Kson -> ListDelimiters.AngleBrackets
+            is Yaml, is Json -> ListDelimiters.SquareBrackets
+        }
         if (elements.isEmpty()) {
             return "${indent.firstLineIndent()}${listDelimiter.open}${listDelimiter.close}"
         }
         return when (compileTarget) {
             is Kson -> {
-                when(compileTarget.formatConfig.formattingStyle) {
+                when (compileTarget.formatConfig.formattingStyle) {
                     FormattingStyle.PLAIN -> {
                         val outputList = formatUndelimitedList(indent, nextNode, compileTarget)
                         /**
@@ -419,10 +427,17 @@ class ListNode(
                             outputList
                         }
                     }
+
                     FormattingStyle.DELIMITED -> formatDelimitedList(indent, nextNode, compileTarget, listDelimiter)
-                    FormattingStyle.COMPACT -> formatCompactList(indent, nextNode, compileTarget, ListDelimiters.SquareBrackets)
+                    FormattingStyle.COMPACT -> formatCompactList(
+                        indent,
+                        nextNode,
+                        compileTarget,
+                        ListDelimiters.SquareBrackets
+                    )
                 }
             }
+
             is Yaml -> formatUndelimitedList(indent, nextNode, compileTarget)
             is Json -> formatDelimitedList(indent, nextNode, compileTarget, listDelimiter)
         }
@@ -451,7 +466,12 @@ class ListNode(
                 indent.bodyLinesIndent() + listDelimiters.close
     }
 
-    private fun formatCompactList(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget, listDelimiters: ListDelimiters): String {
+    private fun formatCompactList(
+        indent: Indent,
+        nextNode: AstNode?,
+        compileTarget: CompileTarget,
+        listDelimiters: ListDelimiters
+    ): String {
         return elements.withIndex().joinToString(
             "",
             prefix = listDelimiters.open.toString(),
@@ -466,7 +486,7 @@ class ListNode(
 
 
             val isNotLastElement = index < elements.size - 1
-            
+
             // Extract current and next element values for type checking
             val currentValue = (element as? ListElementNodeImpl)?.value
             val currentIsObject = currentValue is ObjectNode
@@ -497,8 +517,8 @@ class ListNode(
 
 interface ListElementNode : AstNode
 class ListElementNodeError(content: String, location: Location) : AstNodeError(content, location), ListElementNode
-class ListElementNodeImpl(val value: KsonValueNode, override val comments: List<String>, location: Location)
-    : ListElementNode, AstNodeImpl(location), Documented {
+class ListElementNodeImpl(val value: KsonValueNode, override val comments: List<String>, location: Location) :
+    ListElementNode, AstNodeImpl(location), Documented {
 
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
@@ -552,9 +572,11 @@ abstract class StringNodeImpl(location: Location) : StringNode, KsonValueNodeImp
  *   including all escapes, but excluding the outer quotes.  A [Kson] string is escaped identically to a Json string,
  *   except that [Kson] allows raw whitespace to be embedded in strings
  */
-open class QuotedStringNode(private val ksonEscapedStringContent: String,
-                            private val stringQuote: StringQuote,
-                            location: Location) : StringNodeImpl(location) {
+open class QuotedStringNode(
+    private val ksonEscapedStringContent: String,
+    private val stringQuote: StringQuote,
+    location: Location
+) : StringNodeImpl(location) {
 
     /**
      * An "unquoted" Kson string: i.e. a valid Kson string with all escapes intact except for quote escapes.
@@ -576,22 +598,22 @@ open class QuotedStringNode(private val ksonEscapedStringContent: String,
                 val isSimple = StringUnquoted.isUnquotable(unquotedString)
 
                 indent.firstLineIndent() +
-                    if (isSimple) {
-                        unquotedString
-                    } else {
-                        val singleQuoteCount = SingleQuote.countDelimiterOccurrences(unquotedString)
-                        val doubleQuoteCount = DoubleQuote.countDelimiterOccurrences(unquotedString)
-
-                        // prefer single-quotes unless double-quotes would require less escaping
-                        val chosenDelimiter = if (doubleQuoteCount < singleQuoteCount) {
-                            DoubleQuote
+                        if (isSimple) {
+                            unquotedString
                         } else {
-                            SingleQuote
-                        }
+                            val singleQuoteCount = SingleQuote.countDelimiterOccurrences(unquotedString)
+                            val doubleQuoteCount = DoubleQuote.countDelimiterOccurrences(unquotedString)
 
-                    val escapedContent = chosenDelimiter.escapeQuotes(unquotedString)
-                    "${chosenDelimiter}$escapedContent${chosenDelimiter}"
-                }
+                            // prefer single-quotes unless double-quotes would require less escaping
+                            val chosenDelimiter = if (doubleQuoteCount < singleQuoteCount) {
+                                DoubleQuote
+                            } else {
+                                SingleQuote
+                            }
+
+                            val escapedContent = chosenDelimiter.escapeQuotes(unquotedString)
+                            "${chosenDelimiter}$escapedContent${chosenDelimiter}"
+                        }
             }
 
             is Yaml -> {
@@ -606,15 +628,15 @@ open class QuotedStringNode(private val ksonEscapedStringContent: String,
 }
 
 class UnquotedStringNode(override val stringContent: String, location: Location) : StringNodeImpl(location) {
-    val yamlReservedKeywords =  setOf(
+    val yamlReservedKeywords = setOf(
         // Boolean true values
-        "y","Y","yes","Yes","YES",
-        "true","True","TRUE",
-        "on","On","ON",
+        "y", "Y", "yes", "Yes", "YES",
+        "true", "True", "TRUE",
+        "on", "On", "ON",
         // Boolean false values
-        "n","N","no","No","NO",
-        "false","False","FALSE",
-        "off","Off","OFF",
+        "n", "N", "no", "No", "NO",
+        "false", "False", "FALSE",
+        "off", "Off", "OFF",
         // Null values
         "null", "Null", "NULL"
     )
@@ -626,9 +648,9 @@ class UnquotedStringNode(override val stringContent: String, location: Location)
             }
 
             is Yaml -> {
-                indent.firstLineIndent() + if (yamlReservedKeywords.contains(stringContent)){
+                indent.firstLineIndent() + if (yamlReservedKeywords.contains(stringContent)) {
                     "$DoubleQuote$stringContent$DoubleQuote"
-                }else{
+                } else {
                     stringContent
                 }
             }
@@ -646,13 +668,15 @@ class UnquotedStringNode(override val stringContent: String, location: Location)
 class NumberNode(stringValue: String, location: Location) : KsonValueNodeImpl(location) {
     val value: ParsedNumber by lazy {
         val parsedNumber = NumberParser(stringValue).parse()
-        parsedNumber.number ?: throw IllegalStateException("Hitting this indicates a parser bug: unparseable " +
-                "strings should be passed here but we got: " + stringValue)
+        parsedNumber.number ?: throw IllegalStateException(
+            "Hitting this indicates a parser bug: unparseable " +
+                    "strings should be passed here but we got: " + stringValue
+        )
     }
 
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
-            is Kson, is Yaml, is Json-> {
+            is Kson, is Yaml, is Json -> {
                 indent.firstLineIndent() + value.asString
             }
         }
@@ -672,7 +696,7 @@ class TrueNode(location: Location) : KsonValueNodeImpl(location) {
 class FalseNode(location: Location) : KsonValueNodeImpl(location) {
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
-            is Kson, is Yaml, is Json-> {
+            is Kson, is Yaml, is Json -> {
                 indent.firstLineIndent() + "false"
             }
         }
@@ -716,11 +740,11 @@ class EmbedBlockNode(
                     // without any escaping needed
                     percentCount == 0 ->
                         EmbedDelim.Percent to embedContent
-                    
+
                     // Otherwise, check if we can use the alternate delimiter without escaping
                     dollarCount == 0 ->
                         EmbedDelim.Dollar to EmbedDelim.Dollar.escapeEmbedContent(embedContent)
-                    
+
                     // We'll choose the delimiter that requires less escaping
                     else -> {
                         val chosenDelimiter = if (dollarCount < percentCount) EmbedDelim.Dollar else EmbedDelim.Percent
@@ -728,8 +752,8 @@ class EmbedBlockNode(
                     }
                 }
 
-                val embedPreamble = embedTag + if(metadataTag.isNotEmpty()) ": $metadataTag" else ""
-                when (compileTarget.formatConfig.formattingStyle){
+                val embedPreamble = embedTag + if (metadataTag.isNotEmpty()) ": $metadataTag" else ""
+                when (compileTarget.formatConfig.formattingStyle) {
                     FormattingStyle.PLAIN, FormattingStyle.DELIMITED -> {
                         // Format the embed block
                         indent.firstLineIndent() + delimiter.openDelimiter + embedPreamble + "\n" +
@@ -737,11 +761,12 @@ class EmbedBlockNode(
                             .joinToString("\n${indent.bodyLinesIndent()}") { it } +
                                 delimiter.closeDelimiter
                     }
+
                     FormattingStyle.COMPACT -> {
                         // Format the embed block
                         delimiter.openDelimiter + embedPreamble + "\n" +
                                 content.lines()
-                            .joinToString("\n") { it } +
+                                    .joinToString("\n") { it } +
                                 delimiter.closeDelimiter
                     }
                 }
@@ -754,6 +779,7 @@ class EmbedBlockNode(
                     encodeEmbedBlock(compileTarget, indent)
                 }
             }
+
             is Json -> {
                 if (!compileTarget.retainEmbedTags) {
                     indent.firstLineIndent() + "\"${renderForJsonString(embedContent)}\""
@@ -808,9 +834,9 @@ class EmbedBlockNode(
                         indent.firstLineIndent() + "${EmbedObjectKeys.EMBED_CONTENT.key}: " +
                         renderMultilineYamlString(embedContent, indent.clone(true), indent.next(true))
             }
+
             is Kson -> throw UnsupportedOperationException("should not encode embed block as ${compileTarget::class.simpleName}")
         }
-
     }
 
     /**

--- a/src/commonMain/kotlin/org/kson/parser/KsonBuilder.kt
+++ b/src/commonMain/kotlin/org/kson/parser/KsonBuilder.kt
@@ -398,8 +398,9 @@ class KsonBuilder(private val tokens: List<Token>, private val ignoreErrors: Boo
 
         val embedContentProperty = propertiesMap[EmbedObjectKeys.EMBED_CONTENT.key] ?:
             throw ShouldNotHappenException("should have been validated for nullability above")
+        val escapedContent = EmbedDelim.Percent.escapeEmbedContent(embedContentProperty.processedStringContent)
         val embedContentValue = QuotedStringNode(
-            StringQuote.SingleQuote.escapeQuotes(embedContentProperty.processedStringContent),
+            StringQuote.SingleQuote.escapeQuotes(escapedContent),
             StringQuote.SingleQuote,
             embedContentProperty.location
         )

--- a/src/commonMain/kotlin/org/kson/tools/Formatter.kt
+++ b/src/commonMain/kotlin/org/kson/tools/Formatter.kt
@@ -60,8 +60,10 @@ class IndentFormatter(
      *   should assume the snippet itself is already indented nested to a level of [snippetNestingLevel].
      * @return The indented KSON source code
      */
-    @Deprecated("This formatter is no long a good general purpose formatter. " +
-            "See the TODO in this class's doc for details")
+    @Deprecated(
+        "This formatter is no long a good general purpose formatter. " +
+                "See the TODO in this class's doc for details"
+    )
     private fun indent(source: String, snippetNestingLevel: Int? = null): String {
         if (source.isBlank() && snippetNestingLevel == null) return ""
         val tokens = Lexer(source, gapFree = true).tokenize()
@@ -104,7 +106,7 @@ class IndentFormatter(
                      * carefully preserved
                      */
                     EMBED_CONTENT -> {
-                        val embedContentIndent = if (line.subList(0,tokenIndex + 1).any {
+                        val embedContentIndent = if (line.subList(0, tokenIndex + 1).any {
                                 it.tokenType == COLON
                             }) {
                             /**
@@ -131,6 +133,7 @@ class IndentFormatter(
                         lineContent.clear()
                         break
                     }
+
                     COLON -> {
                         // if we're currently nested in a COLON, consider that nest closed on this line
                         // since we're starting a new object property
@@ -145,20 +148,22 @@ class IndentFormatter(
                         }
                         lineContent.add(token.lexeme.text)
                     }
+
                     in OPENING_DELIMITERS -> {
                         // register the indent from this opening delim
                         nextNests.add(token.tokenType)
                         lineContent.add(token.lexeme.text)
                     }
+
                     in CLOSING_DELIMITERS -> {
                         /**
                          * [CLOSING_DELIMITERS] that are part of a leading line of leading close delimiters
                          * on a line may trigger an immediate un-nest
                          */
                         if (line.subList(0, tokenIndex + 1).all {
-                            CLOSING_DELIMITERS.contains(it.tokenType)
-                                    || it.tokenType == WHITESPACE
-                        }) {
+                                CLOSING_DELIMITERS.contains(it.tokenType)
+                                        || it.tokenType == WHITESPACE
+                            }) {
                             if (nesting.lastOrNull() == COLON) {
                                 /**
                                  * If we spot a [COLON] nest as we're closing things, that must be closed too:
@@ -176,6 +181,7 @@ class IndentFormatter(
                         }
                         lineContent.add(token.lexeme.text)
                     }
+
                     else -> {
                         lineContent.add(token.lexeme.text)
                     }
@@ -265,7 +271,7 @@ class IndentFormatter(
         while (startIndex < tokens.size && tokens[startIndex].tokenType == WHITESPACE) {
             startIndex++
         }
-        
+
         var index = startIndex
         while (index < tokens.size) {
             val token = tokens[index]
@@ -288,12 +294,13 @@ class IndentFormatter(
                 val nextToken = tokens.getOrNull(index + 1)
                 if (nextToken?.tokenType == COMMENT) {
                     var commentToken: Token = nextToken
-                    while(commentToken.tokenType == COMMENT
-                        || (commentToken.tokenType == WHITESPACE && commentToken.lexeme.text.contains('\n'))) {
+                    while (commentToken.tokenType == COMMENT
+                        || (commentToken.tokenType == WHITESPACE && commentToken.lexeme.text.contains('\n'))
+                    ) {
                         index++
                         if (commentToken.tokenType == WHITESPACE) {
                             val numNewlines = commentToken.lexeme.text.count { it == '\n' }
-                            repeat (numNewlines) {
+                            repeat(numNewlines) {
                                 currentLine.add(commentToken.copy(lexeme = commentToken.lexeme.copy(text = "\n")))
                             }
                         } else {

--- a/src/commonTest/kotlin/org/kson/KsonCoreTestEmbedBlock.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestEmbedBlock.kt
@@ -443,7 +443,7 @@ class KsonCoreTestEmbedBlock : KsonCoreTest {
             """
                 embedBlock: %
                   embeddedEmbed: $
-                  EMBED WITH %\% CONTENT
+                  EMBED WITH %\\% CONTENT
                   $$
                   %%
             """.trimIndent(),
@@ -451,14 +451,14 @@ class KsonCoreTestEmbedBlock : KsonCoreTest {
                 embedBlock:
                   embedContent: |
                     embeddedEmbed: ${'$'}
-                    EMBED WITH %% CONTENT
+                    EMBED WITH %\% CONTENT
                     ${'$'}${'$'}
                     
             """.trimIndent(),
             """
                 {
                   "embedBlock": {
-                    "embedContent": "embeddedEmbed: ${'$'}\nEMBED WITH %% CONTENT\n${'$'}${'$'}\n"
+                    "embedContent": "embeddedEmbed: ${'$'}\nEMBED WITH %\\% CONTENT\n${'$'}${'$'}\n"
                   }
                 }
             """.trimIndent(), compileSettings = compileSettings

--- a/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
+++ b/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
@@ -21,9 +21,9 @@ class FormatterTest {
         /**
          * TODO There are two test cases that currently can't roundtrip. After we handled these corner cases we should
          * roundtrip for every test.
-        **/
+         **/
         var roundtripKson = formattedKson
-        if(roundTrip){
+        if (roundTrip) {
             FormattingStyle.entries.filter { it != formattingStyle }.forEach { intermediateStyle ->
                 roundtripKson = format(roundtripKson, KsonFormatterConfig(indentType, intermediateStyle))
             }
@@ -45,7 +45,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testColonWithWhitespace(){
+    fun testColonWithWhitespace() {
         assertFormatting(
             """
             {
@@ -435,7 +435,8 @@ class FormatterTest {
               # comment
               # comment
               y: 12
-            """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     @Test
@@ -472,7 +473,7 @@ class FormatterTest {
         )
 
     }
-    
+
     @Test
     fun testEmbedBlocksAtDifferentNestingLevels() {
         assertFormatting(
@@ -746,7 +747,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testFormattingMixedUnnesting(){
+    fun testFormattingMixedUnnesting() {
         assertFormatting(
             """
             outer_key1: {
@@ -1014,149 +1015,237 @@ class FormatterTest {
     fun testGetCurrentLineIndentLevel() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("{"),
-            "should indent one level after opening brace")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("  {"),
-            "should indent one level after opening brace with existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("{"),
+            "should indent one level after opening brace"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("  {"),
+            "should indent one level after opening brace with existing indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("key:"),
-            "should indent one level after colon")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("  key:"),
-            "should indent one level after colon with existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("key:"),
+            "should indent one level after colon"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("  key:"),
+            "should indent one level after colon with existing indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("<"),
-            "should indent one level after opening angle bracket")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("  <"),
-            "should indent one level after opening angle bracket with existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("<"),
+            "should indent one level after opening angle bracket"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("  <"),
+            "should indent one level after opening angle bracket with existing indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  - item"),
-            "should maintain indent after dash in list")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  - item"),
+            "should maintain indent after dash in list"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  }"),
-            "should match closing brace indent")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    }"),
-            "should match closing brace indent with higher existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  }"),
+            "should match closing brace indent"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    }"),
+            "should match closing brace indent with higher existing indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  >"),
-            "should match closing angle bracket indent")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    >"),
-            "should match closing angle bracket indent with higher existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  >"),
+            "should match closing angle bracket indent"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    >"),
+            "should match closing angle bracket indent with higher existing indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  some text"),
-            "should maintain indent for normal lines")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    other text"),
-            "should maintain indent for normal lines with higher existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  some text"),
+            "should maintain indent for normal lines"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    other text"),
+            "should maintain indent for normal lines with higher existing indent"
+        )
     }
 
     @Test
     fun testEmptyLineIndentLevel() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  "),
-            "should maintain previous indent for empty lines")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    "),
-            "should maintain previous indent for empty lines with higher existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  "),
+            "should maintain previous indent for empty lines"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    "),
+            "should maintain previous indent for empty lines with higher existing indent"
+        )
     }
 
     @Test
     fun testGetCurrentLineIndentLevelWithTabs() {
         val formatter = IndentFormatter(IndentType.Tab())
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("{"),
-            "should indent one level after opening brace with tab indentation")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("\t{"),
-            "should indent one level after opening brace with existing tab indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("{"),
+            "should indent one level after opening brace with tab indentation"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("\t{"),
+            "should indent one level after opening brace with existing tab indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("key:"),
-            "should indent one level after colon with tab indentation")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("\tkey:"),
-            "should indent one level after colon with existing tab indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("key:"),
+            "should indent one level after colon with tab indentation"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("\tkey:"),
+            "should indent one level after colon with existing tab indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("\tsome text"),
-            "should maintain indent for normal lines with tab indentation")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("\t\tother text"),
-            "should maintain indent for normal lines with higher existing tab indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("\tsome text"),
+            "should maintain indent for normal lines with tab indentation"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("\t\tother text"),
+            "should maintain indent for normal lines with higher existing tab indent"
+        )
     }
 
     @Test
     fun testGetCurrentLineIndentLevelWithEmbedBlocks() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(0, formatter.getCurrentLineIndentLevel("%%sql"),
-            "should not change indent for embed block start")
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  %%sql"),
-            "should not change indent for embed block start with existing indent")
+        assertEquals(
+            0, formatter.getCurrentLineIndentLevel("%%sql"),
+            "should not change indent for embed block start"
+        )
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  %%sql"),
+            "should not change indent for embed block start with existing indent"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  SELECT *"),
-            "should maintain indent inside embed block")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  SELECT *"),
+            "should maintain indent inside embed block"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  %%"),
-            "should decrease indent after embed block end")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    %%"),
-            "should decrease indent after embed block end with higher existing indent")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  %%"),
+            "should decrease indent after embed block end"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    %%"),
+            "should decrease indent after embed block end with higher existing indent"
+        )
     }
 
     @Test
     fun testGetCurrentLineIndentLevelWithMixedStructures() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("{"),
-            "should properly indent for nested structures")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("  nested: {"),
-            "should properly indent for nested object properties")
-        assertEquals(3, formatter.getCurrentLineIndentLevel("    items: <"),
-            "should properly indent for nested angle brackets")
-        assertEquals(3, formatter.getCurrentLineIndentLevel("    - {"),
-            "should properly indent for nested list items")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("{"),
+            "should properly indent for nested structures"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("  nested: {"),
+            "should properly indent for nested object properties"
+        )
+        assertEquals(
+            3, formatter.getCurrentLineIndentLevel("    items: <"),
+            "should properly indent for nested angle brackets"
+        )
+        assertEquals(
+            3, formatter.getCurrentLineIndentLevel("    - {"),
+            "should properly indent for nested list items"
+        )
 
-        assertEquals(3, formatter.getCurrentLineIndentLevel("      }"),
-            "should properly indent after closing nested delimiters")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    >"),
-            "should properly indent after closing angle brackets")
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  }"),
-            "should properly indent after closing outer brace")
+        assertEquals(
+            3, formatter.getCurrentLineIndentLevel("      }"),
+            "should properly indent after closing nested delimiters"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    >"),
+            "should properly indent after closing angle brackets"
+        )
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  }"),
+            "should properly indent after closing outer brace"
+        )
     }
 
     @Test
     fun testGetCurrentLineIndentLevelWithMultipleChanges() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(2, formatter.getCurrentLineIndentLevel("{ {"),
-            "should increase indent by more than 1 for multiple opening delimiters on one line")
-        assertEquals(3, formatter.getCurrentLineIndentLevel("{ { {"),
-            "should increase indent by multiple levels for three opening delimiters")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("key: {nested: {"),
-            "should increase indent by more than 1 for nested properties")
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("{ {"),
+            "should increase indent by more than 1 for multiple opening delimiters on one line"
+        )
+        assertEquals(
+            3, formatter.getCurrentLineIndentLevel("{ { {"),
+            "should increase indent by multiple levels for three opening delimiters"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("key: {nested: {"),
+            "should increase indent by more than 1 for nested properties"
+        )
 
-        assertEquals(1, formatter.getCurrentLineIndentLevel("  } }"),
-            "should have no effect on the next line for multiple closing delimiters as they unindent their own line")
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    } } }"),
-            "should maintain existing indent levels for multiple closing delimiters")
+        assertEquals(
+            1, formatter.getCurrentLineIndentLevel("  } }"),
+            "should have no effect on the next line for multiple closing delimiters as they unindent their own line"
+        )
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    } } }"),
+            "should maintain existing indent levels for multiple closing delimiters"
+        )
     }
 
     @Test
     fun testGetCurrentLineIndentLevelWithDeferredClosures() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(0, formatter.getCurrentLineIndentLevel("key:val }}}"),
-            "should trigger an unindent on the next line, not their own line, for non-leading close delimiters")
-        assertEquals(4, formatter.getCurrentLineIndentLevel("              key:val }}}"),
-            "should maintain existing indent for trailing delimiters with leading spaces")
+        assertEquals(
+            0, formatter.getCurrentLineIndentLevel("key:val }}}"),
+            "should trigger an unindent on the next line, not their own line, for non-leading close delimiters"
+        )
+        assertEquals(
+            4, formatter.getCurrentLineIndentLevel("              key:val }}}"),
+            "should maintain existing indent for trailing delimiters with leading spaces"
+        )
     }
 
     @Test
     fun testGetCurrentLineIndentLevelWithNestedClosures() {
         val formatter = IndentFormatter(IndentType.Space(2))
 
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    }}"),
-            "should handle multiple nested structures closing at once")
-        assertEquals(3, formatter.getCurrentLineIndentLevel("      }}}"),
-            "should handle three nested structures closing at once")
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    }}"),
+            "should handle multiple nested structures closing at once"
+        )
+        assertEquals(
+            3, formatter.getCurrentLineIndentLevel("      }}}"),
+            "should handle three nested structures closing at once"
+        )
 
-        assertEquals(2, formatter.getCurrentLineIndentLevel("    }>"),
-            "should work with mixed bracket types")
-        assertEquals(3, formatter.getCurrentLineIndentLevel("      ]}>"),
-            "should work with multiple mixed bracket types")
+        assertEquals(
+            2, formatter.getCurrentLineIndentLevel("    }>"),
+            "should work with mixed bracket types"
+        )
+        assertEquals(
+            3, formatter.getCurrentLineIndentLevel("      ]}>"),
+            "should work with multiple mixed bracket types"
+        )
     }
 
     @Test
@@ -1359,7 +1448,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testDelimitedFormattingStyleLists(){
+    fun testDelimitedFormattingStyleLists() {
         assertFormatting(
             """
                 list: [1,2,3]
@@ -1711,7 +1800,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testPlainFormattingEmptyObject(){
+    fun testPlainFormattingEmptyObject() {
         assertFormatting(
             """
                 key:
@@ -1725,7 +1814,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testDelimitedFormattingEmptyObject(){
+    fun testDelimitedFormattingEmptyObject() {
         assertFormatting(
             """
                 key:
@@ -1741,7 +1830,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testCompactFormattingEmptyObject(){
+    fun testCompactFormattingEmptyObject() {
         assertFormatting(
             """
                 key: {}
@@ -1754,7 +1843,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testPlainFormattingEmptyList(){
+    fun testPlainFormattingEmptyList() {
         assertFormatting(
             """
                 key:
@@ -1768,7 +1857,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testDelimitedFormattingEmptyList(){
+    fun testDelimitedFormattingEmptyList() {
         assertFormatting(
             """
                 key:
@@ -1784,7 +1873,7 @@ class FormatterTest {
     }
 
     @Test
-    fun testCompactFormattingEmptyList(){
+    fun testCompactFormattingEmptyList() {
         assertFormatting(
             """
                 key: <>


### PR DESCRIPTION
Found a small bug in the way we handled escaping while decoding embed blocks. Fixed that in d3122b0b24a73111a60eb2f3094b918b321dee26. 
The other two commits contain some reformatting and a refactoring of the `EmbedBlockNode`.