### PR TITLE
Fix hover docs missing for embed block descriptions

### DIFF
--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/navigation/SchemaInformation.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/navigation/SchemaInformation.kt
@@ -131,9 +131,11 @@ fun InternalKsonValue.extractSchemaInfo(): String? {
         }
 
         // Description (main documentation)
-        (props["description"] as? InternalKsonString)?.value?.let {
-            append("$it\n\n")
-        }
+        when (val desc = props["description"]) {
+            is InternalKsonString -> desc.value
+            is InternalEmbedBlock -> desc.embedContent.value
+            else -> null
+        }?.let { append("$it\n\n") }
 
         // Type information
         when (val typeValue: InternalKsonValue? = props["type"]) {

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaInfoDisplayTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaInfoDisplayTest.kt
@@ -34,6 +34,26 @@ class SchemaInfoDisplayTest {
     }
 
     @Test
+    fun testExtractHoverWithEmbedBlockDescription() {
+        val hoverInfo = getHoverInfo("""
+            {
+                title: "Query"
+                description: %
+                  Multi-line documentation
+                  written in an embed block
+                %%
+                type: "string"
+            }
+        """)
+
+        assertNotNull(hoverInfo)
+        assertTrue(hoverInfo.contains("Multi-line documentation"))
+        assertTrue(hoverInfo.contains("written in an embed block"))
+        assertTrue(hoverInfo.contains("**Query**"))
+        assertTrue(hoverInfo.contains("*Type:* `string`"))
+    }
+
+    @Test
     fun testExtractHoverWithDescriptionOnly() {
         val hoverInfo = getHoverInfo("""
             {


### PR DESCRIPTION
`extractSchemaInfo` only checked for `InternalKsonString` when reading the description field, so schemas using embed blocks for documentation silently showed nothing. Now handles `InternalEmbedBlock` too.