### PR TITLE
Fix $ref resolution in schemas with root $id

### DIFF
--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaCompletionLocationTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaCompletionLocationTest.kt
@@ -1603,4 +1603,174 @@ class SchemaCompletionLocationTest {
               .
             .
     """
+
+    @Test
+    fun testOneOfWithRefAtRootProvidesPropertyCompletions() {
+        val schema = $$"""
+            oneOf:
+              - '$ref': '#/$defs/Model'
+                description: 'A model resource'
+              - '$ref': '#/$defs/View'
+                description: 'A view resource'
+                .
+            '$defs':
+              Model:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    .
+                  type:
+                    type: string
+                    const: model
+                    .
+                  source:
+                    type: string
+                    .
+                  .
+                .
+              View:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    .
+                  type:
+                    type: string
+                    const: view
+                    .
+                  base:
+                    type: string
+                    .
+                  .
+                .
+              .
+        """
+
+        val completions = getCompletionsAtCaret(schema, "<caret>")
+
+        val labels = completions.map { it.label }
+        assertTrue(labels.contains("id"), "Should include shared property 'id', got: $labels")
+        assertTrue(labels.contains("type"), "Should include shared property 'type', got: $labels")
+        assertTrue(labels.contains("source"), "Should include Model-only property 'source', got: $labels")
+        assertTrue(labels.contains("base"), "Should include View-only property 'base', got: $labels")
+    }
+
+    @Test
+    fun testOneOfWithRefAtRootWithSchemaMetadata() {
+        // Root schema with $schema, $id, title, description alongside oneOf
+        val schema = $$"""
+            '$schema': 'http://json-schema.org/draft-07/schema#'
+            '$id': 'test.schema.kson'
+            title: 'Test Resource'
+            description: 'A test resource that is either a Model or a View'
+            oneOf:
+              - '$ref': '#/$defs/Model'
+                description: 'A model resource'
+              - '$ref': '#/$defs/View'
+                description: 'A view resource'
+                .
+            '$defs':
+              Model:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    .
+                  type:
+                    type: string
+                    const: model
+                    .
+                  source:
+                    type: string
+                    .
+                  .
+                .
+              View:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    .
+                  type:
+                    type: string
+                    const: view
+                    .
+                  base:
+                    type: string
+                    .
+                  .
+                .
+              .
+        """
+
+        val completions = getCompletionsAtCaret(schema, "<caret>")
+
+        val labels = completions.map { it.label }
+        assertTrue(labels.contains("id"), "Should include shared property 'id', got: $labels")
+        assertTrue(labels.contains("type"), "Should include shared property 'type', got: $labels")
+        assertTrue(labels.contains("source"), "Should include Model-only property 'source', got: $labels")
+        assertTrue(labels.contains("base"), "Should include View-only property 'base', got: $labels")
+    }
+
+    @Test
+    fun testOneOfWithRefAtRootWithEmbedDescription() {
+        // Root schema with $id and %markdown embed block description alongside oneOf
+        val schema = $$"""
+            '$schema': 'http://json-schema.org/draft-07/schema#'
+            '$id': 'test.schema.kson'
+            title: 'Test Resource'
+            description: %markdown
+              # Test Resource
+
+              Each file is either a `model` or a `view`.
+              Use `type: model` or `type: view` to discriminate.
+              %%
+            oneOf:
+              - '$ref': '#/$defs/Model'
+                description: 'A model resource'
+              - '$ref': '#/$defs/View'
+                description: 'A view resource'
+                .
+            '$defs':
+              Model:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    .
+                  type:
+                    type: string
+                    const: model
+                    .
+                  source:
+                    type: string
+                    .
+                  .
+                .
+              View:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    .
+                  type:
+                    type: string
+                    const: view
+                    .
+                  base:
+                    type: string
+                    .
+                  .
+                .
+              .
+        """
+
+        val completions = getCompletionsAtCaret(schema, "<caret>")
+
+        assertEquals(
+            setOf("id", "type", "source", "base"),
+            completions.map { it.label }.toSet()
+        )
+    }
 }

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaCompletionLocationTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaCompletionLocationTest.kt
@@ -1649,68 +1649,10 @@ class SchemaCompletionLocationTest {
 
         val completions = getCompletionsAtCaret(schema, "<caret>")
 
-        val labels = completions.map { it.label }
-        assertTrue(labels.contains("id"), "Should include shared property 'id', got: $labels")
-        assertTrue(labels.contains("type"), "Should include shared property 'type', got: $labels")
-        assertTrue(labels.contains("source"), "Should include Model-only property 'source', got: $labels")
-        assertTrue(labels.contains("base"), "Should include View-only property 'base', got: $labels")
-    }
-
-    @Test
-    fun testOneOfWithRefAtRootWithSchemaMetadata() {
-        // Root schema with $schema, $id, title, description alongside oneOf
-        val schema = $$"""
-            '$schema': 'http://json-schema.org/draft-07/schema#'
-            '$id': 'test.schema.kson'
-            title: 'Test Resource'
-            description: 'A test resource that is either a Model or a View'
-            oneOf:
-              - '$ref': '#/$defs/Model'
-                description: 'A model resource'
-              - '$ref': '#/$defs/View'
-                description: 'A view resource'
-                .
-            '$defs':
-              Model:
-                type: object
-                properties:
-                  id:
-                    type: string
-                    .
-                  type:
-                    type: string
-                    const: model
-                    .
-                  source:
-                    type: string
-                    .
-                  .
-                .
-              View:
-                type: object
-                properties:
-                  id:
-                    type: string
-                    .
-                  type:
-                    type: string
-                    const: view
-                    .
-                  base:
-                    type: string
-                    .
-                  .
-                .
-              .
-        """
-
-        val completions = getCompletionsAtCaret(schema, "<caret>")
-
-        val labels = completions.map { it.label }
-        assertTrue(labels.contains("id"), "Should include shared property 'id', got: $labels")
-        assertTrue(labels.contains("type"), "Should include shared property 'type', got: $labels")
-        assertTrue(labels.contains("source"), "Should include Model-only property 'source', got: $labels")
-        assertTrue(labels.contains("base"), "Should include View-only property 'base', got: $labels")
+        assertEquals(
+            setOf("id", "type", "source", "base"),
+            completions.map { it.label }.toSet()
+        )
     }
 
     @Test

--- a/src/commonMain/kotlin/org/kson/schema/SchemaIdLookup.kt
+++ b/src/commonMain/kotlin/org/kson/schema/SchemaIdLookup.kt
@@ -28,14 +28,7 @@ class SchemaIdLookup(val schemaRootValue: KsonValue) {
         idMap[KsonDraft7MetaSchema.ID] = KsonDraft7MetaSchema.schemaValue
 
         if (schemaRootValue is KsonObject) {
-            val rootBaseUri = schemaRootValue.propertyLookup["\$id"]?.let { idValue ->
-                if (idValue is KsonString) {
-                    idValue.value
-                } else {
-                    // this $id is completely invalid
-                    null
-                }
-            } ?: ""
+            val rootBaseUri = rootBaseUri()
 
             // Store the root schema at its baseUri
             idMap[rootBaseUri] = schemaRootValue
@@ -44,6 +37,11 @@ class SchemaIdLookup(val schemaRootValue: KsonValue) {
             walkSchemaForIds(schemaRootValue, idMap, rootBaseUri)
         }
     }
+
+    private fun rootBaseUri(): String =
+        (schemaRootValue as? KsonObject)?.propertyLookup["\$id"]
+            ?.let { (it as? KsonString)?.value }
+            ?: ""
 
     /**
      * Resolves a `$ref` reference string to the corresponding schema value.
@@ -166,7 +164,7 @@ class SchemaIdLookup(val schemaRootValue: KsonValue) {
     fun navigateByDocumentPointer(
         documentPointer: JsonPointer,
     ): List<ResolvedRef> {
-        val startingBaseUri = ""
+        val startingBaseUri = rootBaseUri()
         val documentPathTokens = documentPointer.tokens
         if (documentPathTokens.isEmpty()) {
             // Even at root, resolve $ref if present


### PR DESCRIPTION
navigateByDocumentPointer always started with baseUri="" but schemas with $id store their root under that id in the lookup map. $ref resolution then failed because idMap[""] didn't exist. Use the root schema's $id as the starting base URI so refs resolve correctly.