### PR TITLE
Remove unneeded deprecation warning

### DIFF
--- a/src/commonMain/kotlin/org/kson/parser/behavior/quotedstring/QuotedStringContentTransformer.kt
+++ b/src/commonMain/kotlin/org/kson/parser/behavior/quotedstring/QuotedStringContentTransformer.kt
@@ -69,8 +69,14 @@ private data class EscapeInfo(
     val processedLength: Int
 )
 
-@Deprecated("Only supports testing to ensure behavior after a refactor. Will be removed.")
-fun unescapeStringContent(content: String): String {
+/**
+ * Unescape the given string according to KSON's escaping rules.
+ *
+ * NOTE: this is unlikely to be called directly outside of tests. [QuotedStringContentTransformer] performs this
+ * unescaping into its [QuotedStringContentTransformer.processedContent] property, maintaining a [Location] source map
+ * between the unescaped string and original escaped source
+ */
+internal fun unescapeStringContent(content: String): String {
     return unescapeAndTrackEscapes(content).first
 }
 


### PR DESCRIPTION
Had a look at trying to refactor away from exposing this method just for tests, but decided it's actually okay to expose the method. The tests it enables are clear, concise and useful, and the escaping it exposes is a reasonable standalone operation (that we just don't happen to need outside testing).

I've doc'ed the method appropriately and removed the deprecation to clear up the build warnings