### PR TITLE
Remove unused `Json` case from Ast.kt

### DIFF
--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -192,7 +192,7 @@ class KsonRootImpl(
      */
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
-            is Kson, is Yaml, is Json -> {
+            is Kson, is Yaml -> {
                 var ksonDocument = rootNode.toSourceWithNext(indent, trailingContent.firstOrNull(), compileTarget)
 
                 trailingContent.forEachIndexed { index, trailingValue ->
@@ -762,10 +762,6 @@ private fun renderUnquotableKsonString(unquotedKsonString: String, indent: Inden
                 unquotedKsonString
             }
         }
-
-        is Json -> {
-            indent.firstLineIndent() + "\"${renderForJsonString(unquotedKsonString)}\""
-        }
     }
 }
 
@@ -792,7 +788,7 @@ class NumberNode(sourceTokens: List<Token>) : KsonValueNodeImpl(sourceTokens) {
 
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
-            is Kson, is Yaml, is Json -> {
+            is Kson, is Yaml -> {
                 indent.firstLineIndent() + value.asString
             }
         }
@@ -808,7 +804,7 @@ class TrueNode(sourceTokens: List<Token>) : BooleanNode(sourceTokens) {
 
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
-            is Kson, is Yaml, is Json -> {
+            is Kson, is Yaml -> {
                 indent.firstLineIndent() + "true"
             }
         }
@@ -820,7 +816,7 @@ class FalseNode(sourceTokens: List<Token>) : BooleanNode(sourceTokens) {
 
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
-            is Kson, is Yaml, is Json -> {
+            is Kson, is Yaml -> {
                 indent.firstLineIndent() + "false"
             }
         }
@@ -830,7 +826,7 @@ class FalseNode(sourceTokens: List<Token>) : BooleanNode(sourceTokens) {
 class NullNode(sourceTokens: List<Token>) : KsonValueNodeImpl(sourceTokens) {
     override fun toSourceInternal(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
         return when (compileTarget) {
-            is Kson, is Yaml, is Json -> {
+            is Kson, is Yaml -> {
                 indent.firstLineIndent() + "null"
             }
         }


### PR DESCRIPTION
In fbe694e00, we made the Json compile target a subclass/special case of the Kson compile target. So now none of these `Json` cases in the Ast.kt `when (compileTarget)` blocks are ever called---the earlier Kson case runs for them.

It would be nice if the compiler could flag these are unreachable, but it currently doesn't detect this situation (which may make sense). It would be nice to refactor to an object structure that helps the compiler help us see these unused cases (or somehow make `Json` the wrong type to use here), but I haven't been able to solve that puzzle yet. For now just delete the unreachable code so it doesn't cause confusion.