### PR TITLE
Route all TextDocument parses through parseTextDocument helper

### DIFF
--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/ToolingDocumentTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/ToolingDocumentTest.kt
@@ -85,6 +85,21 @@ class ToolingDocumentTest {
     }
 
     @Test
+    fun testParseThreadsFilepathIntoSourceContext() {
+        // Pinning contract: KsonTooling.parse(content, filepath) must make the
+        // filepath visible to validators via SourceContext. No validator currently
+        // reads this field, so this test is the only regression anchor guarding
+        // the plumbing — without it, the URI can be silently dropped and no
+        // behavioral test will catch it.
+        val withPath = KsonTooling.parse("name: John", "file:///foo.kson")
+        assertEquals("file:///foo.kson", withPath.sourceContext.filepath)
+
+        // The default remains null when no filepath is supplied.
+        val withoutPath = KsonTooling.parse("name: John")
+        assertNull(withoutPath.sourceContext.filepath)
+    }
+
+    @Test
     fun testBrokenDocumentGracefulDegradation() {
         val doc = KsonTooling.parse("{ unclosed")
 

--- a/tooling/language-server-protocol/src/core/document/KsonDocument.ts
+++ b/tooling/language-server-protocol/src/core/document/KsonDocument.ts
@@ -3,6 +3,15 @@ import {TextDocument} from "vscode-languageserver-textdocument";
 import {KsonTooling, ToolingDocument} from 'kson-tooling';
 
 /**
+ * Parse a {@link TextDocument} into a {@link ToolingDocument}, threading the
+ * document's URI through as source context so validators can see which
+ * document a diagnostic belongs to.
+ */
+export function parseTextDocument(textDocument: TextDocument): ToolingDocument {
+    return KsonTooling.getInstance().parse(textDocument.getText(), textDocument.uri);
+}
+
+/**
  * Kson Document Entry.
  * This class wraps a standard {@link TextDocument} with its pre-parsed
  * {@link ToolingDocument}, so every tooling operation on the same document
@@ -66,7 +75,7 @@ export class KsonDocument implements TextDocument {
         const schema = this.getSchemaDocument();
         if (!schema) return undefined;
         if (!this._schemaToolingDocument) {
-            this._schemaToolingDocument = KsonTooling.getInstance().parse(schema.getText(), schema.uri);
+            this._schemaToolingDocument = parseTextDocument(schema);
         }
         return this._schemaToolingDocument;
     }

--- a/tooling/language-server-protocol/src/core/document/KsonDocumentsManager.ts
+++ b/tooling/language-server-protocol/src/core/document/KsonDocumentsManager.ts
@@ -1,6 +1,6 @@
 import {TextDocument} from 'vscode-languageserver-textdocument';
-import {KsonTooling, ToolingDocument} from 'kson-tooling';
-import {KsonDocument} from "./KsonDocument.js";
+import {ToolingDocument} from 'kson-tooling';
+import {KsonDocument, parseTextDocument} from "./KsonDocument.js";
 import {KsonSchemaDocument} from "./KsonSchemaDocument.js";
 import {DocumentUri, TextDocuments, TextDocumentContentChangeEvent} from "vscode-languageserver";
 import {SchemaProvider, NoOpSchemaProvider} from "../schema/SchemaProvider.js";
@@ -62,7 +62,7 @@ export class KsonDocumentsManager extends TextDocuments<KsonDocument> {
                 content: string
             ): KsonDocument => {
                 const textDocument = TextDocument.create(uri, languageId, version, content);
-                const toolingDocument = KsonTooling.getInstance().parse(content);
+                const toolingDocument = parseTextDocument(textDocument);
                 return resolveDocument(provider, textDocument, toolingDocument);
             },
             update: (
@@ -75,7 +75,7 @@ export class KsonDocumentsManager extends TextDocuments<KsonDocument> {
                     changes,
                     version
                 );
-                const toolingDocument = KsonTooling.getInstance().parse(textDocument.getText());
+                const toolingDocument = parseTextDocument(textDocument);
                 // Reuse the existing schema/metaschema — it only changes when schema
                 // config changes, which triggers refreshDocumentSchemas() separately.
                 if (ksonDocument instanceof KsonSchemaDocument) {

--- a/tooling/language-server-protocol/src/core/document/KsonSchemaDocument.ts
+++ b/tooling/language-server-protocol/src/core/document/KsonSchemaDocument.ts
@@ -1,6 +1,6 @@
 import {TextDocument} from 'vscode-languageserver-textdocument';
-import {KsonTooling, ToolingDocument} from 'kson-tooling';
-import {KsonDocument} from './KsonDocument.js';
+import {ToolingDocument} from 'kson-tooling';
+import {KsonDocument, parseTextDocument} from './KsonDocument.js';
 
 /**
  * A KsonDocument that represents a schema file.
@@ -33,7 +33,7 @@ export class KsonSchemaDocument extends KsonDocument {
     getMetaSchemaToolingDocument(): ToolingDocument | undefined {
         if (!this.metaSchemaDocument) return undefined;
         if (!this._metaSchemaToolingDocument) {
-            this._metaSchemaToolingDocument = KsonTooling.getInstance().parse(this.metaSchemaDocument.getText(), this.metaSchemaDocument.uri);
+            this._metaSchemaToolingDocument = parseTextDocument(this.metaSchemaDocument);
         }
         return this._metaSchemaToolingDocument;
     }

--- a/tooling/language-server-protocol/src/test/TestHelpers.ts
+++ b/tooling/language-server-protocol/src/test/TestHelpers.ts
@@ -1,7 +1,6 @@
 import {TextDocument} from 'vscode-languageserver-textdocument';
 import {Position} from 'vscode-languageserver';
-import {KsonTooling} from 'kson-tooling';
-import {KsonDocument} from '../core/document/KsonDocument.js';
+import {KsonDocument, parseTextDocument} from '../core/document/KsonDocument.js';
 import {KsonSchemaDocument} from '../core/document/KsonSchemaDocument.js';
 
 export const TEST_URI = 'file:///test.kson';
@@ -12,7 +11,7 @@ export const SCHEMA_URI = 'file:///schema.kson';
  */
 export function createKsonDocument(content: string, schemaContent?: string): KsonDocument {
     const textDoc = TextDocument.create(TEST_URI, 'kson', 1, content);
-    const toolingDoc = KsonTooling.getInstance().parse(content);
+    const toolingDoc = parseTextDocument(textDoc);
     const schemaDoc = schemaContent
         ? TextDocument.create(SCHEMA_URI, 'kson', 1, schemaContent)
         : undefined;
@@ -24,7 +23,7 @@ export function createKsonDocument(content: string, schemaContent?: string): Kso
  */
 export function createKsonSchemaDocument(content: string, metaSchemaContent?: string): KsonSchemaDocument {
     const textDoc = TextDocument.create(SCHEMA_URI, 'kson', 1, content);
-    const toolingDoc = KsonTooling.getInstance().parse(content);
+    const toolingDoc = parseTextDocument(textDoc);
     const metaSchemaDoc = metaSchemaContent
         ? TextDocument.create('bundled://metaschema/draft-07.schema.kson', 'kson', 1, metaSchemaContent)
         : undefined;

--- a/tooling/language-server-protocol/src/test/core/document/KsonSchemaDocument.test.ts
+++ b/tooling/language-server-protocol/src/test/core/document/KsonSchemaDocument.test.ts
@@ -1,8 +1,7 @@
 import {describe, it} from 'mocha';
 import * as assert from 'assert';
 import {TextDocument} from 'vscode-languageserver-textdocument';
-import {KsonTooling} from 'kson-tooling';
-import {KsonDocument} from '../../../core/document/KsonDocument.js';
+import {KsonDocument, parseTextDocument} from '../../../core/document/KsonDocument.js';
 import {KsonSchemaDocument, isKsonSchemaDocument} from '../../../core/document/KsonSchemaDocument.js';
 
 describe('KsonSchemaDocument', () => {
@@ -24,7 +23,7 @@ describe('KsonSchemaDocument', () => {
 
     function createSchemaDocument(metaSchema?: TextDocument): KsonSchemaDocument {
         const textDoc = TextDocument.create('file:///my-schema.kson', 'kson', 1, schemaContent);
-        const toolingDoc = KsonTooling.getInstance().parse(schemaContent);
+        const toolingDoc = parseTextDocument(textDoc);
         return new KsonSchemaDocument(textDoc, toolingDoc, metaSchema);
     }
 
@@ -64,7 +63,7 @@ describe('KsonSchemaDocument', () => {
         it('should return false for plain KsonDocument', () => {
             const content = '{ "name": "test" }';
             const textDoc = TextDocument.create('file:///test.kson', 'kson', 1, content);
-            const toolingDoc = KsonTooling.getInstance().parse(content);
+            const toolingDoc = parseTextDocument(textDoc);
             const doc = new KsonDocument(textDoc, toolingDoc);
             assert.strictEqual(isKsonSchemaDocument(doc), false);
         });
@@ -72,7 +71,7 @@ describe('KsonSchemaDocument', () => {
         it('should return false for KsonDocument with schema', () => {
             const content = '{ "name": "test" }';
             const textDoc = TextDocument.create('file:///test.kson', 'kson', 1, content);
-            const toolingDoc = KsonTooling.getInstance().parse(content);
+            const toolingDoc = parseTextDocument(textDoc);
             const schemaDoc = TextDocument.create('file:///schema.kson', 'kson', 1, '{ "type": "object" }');
             const doc = new KsonDocument(textDoc, toolingDoc, schemaDoc);
             assert.strictEqual(isKsonSchemaDocument(doc), false);
@@ -87,7 +86,7 @@ describe('KsonDocument.getSchemaId', () => {
     "type": "object"
 }`;
         const textDoc = TextDocument.create('file:///test.kson', 'kson', 1, content);
-        const toolingDoc = KsonTooling.getInstance().parse(content);
+        const toolingDoc = parseTextDocument(textDoc);
         const doc = new KsonDocument(textDoc, toolingDoc);
 
         assert.strictEqual(doc.getSchemaId(), 'http://json-schema.org/draft-07/schema#');
@@ -96,7 +95,7 @@ describe('KsonDocument.getSchemaId', () => {
     it('should return undefined when no $schema field', () => {
         const content = '{ "type": "object" }';
         const textDoc = TextDocument.create('file:///test.kson', 'kson', 1, content);
-        const toolingDoc = KsonTooling.getInstance().parse(content);
+        const toolingDoc = parseTextDocument(textDoc);
         const doc = new KsonDocument(textDoc, toolingDoc);
 
         assert.strictEqual(doc.getSchemaId(), undefined);
@@ -105,7 +104,7 @@ describe('KsonDocument.getSchemaId', () => {
     it('should return undefined for non-object document', () => {
         const content = '"just a string"';
         const textDoc = TextDocument.create('file:///test.kson', 'kson', 1, content);
-        const toolingDoc = KsonTooling.getInstance().parse(content);
+        const toolingDoc = parseTextDocument(textDoc);
         const doc = new KsonDocument(textDoc, toolingDoc);
 
         assert.strictEqual(doc.getSchemaId(), undefined);
@@ -114,7 +113,7 @@ describe('KsonDocument.getSchemaId', () => {
     it('should return undefined when $schema is not a string', () => {
         const content = '{ "$schema": 42 }';
         const textDoc = TextDocument.create('file:///test.kson', 'kson', 1, content);
-        const toolingDoc = KsonTooling.getInstance().parse(content);
+        const toolingDoc = parseTextDocument(textDoc);
         const doc = new KsonDocument(textDoc, toolingDoc);
 
         assert.strictEqual(doc.getSchemaId(), undefined);

--- a/tooling/language-server-protocol/src/test/core/features/CodeLensService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/CodeLensService.test.ts
@@ -5,8 +5,7 @@ import assert from 'assert';
 import {FormattingStyle} from 'kson'
 import {createKsonDocument, TEST_URI} from '../../TestHelpers.js';
 import {TextDocument} from 'vscode-languageserver-textdocument';
-import {KsonTooling} from 'kson-tooling';
-import {KsonDocument} from '../../../core/document/KsonDocument.js';
+import {KsonDocument, parseTextDocument} from '../../../core/document/KsonDocument.js';
 
 describe('CodeLensService', () => {
     const service = new CodeLensService();
@@ -76,7 +75,7 @@ describe('CodeLensService', () => {
     it('should use the document URI from the provided document', () => {
         const customUri = 'file:///custom/path/doc.kson';
         const textDoc = TextDocument.create(customUri, 'kson', 1, 'key: value');
-        const toolingDoc = KsonTooling.getInstance().parse('key: value');
+        const toolingDoc = parseTextDocument(textDoc);
         const document = new KsonDocument(textDoc, toolingDoc);
 
         const lenses = service.getCodeLenses(document);


### PR DESCRIPTION
`KsonTooling.parse` takes an optional filepath that feeds `SourceContext`, but `KsonDocumentsManager` dropped it on every document create/update and several test sites did the same. Introduce `parseTextDocument()` as the single site for parsing a `TextDocument`-backed source, and route all such sites through it.
