### PR TITLE
Fix empty javadoc jars in Maven releases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
     id("com.vanniktech.maven.publish") version "0.30.0"
+    id("org.jetbrains.dokka") version "2.0.0"
 
     // configured by `jvmWrapper` block below
     id("me.filippov.gradle.jvm.wrapper") version "0.14.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,8 @@ org.gradle.jvmargs=-Xmx2048m
 # setting (https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1789)
 kotlin.stdlib.default.dependency = true
 
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+# disable the DokkaV2 welcome message in the build
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
+
 org.gradle.console=verbose

--- a/kson-lib/build.gradle.kts
+++ b/kson-lib/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.konan.target.HostManager
 plugins {
     kotlin("multiplatform")
     id("com.vanniktech.maven.publish") version "0.30.0"
+    id("org.jetbrains.dokka") version "2.0.0"
 }
 
 repositories {


### PR DESCRIPTION
Our Maven publishing was creating empty Javadoc JARs because the vanniktech maven publish plugin defaults to JavadocJar.Empty() for Kotlin Multiplatform projects (see [here](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/d0e50fec7a07ef91fde62ae5cb0e4b4b4769d797/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt#L314))

 This change reintroduces Dokka to generate proper javadoc jars for our Kotlin publications (I mistakenly removed Dokka in 672862a because I did not realize the generated javadoc jars were empty)