### PR TITLE
fix python sdist gradle failure

### DIFF
--- a/lib-python/MANIFEST.in
+++ b/lib-python/MANIFEST.in
@@ -8,6 +8,7 @@ recursive-include src *.c
 recursive-include kson-sdist *.kts *.kt *.properties *.md
 # Include Python source files from kson-sdist
 recursive-include kson-sdist *.py
+include kson-sdist/.circleci/config.kson
 include kson-sdist/gradlew
 include kson-sdist/gradlew.bat
 include kson-sdist/buildSrc/gradlew

--- a/lib-python/build.gradle.kts
+++ b/lib-python/build.gradle.kts
@@ -84,7 +84,12 @@ tasks {
         from(rootProject.file("gradle/wrapper")) {
             into("gradle/wrapper")
         }
-        
+
+        // Need this file to satisfy the `transpileCircleCiConfigTask`
+        from(rootProject.file(".circleci/config.kson")){
+            into(".circleci")
+        }
+
         // Copy build configuration files
         from(rootProject.file("build.gradle.kts"))
         from(rootProject.file("settings.gradle.kts"))


### PR DESCRIPTION
A problem was found with the configuration of task ':transpileCircleCiConfigTask' (type 'TranspileKsonToYaml').
 - Type 'TranspileKsonToYaml' property 'ksonFile' specifies file '/tmp/pip-req-build-hc_ilai8/kson-sdist/.circleci/config.kson' which doesn't exist.

By adding `.circleci/config.kson` during the copying of the source distribution we don't fail this gradle task during the build from sdist.