### PR TITLE
Walk AST instead of token stream for folding ranges

### DIFF
--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/FoldingRangeBuilder.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/FoldingRangeBuilder.kt
@@ -1,89 +1,97 @@
 package org.kson.tooling
 
+import org.kson.ast.*
 import org.kson.parser.Token
 import org.kson.parser.TokenType
 
 /**
- * Builds [StructuralRange] lists from KSON source by matching open/close bracket pairs.
+ * Builds [StructuralRange] lists from a KSON document's AST and token stream.
  *
- * Walks the token stream and uses a stack to pair opening delimiters
- * (`{`, `[`, embed open) with their closing counterparts. Only emits
- * ranges that span multiple lines (single-line constructs don't fold).
+ * Walks the AST recursively to emit folding ranges for all multi-line
+ * structural constructs: objects, lists (bracket, angle-bracket, and dash),
+ * object properties, and embed blocks. Also scans the token stream for
+ * consecutive comment lines to produce comment folding ranges.
  */
 internal object FoldingRangeBuilder {
 
-    fun build(tokens: List<Token>): List<StructuralRange> {
+    fun build(rootNode: AstNode?, tokens: List<Token>): List<StructuralRange> {
         val ranges = mutableListOf<StructuralRange>()
-
-        val stack = mutableListOf<OpenToken>()
-
-        for (token in tokens) {
-            when (token.tokenType) {
-                TokenType.CURLY_BRACE_L ->
-                    stack.add(OpenToken(OpenTokenType.BRACE, token.lexeme.location.start.line))
-
-                TokenType.CURLY_BRACE_R -> {
-                    val open = popMatching(stack, OpenTokenType.BRACE)
-                    if (open != null && token.lexeme.location.start.line > open.startLine) {
-                        ranges.add(
-                            StructuralRange(
-                                open.startLine,
-                                token.lexeme.location.start.line,
-                                StructuralRangeKind.OBJECT
-                            )
-                        )
-                    }
-                }
-
-                TokenType.SQUARE_BRACKET_L ->
-                    stack.add(OpenToken(OpenTokenType.BRACKET, token.lexeme.location.start.line))
-
-                TokenType.SQUARE_BRACKET_R -> {
-                    val open = popMatching(stack, OpenTokenType.BRACKET)
-                    if (open != null && token.lexeme.location.start.line > open.startLine) {
-                        ranges.add(
-                            StructuralRange(
-                                open.startLine,
-                                token.lexeme.location.start.line,
-                                StructuralRangeKind.ARRAY
-                            )
-                        )
-                    }
-                }
-
-                TokenType.EMBED_OPEN_DELIM ->
-                    stack.add(OpenToken(OpenTokenType.EMBED, token.lexeme.location.start.line))
-
-                TokenType.EMBED_CLOSE_DELIM -> {
-                    val open = popMatching(stack, OpenTokenType.EMBED)
-                    if (open != null && token.lexeme.location.start.line > open.startLine) {
-                        ranges.add(
-                            StructuralRange(
-                                open.startLine,
-                                token.lexeme.location.start.line,
-                                StructuralRangeKind.EMBED
-                            )
-                        )
-                    }
-                }
-
-                else -> {}
-            }
+        if (rootNode != null) {
+            collectFromAst(rootNode, ranges)
         }
-
+        collectCommentBlocks(tokens, ranges)
         return ranges
     }
 
-    private fun popMatching(stack: MutableList<OpenToken>, type: OpenTokenType): OpenToken? {
-        for (i in stack.indices.reversed()) {
-            if (stack[i].type == type) {
-                return stack.removeAt(i)
+    private fun collectFromAst(node: AstNode, ranges: MutableList<StructuralRange>) {
+        when (node) {
+            is ObjectNode -> {
+                addMultiLineRange(node, StructuralRangeKind.OBJECT, ranges)
+                for (property in node.properties) {
+                    collectFromAst(property, ranges)
+                }
             }
+            is ObjectPropertyNodeImpl -> {
+                addMultiLineRange(node, StructuralRangeKind.PROPERTY, ranges)
+                if (node.value is ListNode) {
+                    for (element in (node.value as ListNode).elements) {
+                        collectFromAst(element, ranges)
+                    }
+                } else {
+                    collectFromAst(node.value, ranges)
+                }
+            }
+            is ListNode -> {
+                addMultiLineRange(node, StructuralRangeKind.ARRAY, ranges)
+                for (element in node.elements) {
+                    collectFromAst(element, ranges)
+                }
+            }
+            is ListElementNodeImpl -> {
+                collectFromAst(node.value, ranges)
+            }
+            is EmbedBlockNode -> {
+                addMultiLineRange(node, StructuralRangeKind.EMBED, ranges)
+            }
+            else -> {}
         }
-        return null
     }
 
-    private data class OpenToken(val type: OpenTokenType, val startLine: Int)
+    private fun addMultiLineRange(node: AstNode, kind: StructuralRangeKind, ranges: MutableList<StructuralRange>) {
+        val location = node.location
+        if (location.end.line > location.start.line) {
+            ranges.add(StructuralRange(location.start.line, location.end.line, kind))
+        }
+    }
 
-    private enum class OpenTokenType { BRACE, BRACKET, EMBED }
+    /**
+     * Scans the token stream for runs of consecutive COMMENT tokens and
+     * emits a COMMENT range for each run that spans multiple lines.
+     */
+    private fun collectCommentBlocks(tokens: List<Token>, ranges: MutableList<StructuralRange>) {
+        var blockStartLine = -1
+        var blockEndLine = -1
+
+        for (token in tokens) {
+            if (token.tokenType == TokenType.COMMENT) {
+                val line = token.lexeme.location.start.line
+                if (blockStartLine < 0 || line != blockEndLine + 1) {
+                    if (blockStartLine >= 0 && blockEndLine > blockStartLine) {
+                        ranges.add(StructuralRange(blockStartLine, blockEndLine, StructuralRangeKind.COMMENT))
+                    }
+                    blockStartLine = line
+                }
+                blockEndLine = line
+            } else if (token.tokenType != TokenType.WHITESPACE) {
+                if (blockStartLine >= 0 && blockEndLine > blockStartLine) {
+                    ranges.add(StructuralRange(blockStartLine, blockEndLine, StructuralRangeKind.COMMENT))
+                }
+                blockStartLine = -1
+            }
+        }
+
+        if (blockStartLine >= 0 && blockEndLine > blockStartLine) {
+            ranges.add(StructuralRange(blockStartLine, blockEndLine, StructuralRangeKind.COMMENT))
+        }
+    }
 }

--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/KsonTooling.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/KsonTooling.kt
@@ -201,14 +201,15 @@ object KsonTooling {
     /**
      * Get structural ranges (foldable regions) from a pre-parsed [ToolingDocument].
      *
-     * Identifies multi-line objects, arrays, and embed blocks that can
-     * be collapsed in an editor. Single-line constructs are excluded.
+     * Identifies multi-line objects, arrays (bracket, angle-bracket, and dash),
+     * object properties, embed blocks, and comment blocks that can be collapsed
+     * in an editor. Single-line constructs are excluded.
      *
      * @param document The pre-parsed KSON document
      * @return List of structural ranges, each spanning at least two lines
      */
     fun getStructuralRanges(document: ToolingDocument): List<StructuralRange> {
-        return FoldingRangeBuilder.build(document.tokens)
+        return FoldingRangeBuilder.build(document.rootAstNode, document.tokens)
     }
 
     /**
@@ -411,7 +412,9 @@ data class StructuralRange(val startLine: Int, val endLine: Int, val kind: Struc
 enum class StructuralRangeKind {
     OBJECT,
     ARRAY,
-    EMBED
+    EMBED,
+    PROPERTY,
+    COMMENT
 }
 
 /**

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/FoldingRangeTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/FoldingRangeTest.kt
@@ -13,7 +13,7 @@ class FoldingRangeTest {
     }
 
     @Test
-    fun testMultiLineObject() {
+    fun testMultiLineDelimitedObject() {
         val content = """
             {
               name: "Alice"
@@ -22,14 +22,13 @@ class FoldingRangeTest {
         """.trimIndent()
         val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
 
-        assertEquals(1, ranges.size)
-        assertEquals(0, ranges[0].startLine)
-        assertEquals(3, ranges[0].endLine)
-        assertEquals(StructuralRangeKind.OBJECT, ranges[0].kind)
+        val objectRange = ranges.single { it.kind == StructuralRangeKind.OBJECT }
+        assertEquals(0, objectRange.startLine)
+        assertEquals(3, objectRange.endLine)
     }
 
     @Test
-    fun testNestedObjects() {
+    fun testNestedDelimitedObjects() {
         val content = """
             {
               person: {
@@ -39,17 +38,15 @@ class FoldingRangeTest {
         """.trimIndent()
         val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
 
-        assertEquals(2, ranges.size)
-        // Inner object folds from line 1 to line 3
-        val innerRange = ranges.find { it.startLine == 1 }
-        assertNotNull(innerRange)
-        assertEquals(3, innerRange.endLine)
-        assertEquals(StructuralRangeKind.OBJECT, innerRange.kind)
-        // Outer object folds from line 0 to line 4
-        val outerRange = ranges.find { it.startLine == 0 }
-        assertNotNull(outerRange)
-        assertEquals(4, outerRange.endLine)
-        assertEquals(StructuralRangeKind.OBJECT, outerRange.kind)
+        val outerObject = ranges.single { it.kind == StructuralRangeKind.OBJECT && it.startLine == 0 }
+        assertEquals(4, outerObject.endLine)
+
+        val innerObject = ranges.single { it.kind == StructuralRangeKind.OBJECT && it.startLine == 1 }
+        assertEquals(3, innerObject.endLine)
+
+        val property = ranges.single { it.kind == StructuralRangeKind.PROPERTY }
+        assertEquals(1, property.startLine)
+        assertEquals(3, property.endLine)
     }
 
     @Test
@@ -63,10 +60,9 @@ class FoldingRangeTest {
         """.trimIndent()
         val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
 
-        assertEquals(1, ranges.size)
-        assertEquals(0, ranges[0].startLine)
-        assertEquals(4, ranges[0].endLine)
-        assertEquals(StructuralRangeKind.ARRAY, ranges[0].kind)
+        val arrayRange = ranges.single { it.kind == StructuralRangeKind.ARRAY }
+        assertEquals(0, arrayRange.startLine)
+        assertEquals(4, arrayRange.endLine)
     }
 
     @Test
@@ -79,10 +75,9 @@ class FoldingRangeTest {
         """.trimIndent()
         val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
 
-        assertEquals(1, ranges.size)
-        assertEquals(0, ranges[0].startLine)
-        assertEquals(3, ranges[0].endLine)
-        assertEquals(StructuralRangeKind.EMBED, ranges[0].kind)
+        val embedRange = ranges.single { it.kind == StructuralRangeKind.EMBED }
+        assertEquals(0, embedRange.startLine)
+        assertEquals(3, embedRange.endLine)
     }
 
     @Test
@@ -112,21 +107,179 @@ class FoldingRangeTest {
         """.trimIndent()
         val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
 
-        assertEquals(3, ranges.size)
-
-        val arrayRange = ranges.find { it.kind == StructuralRangeKind.ARRAY }
-        assertNotNull(arrayRange)
-        assertEquals(1, arrayRange.startLine)
-        assertEquals(4, arrayRange.endLine)
-
-        val embedRange = ranges.find { it.kind == StructuralRangeKind.EMBED }
-        assertNotNull(embedRange)
+        val embedRange = ranges.single { it.kind == StructuralRangeKind.EMBED }
         assertEquals(5, embedRange.startLine)
         assertEquals(7, embedRange.endLine)
 
-        val objectRange = ranges.find { it.kind == StructuralRangeKind.OBJECT }
-        assertNotNull(objectRange)
+        val objectRange = ranges.single { it.kind == StructuralRangeKind.OBJECT }
         assertEquals(0, objectRange.startLine)
         assertEquals(8, objectRange.endLine)
+
+        // items: and code: get PROPERTY folds; the bracket list inside items:
+        // does NOT get a separate ARRAY fold since the PROPERTY fold covers it
+        val properties = ranges.filter { it.kind == StructuralRangeKind.PROPERTY }
+        assertEquals(2, properties.size)
+        assertTrue(ranges.none { it.kind == StructuralRangeKind.ARRAY })
+    }
+
+    @Test
+    fun testDashList() {
+        val content = """
+            - one
+            - two
+            - three
+        """.trimIndent()
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        val listRange = ranges.single { it.kind == StructuralRangeKind.ARRAY }
+        assertEquals(0, listRange.startLine)
+        assertEquals(2, listRange.endLine)
+    }
+
+    @Test
+    fun testAngleBracketList() {
+        val content = """
+            items: <
+              - one
+              - two
+            >
+        """.trimIndent()
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        // Angle-bracket list is a property value — the PROPERTY fold covers it
+        assertTrue(ranges.none { it.kind == StructuralRangeKind.ARRAY })
+        val property = ranges.single { it.kind == StructuralRangeKind.PROPERTY }
+        assertEquals(0, property.startLine)
+        assertEquals(3, property.endLine)
+    }
+
+    @Test
+    fun testMultiLineObjectProperty() {
+        val content = """
+            person:
+              name: "Alice"
+              age: 30
+        """.trimIndent()
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        val propertyRange = ranges.single { it.kind == StructuralRangeKind.PROPERTY }
+        assertEquals(0, propertyRange.startLine)
+        assertEquals(2, propertyRange.endLine)
+    }
+
+    @Test
+    fun testSingleLinePropertyDoesNotFold() {
+        val content = "name: \"Alice\""
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        val properties = ranges.filter { it.kind == StructuralRangeKind.PROPERTY }
+        assertEquals(0, properties.size)
+    }
+
+    @Test
+    fun testCommentBlock() {
+        val content = """
+            # This is a comment
+            # that spans multiple lines
+            name: "Alice"
+        """.trimIndent()
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        val commentRange = ranges.single { it.kind == StructuralRangeKind.COMMENT }
+        assertEquals(0, commentRange.startLine)
+        assertEquals(1, commentRange.endLine)
+    }
+
+    @Test
+    fun testSingleCommentLineDoesNotFold() {
+        val content = """
+            # Just one comment
+            name: "Alice"
+        """.trimIndent()
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        val commentRanges = ranges.filter { it.kind == StructuralRangeKind.COMMENT }
+        assertEquals(0, commentRanges.size)
+    }
+
+    @Test
+    fun testMultipleCommentBlocks() {
+        val content = """
+            # Block one
+            # continues here
+            name: "Alice"
+            # Block two
+            # also continues
+            age: 30
+        """.trimIndent()
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        val commentRanges = ranges.filter { it.kind == StructuralRangeKind.COMMENT }
+        assertEquals(2, commentRanges.size)
+        assertEquals(0, commentRanges[0].startLine)
+        assertEquals(1, commentRanges[0].endLine)
+        assertEquals(3, commentRanges[1].startLine)
+        assertEquals(4, commentRanges[1].endLine)
+    }
+
+    @Test
+    fun testCommentBlocksSeparatedByBlankLine() {
+        val content = """
+            # Block one
+            # continues here
+
+            # Block two
+            # also continues
+            name: "Alice"
+        """.trimIndent()
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        val commentRanges = ranges.filter { it.kind == StructuralRangeKind.COMMENT }
+        assertEquals(2, commentRanges.size)
+        assertEquals(0, commentRanges[0].startLine)
+        assertEquals(1, commentRanges[0].endLine)
+        assertEquals(3, commentRanges[1].startLine)
+        assertEquals(4, commentRanges[1].endLine)
+    }
+
+    @Test
+    fun testNestedDashListWithObjects() {
+        val content = """
+            items:
+              - name: "Alice"
+                age: 30
+              - name: "Bob"
+                age: 25
+        """.trimIndent()
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        // The dash list is a property value, so no separate ARRAY fold —
+        // the PROPERTY fold for items: covers it
+        assertTrue(ranges.none { it.kind == StructuralRangeKind.ARRAY })
+        val property = ranges.single { it.kind == StructuralRangeKind.PROPERTY && it.startLine == 0 }
+        assertEquals(4, property.endLine)
+    }
+
+    @Test
+    fun testEmbedInDashListFoldsIndependently() {
+        val content = """
+            key: value
+            list:
+              - this: key: %typescript
+                  This is typescript
+                  %%
+              - 2
+              - 3
+        """.trimIndent()
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        // Folding at line 2 should only fold the embed (lines 3-4),
+        // not the entire list — "- 2" and "- 3" stay visible
+        val embedRange = ranges.single { it.kind == StructuralRangeKind.EMBED }
+        assertEquals(2, embedRange.startLine)
+        assertEquals(4, embedRange.endLine)
+
+        // No ARRAY fold at line 2 — the PROPERTY fold for list: handles the list
+        assertTrue(ranges.none { it.kind == StructuralRangeKind.ARRAY })
     }
 }

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/FoldingRangeTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/FoldingRangeTest.kt
@@ -261,6 +261,86 @@ class FoldingRangeTest {
     }
 
     @Test
+    fun testDeeplyNestedObjects() {
+        val content = """
+            root:
+              level1:
+                level2:
+                  level3:
+                    value: "deep"
+        """.trimIndent()
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        val root = ranges.single { it.kind == StructuralRangeKind.PROPERTY && it.startLine == 0 }
+        assertEquals(4, root.endLine)
+
+        val level1 = ranges.single { it.kind == StructuralRangeKind.PROPERTY && it.startLine == 1 }
+        assertEquals(4, level1.endLine)
+
+        val level2 = ranges.single { it.kind == StructuralRangeKind.PROPERTY && it.startLine == 2 }
+        assertEquals(4, level2.endLine)
+
+        val level3 = ranges.single { it.kind == StructuralRangeKind.PROPERTY && it.startLine == 3 }
+        assertEquals(4, level3.endLine)
+    }
+
+    @Test
+    fun testDeeplyNestedDashListsAndObjects() {
+        val content = """
+            items:
+              - name: "First"
+                children:
+                  - id: 1
+                    meta:
+                      tag: "a"
+                      .
+                  - id: 2
+                    meta:
+                      tag: "b"
+                      .
+                  =
+              - name: "Second"
+                children:
+                  - id: 3
+                    meta:
+                      tag: "c"
+        """.trimIndent()
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        val items = ranges.single { it.kind == StructuralRangeKind.PROPERTY && it.startLine == 0 }
+        assertEquals(16, items.endLine)
+
+        assertTrue(
+            ranges.any { it.kind == StructuralRangeKind.PROPERTY && it.startLine == 2 },
+            "Expected the children block to produce a foldable property range"
+        )
+
+        assertTrue(
+            ranges.any { it.kind == StructuralRangeKind.PROPERTY && it.startLine == 4 },
+            "Expected the nested meta block to produce a foldable property range"
+        )
+    }
+
+    @Test
+    fun testNestedStructureInsideEmbed() {
+        val content = $$"""
+            query: $sql
+              select * from users
+              where id in (
+                \$\$ nested:
+                  inner:
+                    value: 1
+              )
+              $$
+        """.trimIndent()
+        val ranges = KsonTooling.getStructuralRanges(KsonTooling.parse(content))
+
+        val embedRange = ranges.single { it.kind == StructuralRangeKind.EMBED }
+        assertEquals(0, embedRange.startLine)
+        assertEquals(7, embedRange.endLine)
+    }
+
+    @Test
     fun testEmbedInDashListFoldsIndependently() {
         val content = """
             key: value

--- a/tooling/language-server-protocol/src/core/features/FoldingRangeService.ts
+++ b/tooling/language-server-protocol/src/core/features/FoldingRangeService.ts
@@ -1,5 +1,5 @@
 import {FoldingRange, FoldingRangeKind} from 'vscode-languageserver';
-import {KsonTooling, ToolingDocument} from 'kson-tooling';
+import {KsonTooling, ToolingDocument, StructuralRangeKind} from 'kson-tooling';
 
 /**
  * Service responsible for providing folding ranges for KSON documents.
@@ -11,7 +11,7 @@ export class FoldingRangeService {
         return KsonTooling.getInstance().getStructuralRanges(document).asJsReadonlyArrayView().map(sr => ({
             startLine: sr.startLine,
             endLine: sr.endLine,
-            kind: FoldingRangeKind.Region
+            kind: sr.kind === StructuralRangeKind.COMMENT ? FoldingRangeKind.Comment : FoldingRangeKind.Region
         }));
     }
 }

--- a/tooling/language-server-protocol/src/test/core/features/FoldingRangeService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/FoldingRangeService.test.ts
@@ -7,27 +7,30 @@ import {KsonTooling} from 'kson-tooling';
 describe('FoldingRangeService', () => {
     const service = new FoldingRangeService();
 
+    function parse(content: string) {
+        return KsonTooling.getInstance().parse(content);
+    }
+
     it('should return no folding ranges for single-line document', () => {
-        const ranges = service.getFoldingRanges(KsonTooling.getInstance().parse('key: value'));
+        const ranges = service.getFoldingRanges(parse('key: value'));
         assert.strictEqual(ranges.length, 0);
     });
 
-    it('should fold a multi-line object', () => {
+    it('should fold a multi-line delimited object', () => {
         const content = [
             '{',
             '  name: "Alice"',
             '  age: 30',
             '}'
         ].join('\n');
-        const ranges = service.getFoldingRanges(KsonTooling.getInstance().parse(content));
+        const ranges = service.getFoldingRanges(parse(content));
 
-        assert.strictEqual(ranges.length, 1);
-        assert.strictEqual(ranges[0].startLine, 0);
-        assert.strictEqual(ranges[0].endLine, 3);
-        assert.strictEqual(ranges[0].kind, FoldingRangeKind.Region);
+        const objectRange = ranges.find(r => r.kind === FoldingRangeKind.Region && r.startLine === 0);
+        assert.ok(objectRange);
+        assert.strictEqual(objectRange!.endLine, 3);
     });
 
-    it('should fold nested objects', () => {
+    it('should fold nested objects with property ranges', () => {
         const content = [
             '{',
             '  person: {',
@@ -35,17 +38,15 @@ describe('FoldingRangeService', () => {
             '  }',
             '}'
         ].join('\n');
-        const ranges = service.getFoldingRanges(KsonTooling.getInstance().parse(content));
+        const ranges = service.getFoldingRanges(parse(content));
 
-        assert.strictEqual(ranges.length, 2);
-        // Inner object folds from line 1 to line 3
-        const innerRange = ranges.find(r => r.startLine === 1);
-        assert.ok(innerRange);
-        assert.strictEqual(innerRange!.endLine, 3);
-        // Outer object folds from line 0 to line 4
-        const outerRange = ranges.find(r => r.startLine === 0);
+        // Outer object
+        const outerRange = ranges.find(r => r.startLine === 0 && r.endLine === 4);
         assert.ok(outerRange);
-        assert.strictEqual(outerRange!.endLine, 4);
+
+        // Inner object and property both at lines 1-3
+        const innerRanges = ranges.filter(r => r.startLine === 1 && r.endLine === 3);
+        assert.strictEqual(innerRanges.length, 2);
     });
 
     it('should fold a multi-line array', () => {
@@ -56,11 +57,11 @@ describe('FoldingRangeService', () => {
             '  3',
             ']'
         ].join('\n');
-        const ranges = service.getFoldingRanges(KsonTooling.getInstance().parse(content));
+        const ranges = service.getFoldingRanges(parse(content));
 
-        assert.strictEqual(ranges.length, 1);
-        assert.strictEqual(ranges[0].startLine, 0);
-        assert.strictEqual(ranges[0].endLine, 4);
+        const arrayRange = ranges.find(r => r.startLine === 0 && r.endLine === 4);
+        assert.ok(arrayRange);
+        assert.strictEqual(arrayRange!.kind, FoldingRangeKind.Region);
     });
 
     it('should fold an embed block', () => {
@@ -70,20 +71,20 @@ describe('FoldingRangeService', () => {
             '  FROM users',
             '  $$'
         ].join('\n');
-        const ranges = service.getFoldingRanges(KsonTooling.getInstance().parse(content));
+        const ranges = service.getFoldingRanges(parse(content));
 
-        assert.strictEqual(ranges.length, 1);
-        assert.strictEqual(ranges[0].startLine, 0);
-        assert.strictEqual(ranges[0].endLine, 3);
+        const embedRange = ranges.find(r => r.startLine === 0 && r.endLine === 3);
+        assert.ok(embedRange);
+        assert.strictEqual(embedRange!.kind, FoldingRangeKind.Region);
     });
 
     it('should not fold single-line objects', () => {
-        const ranges = service.getFoldingRanges(KsonTooling.getInstance().parse('{ name: "Alice", age: 30 }'));
+        const ranges = service.getFoldingRanges(parse('{ name: "Alice", age: 30 }'));
         assert.strictEqual(ranges.length, 0);
     });
 
     it('should handle empty document', () => {
-        const ranges = service.getFoldingRanges(KsonTooling.getInstance().parse(''));
+        const ranges = service.getFoldingRanges(parse(''));
         assert.strictEqual(ranges.length, 0);
     });
 
@@ -99,20 +100,66 @@ describe('FoldingRangeService', () => {
             '    $$',
             '}'
         ].join('\n');
-        const ranges = service.getFoldingRanges(KsonTooling.getInstance().parse(content));
+        const ranges = service.getFoldingRanges(parse(content));
 
-        assert.strictEqual(ranges.length, 3);
-
-        const arrayRange = ranges.find(r => r.startLine === 1);
+        const arrayRange = ranges.find(r => r.startLine === 1 && r.endLine === 4);
         assert.ok(arrayRange);
-        assert.strictEqual(arrayRange!.endLine, 4);
 
-        const embedRange = ranges.find(r => r.startLine === 5);
+        const embedRange = ranges.find(r => r.startLine === 5 && r.endLine === 7);
         assert.ok(embedRange);
-        assert.strictEqual(embedRange!.endLine, 7);
 
-        const objectRange = ranges.find(r => r.startLine === 0);
+        const objectRange = ranges.find(r => r.startLine === 0 && r.endLine === 8);
         assert.ok(objectRange);
-        assert.strictEqual(objectRange!.endLine, 8);
+    });
+
+    it('should fold a dash list', () => {
+        const content = [
+            '- one',
+            '- two',
+            '- three'
+        ].join('\n');
+        const ranges = service.getFoldingRanges(parse(content));
+
+        const listRange = ranges.find(r => r.startLine === 0 && r.endLine === 2);
+        assert.ok(listRange);
+        assert.strictEqual(listRange!.kind, FoldingRangeKind.Region);
+    });
+
+    it('should fold a multi-line object property', () => {
+        const content = [
+            'person:',
+            '  name: "Alice"',
+            '  age: 30'
+        ].join('\n');
+        const ranges = service.getFoldingRanges(parse(content));
+
+        const propertyRange = ranges.find(r => r.startLine === 0 && r.endLine === 2);
+        assert.ok(propertyRange);
+        assert.strictEqual(propertyRange!.kind, FoldingRangeKind.Region);
+    });
+
+    it('should fold comment blocks with Comment kind', () => {
+        const content = [
+            '# This is a comment',
+            '# that spans multiple lines',
+            'name: "Alice"'
+        ].join('\n');
+        const ranges = service.getFoldingRanges(parse(content));
+
+        const commentRange = ranges.find(r => r.kind === FoldingRangeKind.Comment);
+        assert.ok(commentRange);
+        assert.strictEqual(commentRange!.startLine, 0);
+        assert.strictEqual(commentRange!.endLine, 1);
+    });
+
+    it('should not fold a single comment line', () => {
+        const content = [
+            '# Just one comment',
+            'name: "Alice"'
+        ].join('\n');
+        const ranges = service.getFoldingRanges(parse(content));
+
+        const commentRanges = ranges.filter(r => r.kind === FoldingRangeKind.Comment);
+        assert.strictEqual(commentRanges.length, 0);
     });
 });


### PR DESCRIPTION
The token-based bracket matching only produced folds for {}, [], and embed blocks. Registering a foldingRangeProvider replaces VS Code's built-in indentation folding, so dash lists, object properties, and comment blocks all lost their ability to fold.

Switch FoldingRangeBuilder to walk the AST, which naturally covers all multi-line constructs. Add comment-block folding from the token stream. Skip the ARRAY fold when a list is a property value — the PROPERTY fold covers it, preventing the list fold from shadowing inner folds like embeds at the same start line.