### PR TITLE
Harden iframe embed: suppress setValue echo + stabilize Playwright tests

### DIFF
--- a/tooling/lsp-clients/monaco/src/iframe/iframeEntry.ts
+++ b/tooling/lsp-clients/monaco/src/iframe/iframeEntry.ts
@@ -3,8 +3,8 @@
  *
  * This script runs inside the iframe created by KsonEditorClient.  It posts
  * `kson:ready` to the parent, waits for `kson:init` with the initial value
- * and options, creates the editor, and relays content changes back via
- * `kson:change`.
+ * and options, creates the editor, and relays user content changes back via
+ * `kson:change` (programmatic setValue flushes are not relayed).
  */
 
 import { createKsonEditor, type KsonEditor } from '../index.js';
@@ -49,9 +49,10 @@ async function init(msg: InitMessage): Promise<KsonEditor> {
         editorOptions: msg.editorOptions as Record<string, unknown> | undefined,
     });
 
-    // Relay content changes to the parent.
     const model = ksonEditor.editor.getModel()!;
-    model.onDidChangeContent(() => {
+    model.onDidChangeContent((e) => {
+        // Parent setValue makes the model emit isFlush — don't round-trip it back as a user change.
+        if (e.isFlush) return;
         window.parent.postMessage(
             { type: 'kson:change', value: model.getValue() },
             '*',

--- a/tooling/lsp-clients/monaco/tests/iframe-embed.spec.ts
+++ b/tooling/lsp-clients/monaco/tests/iframe-embed.spec.ts
@@ -46,8 +46,7 @@ test.describe('Iframe Embed', () => {
         expect(newValue).toBe('{ name: "updated" }');
 
         // Verify the iframe editor actually received the new content.
-        const iframeContent = await editorFrame.locator('.view-lines').textContent();
-        expect(iframeContent!.replace(/\u00A0/g, ' ')).toContain('updated');
+        await expect(editorFrame.locator('.view-lines')).toContainText('updated');
 
         // dispose() should remove the iframe.
         await page.evaluate(() => {

--- a/tooling/lsp-clients/monaco/tests/iframe-embed.spec.ts
+++ b/tooling/lsp-clients/monaco/tests/iframe-embed.spec.ts
@@ -74,4 +74,31 @@ test.describe('Iframe Embed', () => {
         // onChange should have fired with the updated content.
         await expect(output).toContainText('change:', { timeout: 5000 });
     });
+
+    test('setValue does not fire onChange', async ({ page }) => {
+        await page.goto('http://localhost:5173/tests/iframe-embed.html');
+
+        const output = page.locator('#output');
+        await expect(output).toContainText('ready', { timeout: 15000 });
+
+        const editorFrame = page.frameLocator('iframe');
+        await expect(editorFrame.locator('.monaco-editor')).toBeVisible({ timeout: 10000 });
+
+        // Programmatic setValue — must not be echoed back as onChange.
+        await page.evaluate(() => {
+            (window as any).__ksonEditor.setValue('{ name: "from-setValue" }');
+        });
+
+        // Trigger a real user edit, prefixing a distinctive character so the
+        // user-edit echo differs from the (wrongly-relayed) setValue echo.
+        // postMessage is FIFO, so once the user-edit echo reaches the parent,
+        // any suppressed setValue echo would have reached it first — safe sync point.
+        await editorFrame.locator('.view-lines').click();
+        await page.keyboard.press('Home');
+        await page.keyboard.type('X');
+        await expect(output).toContainText('change:X{ name: "from-setValue" }', { timeout: 5000 });
+
+        // The setValue payload alone must never appear as a change event.
+        await expect(output).not.toContainText('change:{ name: "from-setValue" }');
+    });
 });

--- a/tooling/lsp-clients/monaco/tests/monaco-editor.spec.ts
+++ b/tooling/lsp-clients/monaco/tests/monaco-editor.spec.ts
@@ -22,22 +22,10 @@ test.describe('Monaco KSON Editor - Smoke Test', () => {
         await expect(editors.first()).toBeVisible({timeout: 10000});
         await expect(editors).toHaveCount(2);
 
-        // Wait for line numbers to render
-        await page.waitForSelector('.line-numbers', {state: 'visible'});
-        await page.waitForTimeout(1000); // Allow time for content rendering
-
-        // Verify the left editor displays the expected content
-        const leftEditorContent = await page.evaluate(() => {
-            const container = document.getElementById('editor-left');
-            if (!container) return '';
-            const lines = container.querySelectorAll('.view-line');
-            return Array.from(lines)
-                .map(line => line.textContent || '')
-                .join('\n');
-        });
-
-        const normalizedLeft = leftEditorContent.replace(/\u00A0/g, ' ').trim();
-        expect(normalizedLeft).toContain('kson-monaco-editor');
+        // Verify the left editor displays the expected content.
+        await expect(
+            page.locator('#editor-left .view-lines')
+        ).toContainText('kson-monaco-editor');
 
         // Verify syntax highlighting (multiple token classes present)
         const tokenClasses = await page.evaluate(() => {


### PR DESCRIPTION
This PR suppress the `onChange` echo for programmatic `setValue`, the iframe's `onDidChangeContent` handler was
   relaying parent-initiated `setValue` back through `options.onChange`. To prevent this we filter on Monaco's `isFlush`
  flag, which is only set for full-model resets (our only path is parent `setValue`).
Also stabilize two Playwright assertions. Replaced one-shot `textContent` reads (and a `waitForTimeout(1000)` hack) with retrying `expect(locator).toContainText` assertions, removing the possible race condition.
