### PR TITLE
Update clean task

### DIFF
--- a/tooling/language-server-protocol/build.gradle.kts
+++ b/tooling/language-server-protocol/build.gradle.kts
@@ -22,4 +22,9 @@ tasks {
     check {
         dependsOn("npm_run_test")
     }
+
+    clean {
+        delete("out")
+        delete("node_modules")
+    }
 }

--- a/tooling/lsp-clients/build.gradle.kts
+++ b/tooling/lsp-clients/build.gradle.kts
@@ -42,4 +42,14 @@ tasks {
          */
         dependsOn(buildVsCode)
     }
+
+    clean {
+        delete("node_modules")
+        delete("vscode/out")
+        delete("vscode/dist")
+        delete("vscode/node_modules")
+        delete("monaco/dist")
+        delete("monaco/node_modules")
+        delete("shared/out")
+    }
 }


### PR DESCRIPTION
The clean task did not remove `node_modules`, `dist` and `out` folders in JS/TS projects. Sometimes this resulted in weird build errors and we would need to remove these folders manually. Now a `./gradlew clean && ./gradlew check` properly cleans the project.