### PR TITLE
 Fix schema completion and $ref resolution for anyOf/oneOf schemas

### DIFF
--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/SchemaFilteringService.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/SchemaFilteringService.kt
@@ -106,9 +106,12 @@ class SchemaFilteringService(private val schemaIdLookup: SchemaIdLookup) {
         documentValue: KsonValue,
         documentPointer: JsonPointer
     ): List<ResolvedRef> {
-        // Get the object to validate against
-        // For completions, we validate the object where we're adding properties
-        val targetValue = KsonValueWalker.navigateWithJsonPointer(documentValue, documentPointer) ?: documentValue
+        // Get the value at the pointer location to validate against.
+        // If navigation returns null, the value doesn't exist yet (e.g. the user is about
+        // to type at an empty position). In that case there's nothing to filter against,
+        // so return all expanded schemas.
+        val targetValue = KsonValueWalker.navigateWithJsonPointer(documentValue, documentPointer)
+            ?: return candidateSchemas
 
         return candidateSchemas.filter { ref ->
             when (ref.resolutionType) {

--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/navigation/KsonValuePathBuilder.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/navigation/KsonValuePathBuilder.kt
@@ -221,8 +221,14 @@ class KsonValuePathBuilder(
                 pointer.tokens + propertyName
             }
             // Location is outside the token - target the parent element (for completions)
-            // But keep the path as-is for definition lookups
-            !isLocationInsideToken && !includePropertyKeys -> {
+            // But keep the path as-is for definition lookups.
+            // Exception: when lastToken is a container-opening delimiter, the cursor is
+            // inside an empty delimited container — the path already points to the container
+            // and dropping would overshoot to the grandparent.
+            !isLocationInsideToken && !includePropertyKeys
+                    && lastToken?.tokenType != TokenType.SQUARE_BRACKET_L
+                    && lastToken?.tokenType != TokenType.CURLY_BRACE_L
+                    && lastToken?.tokenType != TokenType.ANGLE_BRACKET_L -> {
                 pointer.tokens.dropLast(1)
             }
             // Normal case - return path as-is

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaCompletionLocationTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaCompletionLocationTest.kt
@@ -1286,4 +1286,115 @@ class SchemaCompletionLocationTest {
         assertTrue("phoneNumber" !in labels, "Should NOT include 'phoneNumber' (from SMS branch)")
         assertTrue("message" !in labels, "Should NOT include 'message' (from SMS branch)")
     }
+
+    @Test
+    fun testCompletionsInsideDashListWithRefToAnyOf() {
+        val schema = searchExpressionSchema()
+
+        // Cursor inside an and: dash-list array nested in query
+        val completions = getCompletionsAtCaret(schema, $$"""
+            '$schema': test
+            query:
+              and:
+                - <caret>
+        """.trimIndent())
+
+        assertNotNull(completions, "Should return completions inside dash-list array item")
+        val labels = completions.map { it.label }
+        assertTrue("field" in labels, "Should include 'field' from SearchTerm, got: $labels")
+        assertTrue("term" in labels, "Should include 'term' from SearchTerm, got: $labels")
+        assertTrue("and" in labels, "Should include 'and' from AndExpression, got: $labels")
+        assertTrue("\$schema" !in labels, "Should NOT include root-level '\$schema'")
+        assertTrue("query" !in labels, "Should NOT include root-level 'query'")
+    }
+
+    @Test
+    fun testNoCompletionsInsideDelimitedListWhenSchemaExpectsObject() {
+        val schema = searchExpressionSchema()
+
+        // Cursor inside a [] delimited list, but schema expects objects (SearchTerm
+        // or AndExpression). The structural mismatch means no branch is compatible.
+        val completions = getCompletionsAtCaret(schema, $$"""
+            '$schema': test
+            query:
+              [
+                <caret>
+              ]
+        """.trimIndent())
+
+        assertNotNull(completions)
+        assertTrue(completions.isEmpty(), "Should have no completions when document structure doesn't match schema, got: ${completions.map { it.label }}")
+    }
+
+    @Test
+    fun testCompletionsInsideEmptyDelimitedObject() {
+        // Cursor inside an empty {} — the CURLY_BRACE_L guard should prevent
+        // the path builder from dropping the last path element.
+        val schema = """
+            type: object
+            properties:
+              config:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    .
+                  .
+                .
+              .
+        """
+
+        val completions = getCompletionsAtCaret(schema, """
+            config: {<caret>}
+        """.trimIndent())
+
+        assertNotNull(completions, "Should return completions inside empty delimited object")
+        val labels = completions.map { it.label }
+        assertTrue("name" in labels, "Should include 'name' from config schema, got: $labels")
+        assertTrue("config" !in labels, "Should NOT include 'config' (parent property)")
+    }
+
+    private fun searchExpressionSchema() = $$"""
+        type: object
+        additionalProperties: false
+        properties:
+          '$schema':
+            type: string
+            .
+          query:
+            '$ref': '#/$defs/SearchExpression'
+            .
+          .
+        '$defs':
+          SearchExpression:
+            anyOf:
+              - '$ref': '#/$defs/SearchTerm'
+              - '$ref': '#/$defs/AndExpression'
+              =
+            .
+          SearchTerm:
+            type: object
+            additionalProperties: false
+            properties:
+              field:
+                type: string
+                .
+              term:
+                type: string
+                .
+              .
+            .
+          AndExpression:
+            type: object
+            additionalProperties: false
+            properties:
+              and:
+                type: array
+                items:
+                  '$ref': '#/$defs/SearchExpression'
+                  .
+                .
+              .
+            .
+    """
 }

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaCompletionLocationTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaCompletionLocationTest.kt
@@ -1288,6 +1288,188 @@ class SchemaCompletionLocationTest {
     }
 
     @Test
+    fun testCompletionsAtValuePositionWithRefToAnyOf() {
+        val schema = searchExpressionSchema()
+
+        // Cursor directly at the value position for query (which $refs to SearchExpression anyOf)
+        val completions = getCompletionsAtCaret(schema, $$"""
+            '$schema': test
+            query:
+              <caret>
+        """.trimIndent())
+
+        assertNotNull(completions, "Should return completions at value position with ref to anyOf")
+        val labels = completions.map { it.label }
+        assertTrue("field" in labels, "Should include 'field' from SearchTerm, got: $labels")
+        assertTrue("term" in labels, "Should include 'term' from SearchTerm, got: $labels")
+        assertTrue("and" in labels, "Should include 'and' from AndExpression, got: $labels")
+        assertTrue("\$schema" !in labels, "Should NOT include root-level '\$schema'")
+        assertTrue("query" !in labels, "Should NOT include root-level 'query'")
+    }
+
+    @Test
+    fun testCompletionsAtValuePositionWithRefToAnyOfWithDescription() {
+        // Schema where SearchExpression has description alongside anyOf (like PubMed schema)
+        val schema = $$"""
+            type: object
+            additionalProperties: false
+            properties:
+              '$schema':
+                type: string
+                .
+              query:
+                '$ref': '#/$defs/SearchExpression'
+                description: 'The root of the boolean search expression tree.'
+                .
+              .
+            '$defs':
+              SearchExpression:
+                description: 'A node in the boolean expression tree.'
+                anyOf:
+                  - '$ref': '#/$defs/SearchTerm'
+                  - '$ref': '#/$defs/AndExpression'
+                  - '$ref': '#/$defs/OrExpression'
+                  - '$ref': '#/$defs/NotExpression'
+                    .
+                .
+              SearchTerm:
+                type: object
+                additionalProperties: false
+                required:
+                  - field
+                  - term
+                properties:
+                  field:
+                    type: string
+                    .
+                  term:
+                    type: string
+                    .
+                  exactPhrase:
+                    type: boolean
+                    .
+                  .
+                .
+              AndExpression:
+                type: object
+                additionalProperties: false
+                properties:
+                  and:
+                    type: array
+                    items:
+                      '$ref': '#/$defs/SearchExpression'
+                      .
+                    .
+                  .
+                .
+              OrExpression:
+                type: object
+                additionalProperties: false
+                properties:
+                  or:
+                    type: array
+                    items:
+                      '$ref': '#/$defs/SearchExpression'
+                      .
+                    .
+                  .
+                .
+              NotExpression:
+                type: object
+                additionalProperties: false
+                properties:
+                  not:
+                    type: array
+                    items:
+                      '$ref': '#/$defs/SearchExpression'
+                      .
+                    .
+                  .
+                .
+        """
+
+        // Cursor directly at the value position for query
+        val completions = getCompletionsAtCaret(schema, $$"""
+            '$schema': test
+            query:
+              <caret>
+        """.trimIndent())
+
+        assertNotNull(completions, "Should return completions at value position with ref to anyOf (with description)")
+        val labels = completions.map { it.label }
+        assertTrue("field" in labels, "Should include 'field' from SearchTerm, got: $labels")
+        assertTrue("term" in labels, "Should include 'term' from SearchTerm, got: $labels")
+        assertTrue("and" in labels, "Should include 'and' from AndExpression, got: $labels")
+        assertTrue("or" in labels, "Should include 'or' from OrExpression, got: $labels")
+        assertTrue("not" in labels, "Should include 'not' from NotExpression, got: $labels")
+    }
+
+    @Test
+    fun testCompletionsAtValuePositionWithSchemaId() {
+        // Schema with $id set — ensures $ref resolution works when the schema
+        // has a non-URI $id like 'pubmed.schema.kson'
+        val schema = $$"""
+            '$schema': 'http://json-schema.org/draft-07/schema#'
+            '$id': 'pubmed.schema.kson'
+            type: object
+            additionalProperties: false
+            properties:
+              '$schema':
+                type: string
+                .
+              query:
+                '$ref': '#/$defs/SearchExpression'
+                description: 'The root of the boolean search expression tree.'
+                .
+              .
+            '$defs':
+              SearchExpression:
+                description: 'A node in the boolean expression tree.'
+                anyOf:
+                  - '$ref': '#/$defs/SearchTerm'
+                  - '$ref': '#/$defs/AndExpression'
+                    .
+                .
+              SearchTerm:
+                type: object
+                additionalProperties: false
+                properties:
+                  field:
+                    type: string
+                    .
+                  term:
+                    type: string
+                    .
+                  .
+                .
+              AndExpression:
+                type: object
+                additionalProperties: false
+                properties:
+                  and:
+                    type: array
+                    items:
+                      '$ref': '#/$defs/SearchExpression'
+                      .
+                    .
+                  .
+                .
+        """
+
+        val completions = getCompletionsAtCaret(schema, $$"""
+            '$schema': 'pubmed.schema.kson'
+            query:
+              <caret>
+        """.trimIndent())
+
+        assertNotNull(completions, "Should return completions with ${'$'}id set on schema")
+        val labels = completions.map { it.label }
+        assertTrue("field" in labels, "Should include 'field' from SearchTerm, got: $labels")
+        assertTrue("term" in labels, "Should include 'term' from SearchTerm, got: $labels")
+        assertTrue("and" in labels, "Should include 'and' from AndExpression, got: $labels")
+    }
+
+    @Test
     fun testCompletionsInsideDashListWithRefToAnyOf() {
         val schema = searchExpressionSchema()
 
@@ -1314,6 +1496,9 @@ class SchemaCompletionLocationTest {
 
         // Cursor inside a [] delimited list, but schema expects objects (SearchTerm
         // or AndExpression). The structural mismatch means no branch is compatible.
+        // This also exercises the SQUARE_BRACKET_L guard in the path builder: the
+        // path must point at /query (not drop to root), otherwise the filter would
+        // see root-level completions leak through.
         val completions = getCompletionsAtCaret(schema, $$"""
             '$schema': test
             query:
@@ -1324,6 +1509,27 @@ class SchemaCompletionLocationTest {
 
         assertNotNull(completions)
         assertTrue(completions.isEmpty(), "Should have no completions when document structure doesn't match schema, got: ${completions.map { it.label }}")
+    }
+
+    @Test
+    fun testNoCompletionsInsideEmptyDelimitedDashListWhenSchemaExpectsObject() {
+        val schema = searchExpressionSchema()
+
+        // Cursor inside an empty delimited dash-list `<>`, but schema expects
+        // objects (SearchTerm or AndExpression). Exercises the ANGLE_BRACKET_L
+        // guard in the path builder: without it, the pointer would overshoot
+        // to root and root-level properties would leak through as completions.
+        val completions = getCompletionsAtCaret(schema, $$"""
+            '$schema': test
+            query: <<caret>>
+        """.trimIndent())
+
+        assertNotNull(completions)
+        assertTrue(
+            completions.isEmpty(),
+            "Should have no completions: the path must target /query, and array-at-object " +
+                "filters out both anyOf branches. Got: ${completions.map { it.label }}"
+        )
     }
 
     @Test

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaFilteringServiceTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaFilteringServiceTest.kt
@@ -3,6 +3,8 @@ package org.kson
 import org.kson.value.navigation.json_pointer.JsonPointer
 import org.kson.schema.SchemaIdLookup
 import org.kson.tooling.SchemaFilteringService
+import org.kson.value.KsonObject
+import org.kson.value.KsonString
 import org.kson.value.KsonValue
 import kotlin.test.*
 
@@ -14,6 +16,11 @@ import kotlin.test.*
  */
 class SchemaFilteringServiceTest {
 
+    /**
+     * Parses [schema] and [document], navigates to [documentPointer] in the schema,
+     * and returns the valid schemas after [SchemaFilteringService] has expanded
+     * combinators and filtered incompatible branches.
+     */
     private fun getValidSchemasForDocument(
         schema: String,
         document: String,
@@ -27,8 +34,28 @@ class SchemaFilteringServiceTest {
         return filteringService.getValidSchemas(candidateSchemas, parsedDocument, documentPointer).map { it.resolvedValue }
     }
 
+    /**
+     * Reads the string value at `properties.<propertyName>.<fieldName>` for a
+     * schema branch, or null if the branch doesn't have one. Used to identify
+     * which branch of a `oneOf` survived filtering by reading a discriminating
+     * sub-field of a property's schema (e.g. `properties.type.const` or
+     * `properties.value.type`).
+     */
+    private fun propertyFieldOf(
+        schema: KsonValue,
+        propertyName: String,
+        fieldName: String
+    ): String? {
+        val obj = schema as? KsonObject ?: return null
+        val properties = obj.propertyLookup["properties"] as? KsonObject ?: return null
+        val prop = properties.propertyLookup[propertyName] as? KsonObject ?: return null
+        return (prop.propertyLookup[fieldName] as? KsonString)?.value
+    }
+
     @Test
     fun testGetValidSchemas_withOneOfCombinator_filtersIncompatibleSchemas() {
+        // Two branches discriminated by `type` const. Document says `type: email`,
+        // so only the email branch should survive; the sms branch must be dropped.
         val schema = """
             oneOf:
               - type: object
@@ -51,11 +78,17 @@ class SchemaFilteringServiceTest {
 
         val validSchemas = getValidSchemasForDocument(schema, document)
 
-        assertTrue(validSchemas.size >= 1, "Should have at least 1 valid schema")
+        // Parent + email branch (sms filtered out)
+        assertEquals(2, validSchemas.size, "Should return parent + email branch only")
+        val survivingConsts = validSchemas.mapNotNull { propertyFieldOf(it, "type", "const") }
+        assertEquals(listOf("email"), survivingConsts, "Only the email branch should survive")
     }
 
     @Test
-    fun testGetValidSchemas_withAnyOfCombinator_filtersIncompatibleSchemas() {
+    fun testGetValidSchemas_withAnyOfCombinator_bothBranchesCompatible() {
+        // Document has `name` and `age`. Branch 1 describes name+age, branch 2 describes
+        // name+role. Both branches are compatible because missing required props are
+        // ignored and there's no additionalProperties:false on branch 2. So both survive.
         val schema = """
             anyOf:
               - type: object
@@ -79,11 +112,14 @@ class SchemaFilteringServiceTest {
 
         val validSchemas = getValidSchemasForDocument(schema, document)
 
-        assertTrue(validSchemas.size >= 1, "Should have at least 1 valid schema")
+        // Parent + both branches — nothing to filter out.
+        assertEquals(3, validSchemas.size, "Should return parent + both anyOf branches (both are compatible)")
     }
 
     @Test
     fun testGetValidSchemas_withAllOfCombinator_includesAllBranches() {
+        // allOf never filters — all branches must hold simultaneously, so the
+        // filter returns them all verbatim (plus the parent schema).
         val schema = """
             allOf:
               - type: object
@@ -107,6 +143,8 @@ class SchemaFilteringServiceTest {
 
     @Test
     fun testGetValidSchemas_withInvalidDocument_fallsBackToUnfilteredSchemas() {
+        // When the document doesn't parse, the filter has nothing to validate against
+        // and must fall back to the fully expanded schema list (parent + all branches).
         val schema = """
             oneOf:
               - type: string
@@ -120,6 +158,7 @@ class SchemaFilteringServiceTest {
 
     @Test
     fun testGetValidSchemas_withNoCombinators_returnsAllSchemas() {
+        // No combinators means no filtering — the single candidate passes through.
         val schema = """
             type: object
             properties:
@@ -135,11 +174,14 @@ class SchemaFilteringServiceTest {
 
         val validSchemas = getValidSchemasForDocument(schema, document)
 
-        assertEquals(1, validSchemas.size, "Should return all schemas when no combinators")
+        assertEquals(1, validSchemas.size, "Should return a single schema when there are no combinators")
     }
 
     @Test
     fun testGetValidSchemas_ignoresRequiredPropertyErrors() {
+        // Document has only `name`, but both branches require additional properties.
+        // Missing-required errors are expected during completion and must not
+        // disqualify a branch, so both survive.
         val schema = """
             oneOf:
               - type: object
@@ -164,11 +206,18 @@ class SchemaFilteringServiceTest {
 
         val validSchemas = getValidSchemasForDocument(schema, document)
 
-        assertEquals(3, validSchemas.size, "Parent + both branches should be valid - missing required props are ignored")
+        assertEquals(
+            3, validSchemas.size,
+            "Parent + both branches should be valid — missing required props are ignored"
+        )
     }
 
     @Test
     fun testGetValidSchemas_withNonRootPointerToMissingValue_returnsAllBranches() {
+        // Navigation to /query returns null because the document doesn't have
+        // a `query` key yet. The filter must return all expanded candidates
+        // rather than validating against the root document (which would fail
+        // additionalProperties:false on every branch).
         val schema = """
             type: object
             properties:
@@ -184,11 +233,16 @@ class SchemaFilteringServiceTest {
 
         val validSchemas = getValidSchemasForDocument(schema, document, JsonPointer("/query"))
 
-        assertEquals(3, validSchemas.size, "Parent + both oneOf branches should be returned when target value doesn't exist yet")
+        assertEquals(
+            3, validSchemas.size,
+            "Parent + both oneOf branches should be returned when the target value doesn't exist yet"
+        )
     }
 
     @Test
     fun testGetValidSchemas_filtersBasedOnTypeViolations() {
+        // Document has `value: hello` (a string). Only the string branch is compatible;
+        // the number branch is filtered out.
         val schema = """
             oneOf:
               - type: object
@@ -207,11 +261,18 @@ class SchemaFilteringServiceTest {
 
         val validSchemas = getValidSchemasForDocument(schema, document)
 
-        assertEquals(2, validSchemas.size, "Should match parent + the string branch")
+        assertEquals(2, validSchemas.size, "Should match parent + exactly one branch")
+        val survivingValueTypes = validSchemas.mapNotNull { propertyFieldOf(it, "value", "type") }
+        assertEquals(
+            listOf("string"), survivingValueTypes,
+            "Only the string branch should survive; the number branch must be filtered out"
+        )
     }
 
     @Test
     fun testGetValidSchemas_withTypeMismatchAtTarget_filtersOutIncompatibleBranches() {
+        // Document is a list; both branches expect objects. No branch survives —
+        // only the parent (oneOf container) remains.
         val schema = """
             oneOf:
               - type: object
@@ -230,6 +291,9 @@ class SchemaFilteringServiceTest {
 
         val validSchemas = getValidSchemasForDocument(schema, document)
 
-        assertEquals(1, validSchemas.size, "Only parent schema should remain when target type doesn't match any branch")
+        assertEquals(
+            1, validSchemas.size,
+            "Only the parent schema should remain when target type doesn't match any branch"
+        )
     }
 }

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaFilteringServiceTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaFilteringServiceTest.kt
@@ -7,32 +7,28 @@ import org.kson.value.KsonValue
 import kotlin.test.*
 
 /**
- * Unit tests for [org.kson.tooling.SchemaFilteringService]
+ * Unit tests for [SchemaFilteringService]
  *
  * These tests focus on the schema filtering logic in isolation,
  * without going through the full public API.
  */
 class SchemaFilteringServiceTest {
 
-    /**
-     * Helper function to set up schema filtering and return valid schemas for a given document.
-     *
-     * @param schema The schema definition as a string
-     * @param document The document to validate against the schema
-     * @return List of valid schemas after filtering
-     */
-    private fun getValidSchemasForDocument(schema: String, document: String): List<KsonValue> {
+    private fun getValidSchemasForDocument(
+        schema: String,
+        document: String,
+        documentPointer: JsonPointer = JsonPointer("")
+    ): List<KsonValue> {
         val parsedSchema = KsonCore.parseToAst(schema).ksonValue ?: fail("Schema should parse")
         val parsedDocument = KsonCore.parseToAst(document).ksonValue
         val schemaIdLookup = SchemaIdLookup(parsedSchema)
         val filteringService = SchemaFilteringService(schemaIdLookup)
-        val candidateSchemas = schemaIdLookup.navigateByDocumentPointer(JsonPointer(""))
-        return filteringService.getValidSchemas(candidateSchemas, parsedDocument, JsonPointer("")).map { it.resolvedValue }
+        val candidateSchemas = schemaIdLookup.navigateByDocumentPointer(documentPointer)
+        return filteringService.getValidSchemas(candidateSchemas, parsedDocument, documentPointer).map { it.resolvedValue }
     }
 
     @Test
     fun testGetValidSchemas_withOneOfCombinator_filtersIncompatibleSchemas() {
-        // Schema with oneOf combinator
         val schema = """
             oneOf:
               - type: object
@@ -49,25 +45,17 @@ class SchemaFilteringServiceTest {
                     type: string
         """.trimIndent()
 
-        // Document with type: email (should only match first branch)
         val document = """
             type: email
         """.trimIndent()
 
         val validSchemas = getValidSchemasForDocument(schema, document)
 
-        // Should filter to only the email branch (oneOf creates 2 branches, only 1 should be valid)
-        // Note: The filtering happens after expansion, so we expect 1 valid schema
         assertTrue(validSchemas.size >= 1, "Should have at least 1 valid schema")
-
-        // The valid schema should be the one with type: email (first branch)
-        // We can verify this by checking that it validates against our document
-        // Since the filtering already happened, any returned schema is compatible
     }
 
     @Test
     fun testGetValidSchemas_withAnyOfCombinator_filtersIncompatibleSchemas() {
-        // Schema with anyOf combinator
         val schema = """
             anyOf:
               - type: object
@@ -84,7 +72,6 @@ class SchemaFilteringServiceTest {
                     type: string
         """.trimIndent()
 
-        // Document with 'age' property (should only match first branch)
         val document = """
             name: John
             age: 30
@@ -92,16 +79,11 @@ class SchemaFilteringServiceTest {
 
         val validSchemas = getValidSchemasForDocument(schema, document)
 
-        // Should filter to compatible branches only
         assertTrue(validSchemas.size >= 1, "Should have at least 1 valid schema")
-        // Since document has 'age: 30' (number), only first branch should be valid
-        // The second branch expects 'role' which is not present, but missing required props are ignored,
-        // so we might get both branches. Let's just verify we get at least one.
     }
 
     @Test
     fun testGetValidSchemas_withAllOfCombinator_includesAllBranches() {
-        // Schema with allOf combinator - all branches should always be included
         val schema = """
             allOf:
               - type: object
@@ -120,31 +102,24 @@ class SchemaFilteringServiceTest {
 
         val validSchemas = getValidSchemasForDocument(schema, document)
 
-        // allOf should include all branches (no filtering) plus the parent schema
         assertEquals(3, validSchemas.size, "allOf should include parent + all branches without filtering")
     }
 
     @Test
     fun testGetValidSchemas_withInvalidDocument_fallsBackToUnfilteredSchemas() {
-        // Schema with oneOf
         val schema = """
             oneOf:
               - type: string
               - type: number
         """.trimIndent()
 
-        // Invalid document (not parseable)
-        val invalidDocument = "{ invalid json"
+        val validSchemas = getValidSchemasForDocument(schema, "{ invalid json")
 
-        val validSchemas = getValidSchemasForDocument(schema, invalidDocument)
-
-        // Should fall back to all expanded schemas without filtering (parent + branches)
         assertEquals(3, validSchemas.size, "Should return parent + all branches when document doesn't parse")
     }
 
     @Test
     fun testGetValidSchemas_withNoCombinators_returnsAllSchemas() {
-        // Simple schema without combinators
         val schema = """
             type: object
             properties:
@@ -160,13 +135,11 @@ class SchemaFilteringServiceTest {
 
         val validSchemas = getValidSchemasForDocument(schema, document)
 
-        // Should return all candidate schemas since there are no combinators (only 1 in this case)
         assertEquals(1, validSchemas.size, "Should return all schemas when no combinators")
     }
 
     @Test
     fun testGetValidSchemas_ignoresRequiredPropertyErrors() {
-        // Schema with required properties
         val schema = """
             oneOf:
               - type: object
@@ -185,21 +158,37 @@ class SchemaFilteringServiceTest {
                     type: string
         """.trimIndent()
 
-        // Document with only 'name' (missing required 'email' or 'phone')
-        // Both branches should still be valid because missing required props are ignored
         val document = """
             name: John
         """.trimIndent()
 
         val validSchemas = getValidSchemasForDocument(schema, document)
 
-        // Both branches should be valid (missing required properties are ignored during filtering) plus parent
         assertEquals(3, validSchemas.size, "Parent + both branches should be valid - missing required props are ignored")
     }
 
     @Test
+    fun testGetValidSchemas_withNonRootPointerToMissingValue_returnsAllBranches() {
+        val schema = """
+            type: object
+            properties:
+              query:
+                oneOf:
+                  - type: string
+                  - type: number
+        """.trimIndent()
+
+        val document = """
+            name: test
+        """.trimIndent()
+
+        val validSchemas = getValidSchemasForDocument(schema, document, JsonPointer("/query"))
+
+        assertEquals(3, validSchemas.size, "Parent + both oneOf branches should be returned when target value doesn't exist yet")
+    }
+
+    @Test
     fun testGetValidSchemas_filtersBasedOnTypeViolations() {
-        // Schema with different type requirements
         val schema = """
             oneOf:
               - type: object
@@ -212,14 +201,35 @@ class SchemaFilteringServiceTest {
                     type: number
         """.trimIndent()
 
-        // Document with string value (should only match first branch)
         val document = """
             value: hello
         """.trimIndent()
 
         val validSchemas = getValidSchemasForDocument(schema, document)
 
-        // Should filter to only the string branch plus parent
         assertEquals(2, validSchemas.size, "Should match parent + the string branch")
+    }
+
+    @Test
+    fun testGetValidSchemas_withTypeMismatchAtTarget_filtersOutIncompatibleBranches() {
+        val schema = """
+            oneOf:
+              - type: object
+                properties:
+                  field:
+                    type: string
+              - type: object
+                properties:
+                  and:
+                    type: array
+        """.trimIndent()
+
+        val document = """
+            - item
+        """.trimIndent()
+
+        val validSchemas = getValidSchemasForDocument(schema, document)
+
+        assertEquals(1, validSchemas.size, "Only parent schema should remain when target type doesn't match any branch")
     }
 }

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaRefResolutionTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaRefResolutionTest.kt
@@ -311,4 +311,22 @@ class SchemaRefResolutionTest {
             }
         """.trimIndent())
     }
+
+    @Test
+    fun testResolveRef_withNonUriSchemaId() {
+        // Schema with a non-URI $id (e.g. a filename) should still resolve refs
+        assertRefResolution($$"""
+            '$id': 'pubmed.schema.kson'
+            type: object
+            properties:
+              query:
+                '$ref': '#/$defs/Data<cursor>'
+                .
+              .
+            '$defs':
+              Data:
+                <target>type: string
+                .</target>
+        """.trimIndent())
+    }
 }

--- a/src/commonMain/kotlin/org/kson/schema/SchemaIdLookup.kt
+++ b/src/commonMain/kotlin/org/kson/schema/SchemaIdLookup.kt
@@ -37,7 +37,7 @@ class SchemaIdLookup(val schemaRootValue: KsonValue) {
                 }
             } ?: ""
 
-            // Store the root schema at is baseUri
+            // Store the root schema at its baseUri
             idMap[rootBaseUri] = schemaRootValue
 
             // Walk the schema tree to collect all IDs with fully-qualified URIs
@@ -496,21 +496,38 @@ class SchemaIdLookup(val schemaRootValue: KsonValue) {
          * This works analogously to how url updates in a web browsers: if you are "on" [baseUri] and "click" on
          *   and link with href="[uri]", you will be sent to the uri defined by the returned [RefUriParts]
          *
-         * NOTE: this attempts to implement the rules specified in [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-5)
-         *   but is a little ad-hoc compared to what is there.  If/when bugs creep up with their root cause in this
-         *   method, let's more carefully port the behavior specified there
+         * NOTE: this implements reference transformation from
+         *   [RFC 3986 §5.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.2) — including its
+         *   scheme/authority inheritance cases and the
+         *   [§5.2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.3) merge-paths sub-operation.
+         *   It does not yet perform the
+         *   [§5.2.4](https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4) remove-dot-segments sub-operation;
+         *   add that when a case needs it.
          */
         fun resolveUri(uri: String, baseUri: String): RefUriParts {
             val uriParts = parseUri(uri)
             val baseUriParts = parseUri(baseUri)
             val origin = uriParts.origin.ifBlank { baseUriParts.origin }
-            val path = if (uriParts.path.startsWith('/')) {
-                uriParts.path
-            } else if (uriParts.path.isNotBlank()) {
-                baseUriParts.path.substringBeforeLast("/") + "/" + uriParts.path.removePrefix("/")
-            }
-            else {
-                baseUriParts.path
+            val path = when {
+                // Absolute-path reference: use as-is.
+                uriParts.path.startsWith('/') -> uriParts.path
+                // Empty reference path: inherit the base path.
+                uriParts.path.isEmpty() -> baseUriParts.path
+                // Relative reference path: merge with base path per RFC 3986 §5.2.3.
+                // If the base has an authority and an empty path, the merged path
+                // starts with "/". Otherwise, replace the last segment of the base
+                // path with the reference path; if the base path has no "/", the
+                // entire base path is discarded.
+                baseUriParts.origin.isNotEmpty() && baseUriParts.path.isEmpty() ->
+                    "/" + uriParts.path
+                else -> {
+                    val lastSlash = baseUriParts.path.lastIndexOf('/')
+                    if (lastSlash < 0) {
+                        uriParts.path
+                    } else {
+                        baseUriParts.path.substring(0, lastSlash + 1) + uriParts.path
+                    }
+                }
             }
             return RefUriParts(origin, path, uriParts.fragment)
         }

--- a/src/commonTest/kotlin/org/kson/schema/SchemaIdLookupResolveUriTest.kt
+++ b/src/commonTest/kotlin/org/kson/schema/SchemaIdLookupResolveUriTest.kt
@@ -1,0 +1,75 @@
+package org.kson.schema
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Direct tests for [SchemaIdLookup.Companion.resolveUri].
+ *
+ * These exercise the RFC 3986 §5.2 transform rules that the schema ref
+ * resolver depends on for consistent idMap lookups.
+ */
+class SchemaIdLookupResolveUriTest {
+
+    private fun resolve(uri: String, base: String): String =
+        SchemaIdLookup.resolveUri(uri, base).toString()
+
+    @Test
+    fun testRelativeRefAgainstEmptyBase_returnsRefUnchanged() {
+        // A bare filename resolved against an empty base should remain unchanged.
+        assertEquals("pubmed.schema.kson", resolve("pubmed.schema.kson", ""))
+    }
+
+    @Test
+    fun testAbsolutePathRef_usedAsIs_inheritsBaseOrigin() {
+        // Per RFC 3986 §5.2.2, an absolute-path reference inherits the base's
+        // scheme/authority, but its own path overrides the base's path.
+        assertEquals("/foo/bar", resolve("/foo/bar", ""))
+        assertEquals("http://example.com/foo/bar", resolve("/foo/bar", "http://example.com/a/b"))
+    }
+
+    @Test
+    fun testEmptyRef_inheritsBasePath() {
+        assertEquals("http://example.com/a/b", resolve("", "http://example.com/a/b"))
+        assertEquals("", resolve("", ""))
+    }
+
+    @Test
+    fun testRelativeRefAgainstBaseWithAuthorityAndEmptyPath_prependsSlash() {
+        // RFC 3986 §5.2.3: base has authority but empty path — merged path starts with "/".
+        assertEquals("http://example.com/foo", resolve("foo", "http://example.com"))
+    }
+
+    @Test
+    fun testRelativeRefAgainstBaseWithTrailingSlash_appendsAfterLastSlash() {
+        assertEquals("http://example.com/a/b/c", resolve("c", "http://example.com/a/b/"))
+    }
+
+    @Test
+    fun testRelativeRefAgainstBaseWithoutTrailingSlash_replacesLastSegment() {
+        // Last segment "b" is replaced by the reference.
+        assertEquals("http://example.com/a/c", resolve("c", "http://example.com/a/b"))
+    }
+
+    @Test
+    fun testRelativeRefAgainstBaseWithNoSlash_discardsEntireBasePath() {
+        // RFC 3986 §5.2.3: "excluding the entire base URI path if it does not contain any / characters".
+        assertEquals("bar", resolve("bar", "foo"))
+    }
+
+    @Test
+    fun testFragmentAlwaysComesFromRef() {
+        // Pure fragment: inherits the base path.
+        assertEquals("http://example.com/a/b#frag", resolve("#frag", "http://example.com/a/b"))
+        // Relative path + fragment: merges the path and keeps the ref's fragment.
+        assertEquals("http://example.com/a/c#frag", resolve("c#frag", "http://example.com/a/b"))
+    }
+
+    @Test
+    fun testAbsoluteUriIgnoresBase() {
+        assertEquals(
+            "http://other.example/x",
+            resolve("http://other.example/x", "http://example.com/a/b")
+        )
+    }
+}


### PR DESCRIPTION
- Fix completions lost when cursor is inside an empty delimited container ([], {}) or at a position where the value doesn't exist yet — `SchemaFilteringService` was validating against  the root document instead of returning all branches when navigation returned null, and the   path builder was incorrectly collapsing the pointer to root inside empty containers
-  Fix $ref resolution failure when a schema has a non-URI `$id` (e.g. "pubmed.schema.kson"), `SchemaIdLookup` stored the raw `$id` but lookups resolved it through `resolveUri`, producing a  mismatched key
