### PR TITLE
Use a value-based "logical" equals for KsonValue

### DIFF
--- a/src/commonMain/kotlin/org/kson/schema/validators/ConstValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/ConstValidator.kt
@@ -14,7 +14,7 @@ import org.kson.value.KsonString
 
 class ConstValidator(private val const: KsonValue) : JsonSchemaValidator {
     override fun validate(ksonValue: KsonValue, messageSink: MessageSink) {
-        if (!ksonValue.dataEquals(const)) {
+        if (ksonValue != const) {
             val requiredValue = when (const) {
                 is KsonNull -> "null"
                 is KsonBoolean -> const.value.toString()

--- a/src/commonMain/kotlin/org/kson/schema/validators/EnumValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/EnumValidator.kt
@@ -8,10 +8,8 @@ import org.kson.schema.JsonSchemaValidator
 
 class EnumValidator(private val enum: KsonList) : JsonSchemaValidator {
     override fun validate(ksonValue: KsonValue, messageSink: MessageSink) {
-        val enumMatch = enum.elements.any {
-            it.dataEquals(ksonValue)
-        }
-        if (!enumMatch) {
+        val enumValues = enum.elements
+        if (!enumValues.contains(ksonValue)) {
             messageSink.error(ksonValue.location, MessageType.SCHEMA_ENUM_VALUE_NOT_ALLOWED.create())
         }
     }

--- a/src/commonMain/kotlin/org/kson/schema/validators/UniqueItemsValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/UniqueItemsValidator.kt
@@ -19,7 +19,7 @@ class UniqueItemsValidator(private val uniqueItems: Boolean) : JsonArrayValidato
     private fun areItemsUnique(elements: List<KsonValue>): Boolean {
         for (i in elements.indices) {
             for (j in i + 1 until elements.size) {
-                if (elements[i].dataEquals(elements[j])) {
+                if (elements[i] == elements[j]) {
                     return false
                 }
             }


### PR DESCRIPTION
We toyed with being more strict in d05967d3, but in practice we had it right initially: KsonValue equals should be implemented as a logical equals based on the underlying value.

This makes a KsonValue tree much more ergonomic to work with because the values really then become _values_ that can be compared as such.