### PR TITLE
add task to help installing `npm dependencies`

### DIFF
--- a/kson-lib/build.gradle.kts
+++ b/kson-lib/build.gradle.kts
@@ -108,6 +108,26 @@ tasks.register("copyNodeDistribution") {
     }
 }
 
+/**
+ * Task to install npm dependencies in the production library output directory.
+ *
+ * This task is used when you need to prepare the production library with its dependencies
+ * installed.
+ * 
+ * This will:
+ * 1. Build the production library (via jsNodeProductionLibraryDistribution)
+ * 2. Run 'npm install' in build/dist/js/productionLibrary
+ * 3. Install all dependencies specified in the library's package.json
+ */
+tasks.register<PixiExecTask>("npmInstallProductionLibrary") {
+    description = "Install npm dependencies in the production library output"
+    dependsOn("jsNodeProductionLibraryDistribution")
+
+    command.set(listOf("npm", "install"))
+    workingDirectory.set(layout.buildDirectory.dir("dist/js/productionLibrary"))
+    doNotTrackState("npm already tracks its own state")
+}
+
 // Configure task ordering to ensure sequential execution
 afterEvaluate {
     tasks.named("jsNodeProductionLibraryDistribution") {


### PR DESCRIPTION
Task to install npm dependencies in the production library output directory. This is necessary to install transitive npm dependencies in package.json. Otherwise, downstream packages (like language-server-protocol) won't be able to use `kson-lib` as local file dependency.

The task is essentially a helper for running:
```
cd ./kson-lib/build/dist/js/productionLibrary
npm install
```