### PR TITLE
Improve duplicate key detection comparisons

### DIFF
--- a/src/commonMain/kotlin/org/kson/validation/DuplicateKeyValidator.kt
+++ b/src/commonMain/kotlin/org/kson/validation/DuplicateKeyValidator.kt
@@ -63,7 +63,7 @@ class DuplicateKeyValidator {
         objNode.properties.filterIsInstance<ObjectPropertyNodeImpl>().forEach {
             // Get the property key as string
             val keyString = if (it.key is ObjectKeyNodeImpl && it.key.key is StringNodeImpl) {
-                it.key.key.stringContent
+                it.key.key.processedStringContent
             } else {
                 ""
             }

--- a/src/commonTest/kotlin/org/kson/validation/DuplicateKeyValidatorTest.kt
+++ b/src/commonTest/kotlin/org/kson/validation/DuplicateKeyValidatorTest.kt
@@ -127,4 +127,19 @@ class DuplicateKeyValidatorTest {
         val result = KsonCore.parseToAst(source)
         assertTrue(result.messages.isEmpty(), "Same key in different objects should be allowed")
     }
+
+    @Test
+    fun testEquivalentKeyWithDifferentStringIsNotAllowed() {
+        val source = """
+            # these two keys are identical in spite of being represented differently
+            'key with\nnewline': 1
+            'key with
+            newline': 1
+        """.trimIndent()
+
+        val messages = KsonCore.parseToAst(source).messages
+        assertEquals(1, messages.size, "Should have errors for duplicate keys in list objects")
+
+        assertEquals(OBJECT_DUPLICATE_KEY, messages[0].message.type, "should have duplicate key error")
+    }
 }


### PR DESCRIPTION
We were doing duplicate detection against the raw source value of string keys, but this naturally misses cases where two strings are semantically identical in spite of being expressed slightly differently in the raw.