### PR TITLE
Fix browser tests hanging due to VS Code ESM migration

### DIFF
--- a/tooling/lsp-clients/vscode/test/runTests.ts
+++ b/tooling/lsp-clients/vscode/test/runTests.ts
@@ -37,7 +37,9 @@ async function main() {
                 extensionTestsPath: extensionBrowserTestsPath,
                 folderPath: testWorkspacePath,
                 headless: false,
-                permissions: ['clipboard-read', 'clipboard-write']
+                permissions: ['clipboard-read', 'clipboard-write'],
+                quality: 'stable',
+                commit: '994fd12f8d3a5aa16f17d42c041e5809167e845a'
             });
         }
 


### PR DESCRIPTION
VS Code "Insiders" builds have migrated from AMD to ESM modules, removing loader.js and causing @vscode/test-web to fail with 404s for core VS Code files. This results in our Monaco tests opening the browser, but hanging there waiting for anything to load.

The root cause here is that by previously not pinning to a precise version of VS Code, we effectively had a SNAPSHOT dependency on the VS Code we pull in for test. So this means that all our historical builds hang here too, which is a shame. We're a bit lucky in that the historical tests don't _fail_ and when you exit the hanging browser the test proceed, but it's always best to have builds be as reproducible as possible.