### PR TITLE
add platforms to pixi and constrain dependencies

### DIFF
--- a/kson-lib/pixi.toml
+++ b/kson-lib/pixi.toml
@@ -2,10 +2,16 @@
 authors = ["Adolfo Ochagavía <github@adolfo.ochagavia.nl>"]
 channels = ["conda-forge"]
 name = "kson"
-platforms = ["win-64"]
+platforms = [
+    "linux-64",
+    "linux-aarch64",
+    "osx-arm64",
+    "osx-64",
+    "win-64",
+]
 version = "0.1.0"
 
 [tasks]
 
-[dependencies]
+[target.win-64.dependencies]
 vs2022_win-64 = ">=19.44.35207,<20"

--- a/tooling/cli/pixi.toml
+++ b/tooling/cli/pixi.toml
@@ -2,7 +2,13 @@
 authors = ["Adolfo Ochagavía <github@adolfo.ochagavia.nl>"]
 channels = ["conda-forge"]
 name = "cli"
-platforms = ["win-64"]
+platforms = [
+    "linux-64",
+    "linux-aarch64",
+    "osx-arm64",
+    "osx-64",
+    "win-64",
+]
 version = "0.1.0"
 
 [tasks]


### PR DESCRIPTION
I don't fully understand why, but suddenly we started getting test failures in CircleCI (but not on Mac):
```
Task :tooling:cli:buildNativeImage FAILED
Building native image with GraalVM using pixi
Creating executable: /home/circleci/repo/tooling/cli/build/native/nativeCompile/kson
Pixi wrapper not found at ./pixiw, generating...
Generated Pixi wrapper scripts in /home/circleci/repo/tooling/cli

> Task :kson-lib:jsProductionLibraryValidateGeneratedByCompilerTypeScript
> Task :kson-lib:jsProductionLibraryCompileSync
> Task :kson-tooling-lib:jsProductionLibraryValidateGeneratedByCompilerTypeScript
> Task :tooling:jetbrains:compileKotlin
104 actionable tasks: 102 executed, 2 up-to-date
<-------------> 0% WAITING
> IDLE
> IDLE
> IDLE
> IDLE

  │ Add it with 'pixi workspace platform add linux-64'.
  help: supported platforms are win-64


FAILURE: Build failed with an exception.
```

This fixes the build