### PR TITLE
Improve YAML transpiling for "simple" strings

### DIFF
--- a/src/commonTest/kotlin/org/kson/KsonCoreTestComment.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestComment.kt
@@ -20,7 +20,7 @@ class KsonCoreTestComment : KsonCoreTest {
         """.trimIndent(),
             """
             # this is a comment
-            "string"
+            string
         """.trimIndent(),
             """
             "string"

--- a/src/commonTest/kotlin/org/kson/KsonCoreTestEmbedBlock.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestEmbedBlock.kt
@@ -346,8 +346,8 @@ class KsonCoreTestEmbedBlock : KsonCoreTest {
             """.trimIndent(),
             """
                 embedBlock:
-                  "embedContent": "content\n"
-                  "unrelatedKey": "is not an embed block"
+                  embedContent: "content\n"
+                  unrelatedKey: "is not an embed block"
             """.trimIndent(),
             """
                 {
@@ -382,9 +382,9 @@ class KsonCoreTestEmbedBlock : KsonCoreTest {
             """.trimIndent(),
             """
                 embedBlock:
-                  "embedContent":
+                  embedContent:
                     not: content
-                  "unrelatedKey": "is not an embed block"
+                  unrelatedKey: "is not an embed block"
             """.trimIndent(),
             """
                 {

--- a/src/commonTest/kotlin/org/kson/KsonCoreTestObject.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestObject.kt
@@ -149,7 +149,7 @@ class KsonCoreTestObject : KsonCoreTest {
                 '
             """.trimIndent(),
             """
-                first: "value"
+                first: value
                 second: "this is a string with a
                 raw newline in it and at its end
                 "

--- a/src/commonTest/kotlin/org/kson/KsonCoreTestString.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestString.kt
@@ -21,6 +21,26 @@ class KsonCoreTestString : KsonCoreTest {
     }
 
     @Test
+    fun testQuotedSimpleString() {
+        assertParsesTo(
+            """
+                "simpleKey": "simpleValue"
+            """.trimIndent(),
+            """
+                simpleKey: simpleValue
+            """.trimIndent(),
+            """
+                simpleKey: simpleValue
+            """.trimIndent(),
+            """
+                {
+                  "simpleKey": "simpleValue"
+                }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
     fun testStringWithRawWhitespace() {
         assertParsesTo(
             """

--- a/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
+++ b/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
@@ -179,7 +179,7 @@ class CommandLineInterfaceTest {
                 number: 42
             """.trimIndent(),
             expectedOutput = OutputExpectation.Success("""
-                key: "value"
+                key: value
                 number: 42
             """.trimIndent())
         )
@@ -200,7 +200,7 @@ class CommandLineInterfaceTest {
                 }
             """.trimIndent(),
             expectedOutput = OutputExpectation.Success("""
-                string: "value"
+                string: value
                 number: 42
                 boolean: true
                 null_value: null
@@ -209,7 +209,7 @@ class CommandLineInterfaceTest {
                   - 2
                   - 3
                 object:
-                  nested: "value"
+                  nested: value
             """.trimIndent())
         )
     }
@@ -311,11 +311,11 @@ class CommandLineInterfaceTest {
             """.trimIndent(),
             expectedOutput = OutputExpectation.Success("""
                 database:
-                  host: "localhost"
+                  host: localhost
                   port: 5432
                   credentials:
-                    username: "admin"
-                    password: "secret"
+                    username: admin
+                    password: secret
             """.trimIndent())
         )
     }
@@ -447,7 +447,7 @@ class CommandLineInterfaceTest {
                 }
             """.trimIndent(),
             expectedOutput = OutputExpectation.Success("""
-                key: "value"
+                key: value
                 nested:
                   inner: 123
             """.trimIndent()),
@@ -506,7 +506,7 @@ class CommandLineInterfaceTest {
             main(arrayOf("yaml", "-o", outputFile.absolutePath))
             assertEquals(
                 """
-                key: "value"
+                key: value
                 number: 42
                 """.trimIndent(),
                 outputFile.readText()


### PR DESCRIPTION
Previously, any string that was quoted in the input KSON would be quoted in the transpiled YAML, even if it was "simple" and could be rendered without quotes.  Refactor to have QuotedStringNode delegate to the UnquotedStringNode rendering when appropriate to fix this and keep these in sync going forward.