### PR TITLE
fix bug in compact formatting

### DIFF
--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -527,8 +527,17 @@ class ListNode(
 
             // Determine formatting based on context
             when {
-                // Both objects need a dot separator, with space if current ends with number
-                (isNotLastElement && currentIsObject && nextIsObject) -> "{$elementString}"
+                // Both objects need a separator when both are non-empty
+                (isNotLastElement && currentIsObject && nextIsObject) -> {
+                    val currentIsEmptyObject = currentValue.properties.isEmpty()
+                    if (currentIsEmptyObject) {
+                        // Empty objects already have braces, don't wrap them
+                        "$elementString "
+                    } else {
+                        // Non-empty objects need to be wrapped to separate from the next object
+                        "{$elementString}"
+                    }
+                }
 
                 // Add space between elements in a list, except when the element is a list
                 isNotLastElement && element is ListElementNodeImpl && element.value !is ListNode -> {

--- a/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
+++ b/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
@@ -1817,6 +1817,18 @@ class FormatterTest {
             """.trimIndent(),
             formattingStyle = FormattingStyle.PLAIN
         )
+
+        assertFormatting(
+            """
+                  - {}
+                  - items: {}
+            """.trimIndent(),
+            """
+                  - {}
+                  - items: {}
+            """.trimIndent(),
+            formattingStyle = FormattingStyle.PLAIN
+        )
     }
 
     @Test


### PR DESCRIPTION
The kson document:
```
- {}
- items: {}
```
formatted to
```
- {
- }
- items: {}
```
after roundtripping through compact mode.

Compact mode formats this document to:
```
[{{}}items:{}]
```
due to a mistake in handling the delimiters.