### PR TITLE
Change filter in CI to branch filter

### DIFF
--- a/.circleci/config.kson
+++ b/.circleci/config.kson
@@ -250,7 +250,7 @@ jobs:
           command: 'google-chrome --version'
 
       - 'restore-gradle-caches':
-            platform: 'linux-amd64'
+          platform: 'linux-amd64'
       # Linux-specific installations
       - run:
           name: 'Install system dependencies'
@@ -399,19 +399,12 @@ workflows:
       - 'build-linux-amd64'
       - 'build-windows-amd64':
           filters:
-            tags:
-              only: '/^v\\d+\\.\\d+\\.\\d+$/'
-              .
             branches:
-              ignore: '/.*/'
-
+              only: '/release.*\\d+\\.\\d+\\.\\d+$/'
       - 'build-macos-arm64':
           filters:
-            tags:
-              only: '/^v\\d+\\.\\d+\\.\\d+$/'
-              .
             branches:
-              ignore: '/.*/'
+              only: '/release.*\\d+\\.\\d+\\.\\d+$/'
               .
             .
           .
@@ -421,40 +414,25 @@ workflows:
     jobs:
       - 'build-python-sdist':
           filters:
-            tags:
-              only: '/^v\\d+\\.\\d+\\.\\d+$/'
-              .
             branches:
-              ignore: '/.*/'
-
+              only: '/release.*\\d+\\.\\d+\\.\\d+$/'
       - 'test-python-sdist-linux-amd64':
           requires:
             - 'build-python-sdist'
           filters:
-            tags:
-              only: '/^v\\d+\\.\\d+\\.\\d+$/'
-              .
             branches:
-              ignore: '/.*/'
-
+              only: '/release.*\\d+\\.\\d+\\.\\d+$/'
 
       - 'test-python-sdist-macos':
           requires:
             - 'build-python-sdist'
           filters:
-            tags:
-              only: '/^v\\d+\\.\\d+\\.\\d+$/'
-              .
             branches:
-              ignore: '/.*/'
-
+              only: '/release.*\\d+\\.\\d+\\.\\d+$/'
 
       - 'test-python-sdist-windows':
           requires:
             - 'build-python-sdist'
           filters:
-            tags:
-              only: '/^v\\d+\\.\\d+\\.\\d+$/'
-              .
             branches:
-              ignore: '/.*/'
+              only: '/release.*\\d+\\.\\d+\\.\\d+$/'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,52 +362,35 @@ workflows:
       - "build-linux-amd64"
       - "build-windows-amd64":
           filters:
-            tags:
-              only: "/^v\\d+\\.\\d+\\.\\d+$/"
             branches:
-              ignore: "/.*/"
-
+              only: "/release.*\\d+\\.\\d+\\.\\d+$/"
       - "build-macos-arm64":
           filters:
-            tags:
-              only: "/^v\\d+\\.\\d+\\.\\d+$/"
             branches:
-              ignore: "/.*/"
-
+              only: "/release.*\\d+\\.\\d+\\.\\d+$/"
   "build-python-and-test":
     jobs:
       - "build-python-sdist":
           filters:
-            tags:
-              only: "/^v\\d+\\.\\d+\\.\\d+$/"
             branches:
-              ignore: "/.*/"
-
+              only: "/release.*\\d+\\.\\d+\\.\\d+$/"
       - "test-python-sdist-linux-amd64":
           requires:
             - "build-python-sdist"
           filters:
-            tags:
-              only: "/^v\\d+\\.\\d+\\.\\d+$/"
             branches:
-              ignore: "/.*/"
-
+              only: "/release.*\\d+\\.\\d+\\.\\d+$/"
 
       - "test-python-sdist-macos":
           requires:
             - "build-python-sdist"
           filters:
-            tags:
-              only: "/^v\\d+\\.\\d+\\.\\d+$/"
             branches:
-              ignore: "/.*/"
-
+              only: "/release.*\\d+\\.\\d+\\.\\d+$/"
 
       - "test-python-sdist-windows":
           requires:
             - "build-python-sdist"
           filters:
-            tags:
-              only: "/^v\\d+\\.\\d+\\.\\d+$/"
             branches:
-              ignore: "/.*/"
+              only: "/release.*\\d+\\.\\d+\\.\\d+$/"


### PR DESCRIPTION
Initially we were filtering the jobs on a specific tag. However, that has as drawback that we first need to tag a commit before CircleCI can run all jobs.

Instead of filtering on tags we filter on branch names that match the following regex-pattern: `release.*\d+\.\d+\.\d+$`