### PR TITLE
configure file extensions from package.json

### DIFF
--- a/tooling/lsp-clients/vscode/src/client/browser/ksonClientMain.ts
+++ b/tooling/lsp-clients/vscode/src/client/browser/ksonClientMain.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/browser';
 import { createClientOptions } from '../../config/clientOptions';
+import { initializeLanguageConfig } from '../../config/languageConfig';
 import {deactivate} from '../common/deactivate';
 
 /**
@@ -8,6 +9,9 @@ import {deactivate} from '../common/deactivate';
  * This handles VS Code Web and GitHub.dev environments where we run in a browser.
  */
 export async function activate(context: vscode.ExtensionContext) {
+    // Initialize language configuration from package.json
+    initializeLanguageConfig(context.extension.packageJSON);
+
     // Create log output channel
     const logOutputChannel = vscode.window.createOutputChannel('Kson Language Server', { log: true });
     context.subscriptions.push(logOutputChannel);
@@ -23,9 +27,14 @@ export async function activate(context: vscode.ExtensionContext) {
         // In test environments, we need to support the vscode-test-web scheme
         // This is only needed for the test runner, not in production
         if (context.extensionMode === vscode.ExtensionMode.Test) {
+            // Add test scheme for all configured language IDs
+            const testSelectors = (clientOptions.documentSelector || []).map((selector: any) => ({
+                ...selector,
+                scheme: 'vscode-test-web'
+            }));
             clientOptions.documentSelector = [
                 ...(clientOptions.documentSelector || []),
-                { scheme: 'vscode-test-web', language: 'kson' }
+                ...testSelectors
             ];
         }
 

--- a/tooling/lsp-clients/vscode/src/config/clientOptions.ts
+++ b/tooling/lsp-clients/vscode/src/config/clientOptions.ts
@@ -3,23 +3,34 @@ import {
     LanguageClientOptions,
     ErrorAction,
     CloseAction,
+    DocumentSelector,
 } from 'vscode-languageclient';
+import { getLanguageConfiguration } from './languageConfig';
 
 // Create shared client options
 export const createClientOptions = (outputChannel: vscode.OutputChannel): LanguageClientOptions => {
+    const { languageIds, fileExtensions } = getLanguageConfiguration();
+
+    // Build document selector for all supported language IDs
+    const documentSelector: DocumentSelector = languageIds.flatMap(languageId => [
+        { scheme: 'file', language: languageId },
+        { scheme: 'untitled', language: languageId }
+    ]);
+
+    // Build file watcher pattern for all file extensions
+    const fileWatcherPattern = fileExtensions.length > 1
+        ? `**/*.{${fileExtensions.join(',')}}`
+        : `**/*.${fileExtensions[0]}`;
 
     return {
-        documentSelector: [
-            {scheme: 'file', language: 'kson'},
-            {scheme: 'untitled', language: 'kson'}
-        ],
+        documentSelector,
         synchronize: {
             /**
              * TODO - Even though this setting is deprecated it is the easiest way to get configuration going.
              * We should find a way in the future to replace this with the /pull model.
              */
             configurationSection: 'kson',
-            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.kson')
+            fileEvents: vscode.workspace.createFileSystemWatcher(fileWatcherPattern)
         },
         outputChannel,
         errorHandler: {

--- a/tooling/lsp-clients/vscode/src/config/languageConfig.ts
+++ b/tooling/lsp-clients/vscode/src/config/languageConfig.ts
@@ -1,0 +1,42 @@
+export interface LanguageConfiguration {
+    languageIds: string[];
+    fileExtensions: string[];
+}
+
+let cachedConfig: LanguageConfiguration | null = null;
+
+/**
+ * Get language configuration. Must be initialized first via initializeLanguageConfig.
+ */
+export function getLanguageConfiguration(): LanguageConfiguration {
+    if (!cachedConfig) {
+        throw new Error('Language configuration not initialized. Call initializeLanguageConfig first.');
+    }
+    return cachedConfig;
+}
+
+/**
+ * Check if a language ID is a KSON dialect.
+ */
+export function isKsonDialect(languageId: string): boolean {
+    return getLanguageConfiguration().languageIds.includes(languageId);
+}
+
+/**
+ * Initialize language configuration from extension's package.json.
+ * Call this early in the activate function.
+ */
+export function initializeLanguageConfig(packageJson: any): void {
+    const languages = packageJson?.contributes?.languages || [];
+    cachedConfig = {
+        languageIds: languages.map((lang: any) => lang.id).filter(Boolean),
+        fileExtensions: languages
+            .flatMap((lang: any) => lang.extensions || [])
+            .filter(Boolean)
+            .map((ext: string) => ext.replace(/^\./, ''))
+    };
+}
+
+export function resetLanguageConfiguration(): void {
+    cachedConfig = null;
+}

--- a/tooling/lsp-clients/vscode/test/suite/dialect-support.test.ts
+++ b/tooling/lsp-clients/vscode/test/suite/dialect-support.test.ts
@@ -1,0 +1,116 @@
+import * as vscode from 'vscode';
+import { assert } from './assert';
+import { createTestFile, cleanUp } from './common';
+
+/**
+ * Tests for KSON dialect support.
+ *
+ * These tests verify that dialect files (e.g., .KuStON) get the same
+ * language server features as .kson files.
+ */
+describe('Dialect Support Tests', () => {
+
+    async function waitForDiagnostics(uri: vscode.Uri, expectedCount: number, timeout: number = 5000): Promise<vscode.Diagnostic[]> {
+        const startTime = Date.now();
+
+        while (Date.now() - startTime < timeout) {
+            const diagnostics = vscode.languages.getDiagnostics(uri);
+            if (diagnostics.length === expectedCount) {
+                return diagnostics;
+            }
+            await new Promise(resolve => setTimeout(resolve, 100));
+        }
+
+        throw new Error(`Timeout waiting for ${expectedCount} diagnostics, found ${vscode.languages.getDiagnostics(uri).length}`);
+    }
+
+    it('Should report diagnostics for invalid dialect file', async function() {
+        // Skip this test if no dialects are configured
+        const extension = vscode.extensions.getExtension('kson.kson');
+        if (!extension) {
+            this.skip();
+            return;
+        }
+
+        const packageJson = extension.packageJSON;
+        const languages = packageJson?.contributes?.languages || [];
+        const dialectLanguages = languages.filter((lang: any) => lang.id !== 'kson');
+
+        if (dialectLanguages.length === 0) {
+            console.log('No dialects configured, skipping dialect test');
+            this.skip();
+            return;
+        }
+
+        // Test with the first configured dialect
+        const dialect = dialectLanguages[0];
+        const extension_suffix = dialect.extensions?.[0] || '.dialect';
+        const fileName = `test${extension_suffix}`;
+
+        const errorContent = 'key: "value" extraValue'; // Invalid KSON
+        const [testFileUri, document] = await createTestFile(errorContent, fileName);
+
+        // Verify the document has the correct language ID
+        assert.strictEqual(document.languageId, dialect.id, `Document should have language ID: ${dialect.id}`);
+
+        // Should get diagnostics just like a .kson file
+        const diagnostics = await waitForDiagnostics(document.uri, 1);
+        assert.ok(diagnostics.length === 1, `Dialect file should receive diagnostics`);
+
+        await cleanUp(testFileUri);
+    }).timeout(10000);
+
+    it('Should not report diagnostics for valid dialect file', async function() {
+        // Skip this test if no dialects are configured
+        const extension = vscode.extensions.getExtension('kson.kson');
+        if (!extension) {
+            this.skip();
+            return;
+        }
+
+        const packageJson = extension.packageJSON;
+        const languages = packageJson?.contributes?.languages || [];
+        const dialectLanguages = languages.filter((lang: any) => lang.id !== 'kson');
+
+        if (dialectLanguages.length === 0) {
+            console.log('No dialects configured, skipping dialect test');
+            this.skip();
+            return;
+        }
+
+        // Test with the first configured dialect
+        const dialect = dialectLanguages[0];
+        const extension_suffix = dialect.extensions?.[0] || '.dialect';
+        const fileName = `test${extension_suffix}`;
+
+        const validContent = 'key: "value"'; // Valid KSON
+        const [testFileUri, document] = await createTestFile(validContent, fileName);
+
+        // Verify the document has the correct language ID
+        assert.strictEqual(document.languageId, dialect.id, `Document should have language ID: ${dialect.id}`);
+
+        // Should not get diagnostics
+        const diagnostics = await waitForDiagnostics(document.uri, 0);
+        assert.ok(diagnostics.length === 0, `Valid dialect file should not have diagnostics`);
+
+        await cleanUp(testFileUri);
+    }).timeout(10000);
+
+    it('Should support multiple dialects if configured', async function() {
+        const extension = vscode.extensions.getExtension('kson.kson');
+        if (!extension) {
+            this.skip();
+            return;
+        }
+
+        const packageJson = extension.packageJSON;
+        const languages = packageJson?.contributes?.languages || [];
+
+        // Should have at least kson registered
+        assert.ok(languages.length >= 1, 'Should have at least kson language registered');
+        assert.ok(languages.some((lang: any) => lang.id === 'kson'), 'Should have kson language');
+
+        // Log configured languages for debugging
+        console.log('Configured languages:', languages.map((l: any) => l.id).join(', '));
+    }).timeout(5000);
+});

--- a/tooling/lsp-clients/vscode/test/suite/language-config.test.ts
+++ b/tooling/lsp-clients/vscode/test/suite/language-config.test.ts
@@ -1,0 +1,72 @@
+import { assert } from './assert';
+import { initializeLanguageConfig, getLanguageConfiguration, isKsonDialect, resetLanguageConfiguration } from '../../src/config/languageConfig';
+
+describe('Language Configuration Tests', () => {
+
+    beforeEach(() => resetLanguageConfiguration());
+    afterEach(() => resetLanguageConfiguration());
+
+    function initWithLanguages(languages: any[]) {
+        initializeLanguageConfig({ contributes: { languages } });
+    }
+
+    describe('getLanguageConfiguration', () => {
+        it('Should extract kson language and extension', () => {
+            initWithLanguages([{ id: 'kson', extensions: ['.kson'] }]);
+            const config = getLanguageConfiguration();
+
+            assert.deepStrictEqual(config.languageIds, ['kson']);
+            assert.deepStrictEqual(config.fileExtensions, ['kson']);
+        });
+
+        it('Should extract multiple dialects', () => {
+            initWithLanguages([
+                { id: 'kson', extensions: ['.kson'] },
+                { id: 'KuStON', extensions: ['.KuStON'] }
+            ]);
+            const config = getLanguageConfiguration();
+
+            assert.ok(config.languageIds.includes('kson'));
+            assert.ok(config.languageIds.includes('KuStON'));
+            assert.ok(config.fileExtensions.includes('kson'));
+            assert.ok(config.fileExtensions.includes('KuStON'));
+        });
+
+        it('Should handle multiple extensions for one language', () => {
+            initWithLanguages([{ id: 'kson', extensions: ['.kson', '.json5'] }]);
+            const config = getLanguageConfiguration();
+
+            assert.deepStrictEqual(config.languageIds, ['kson']);
+            assert.ok(config.fileExtensions.includes('kson'));
+            assert.ok(config.fileExtensions.includes('json5'));
+        });
+
+        it('Should strip leading dots from extensions', () => {
+            initWithLanguages([{ id: 'kson', extensions: ['.kson', 'other'] }]);
+            const config = getLanguageConfiguration();
+
+            assert.ok(config.fileExtensions.includes('kson'));
+            assert.ok(config.fileExtensions.includes('other'));
+        });
+    });
+
+    describe('isKsonDialect', () => {
+        it('Should return true for kson language', () => {
+            initWithLanguages([{ id: 'kson', extensions: ['.kson'] }]);
+            assert.strictEqual(isKsonDialect('kson'), true);
+        });
+
+        it('Should return true for registered dialect', () => {
+            initWithLanguages([
+                { id: 'kson', extensions: ['.kson'] },
+                { id: 'KuStON', extensions: ['.KuStON'] }
+            ]);
+            assert.strictEqual(isKsonDialect('KuStON'), true);
+        });
+
+        it('Should return false for unregistered language', () => {
+            initWithLanguages([{ id: 'kson', extensions: ['.kson'] }]);
+            assert.strictEqual(isKsonDialect('python'), false);
+        });
+    });
+});

--- a/tooling/lsp-clients/vscode/test/test-files.json
+++ b/tooling/lsp-clients/vscode/test/test-files.json
@@ -3,8 +3,10 @@
     "syntax-highlighting.test",
     "status-bar-schema-association.test",
     "schema-loading.test",
+    "language-config.test",
     "formatting-settings.test",
     "editing.test",
+    "dialect-support.test",
     "diagnostics.test"
   ]
 }


### PR DESCRIPTION
Initially the file extension we used were hardcoded in the VSCode plugin. Now we retrieve the extensions from the `package.json`. This way we could support different or multiple file extensions by adding a new language to the languages-array in `package.json`