### PR TITLE
Address detekt warnings surfaced by #378

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -3,11 +3,11 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:Escaping.kt$fun renderForJsonString(content: String): String</ID>
-    <ID>CyclomaticComplexMethod:Formatter.kt$IndentFormatter$@Deprecated( "This formatter is no long a good general purpose formatter. " + "See the TODO in this class's doc for details" ) private fun indent(source: String, snippetNestingLevel: Int? = null): String</ID>
+    <ID>CyclomaticComplexMethod:Formatter.kt$IndentFormatter$@Deprecated( "This formatter is no long a good general purpose formatter. " + "See the TODO in this class's doc for details" ) @Suppress("NestedBlockDepth") private fun indent(source: String, snippetNestingLevel: Int? = null): String</ID>
     <ID>CyclomaticComplexMethod:KsonBuilder.kt$KsonBuilder$private fun toAst(marker: KsonMarker): AstNode</ID>
     <ID>CyclomaticComplexMethod:KsonValue.kt$fun AstNode.toKsonValue(): KsonValue</ID>
     <ID>CyclomaticComplexMethod:Lexer.kt$Lexer$private fun scan()</ID>
-    <ID>CyclomaticComplexMethod:SchemaParser.kt$SchemaParser$private fun parseObjectSchema( schemaObject: KsonObject, messageSink: MessageSink, currentBaseUri: String, idLookup: SchemaIdLookup, propertyName: String? = null ): JsonSchema?</ID>
+    <ID>CyclomaticComplexMethod:SchemaParser.kt$SchemaParser$@Suppress("NestedBlockDepth") // baselined as LongMethod/CyclomaticComplexMethod; a full refactor is its own story private fun parseObjectSchema( schemaObject: KsonObject, messageSink: MessageSink, currentBaseUri: String, idLookup: SchemaIdLookup, propertyName: String? = null ): JsonSchema?</ID>
     <ID>CyclomaticComplexMethod:TreeNavigation.kt$TreeNavigator$private fun processSingleToken( currentNodes: List&lt;N>, token: PointerParser.Tokens ): List&lt;N></ID>
     <ID>CyclomaticComplexMethod:TypeValidator.kt$TypeValidator$fun validate(ksonValue: KsonValue, messageSink: MessageSink): Boolean</ID>
     <ID>LargeClass:FormatterTest.kt$FormatterTest</ID>
@@ -44,7 +44,7 @@
     <ID>LargeClass:SchemaDraft7SuiteTest_type.kt$SchemaDraft7SuiteTest_type : JsonSchemaTest</ID>
     <ID>LargeClass:SchemaDraft7SuiteTest_uniqueItems.kt$SchemaDraft7SuiteTest_uniqueItems : JsonSchemaTest</ID>
     <ID>LargeClass:TreeNavigationTest.kt$TreeNavigationTest</ID>
-    <ID>LongMethod:Formatter.kt$IndentFormatter$@Deprecated( "This formatter is no long a good general purpose formatter. " + "See the TODO in this class's doc for details" ) private fun indent(source: String, snippetNestingLevel: Int? = null): String</ID>
+    <ID>LongMethod:Formatter.kt$IndentFormatter$@Deprecated( "This formatter is no long a good general purpose formatter. " + "See the TODO in this class's doc for details" ) @Suppress("NestedBlockDepth") private fun indent(source: String, snippetNestingLevel: Int? = null): String</ID>
     <ID>LongMethod:FormatterTest.kt$FormatterTest$@Test fun testCompactFormattingStyleNestedStructures()</ID>
     <ID>LongMethod:FormatterTest.kt$FormatterTest$@Test fun testMultipleTrailingContent()</ID>
     <ID>LongMethod:KsonBuilder.kt$KsonBuilder$private fun toAst(marker: KsonMarker): AstNode</ID>
@@ -77,7 +77,7 @@
     <ID>LongMethod:SchemaDraft2020_12SuiteTest_unevaluatedProperties.kt$SchemaDraft2020_12SuiteTest_unevaluatedProperties$@Test fun jsonSchemaSuiteTest_99()</ID>
     <ID>LongMethod:SchemaDraft7SuiteTest_ref.kt$SchemaDraft7SuiteTest_ref$@Test fun jsonSchemaSuiteTest_30()</ID>
     <ID>LongMethod:SchemaDraft7SuiteTest_ref.kt$SchemaDraft7SuiteTest_ref$@Test fun jsonSchemaSuiteTest_31()</ID>
-    <ID>LongMethod:SchemaParser.kt$SchemaParser$private fun parseObjectSchema( schemaObject: KsonObject, messageSink: MessageSink, currentBaseUri: String, idLookup: SchemaIdLookup, propertyName: String? = null ): JsonSchema?</ID>
+    <ID>LongMethod:SchemaParser.kt$SchemaParser$@Suppress("NestedBlockDepth") // baselined as LongMethod/CyclomaticComplexMethod; a full refactor is its own story private fun parseObjectSchema( schemaObject: KsonObject, messageSink: MessageSink, currentBaseUri: String, idLookup: SchemaIdLookup, propertyName: String? = null ): JsonSchema?</ID>
     <ID>LoopWithTooManyJumpStatements:KsonStringValidator.kt$KsonStringValidator$while</ID>
     <ID>LoopWithTooManyJumpStatements:Parser.kt$Parser$while</ID>
     <ID>ReturnCount:SubParseableTest.kt$SubParseableTest$private fun findEmbeddedSRC(ksonValue: KsonValue): KsonString?</ID>

--- a/detekt.kson
+++ b/detekt.kson
@@ -23,14 +23,6 @@ complexity:
     thresholdInObjects: 25
     thresholdInEnums: 25
     .
-  NestedBlockDepth:
-    active: true
-    threshold: 6
-    .
-  ComplexCondition:
-    active: true
-    threshold: 10
-    .
   .
 
 style:

--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/FoldingRangeBuilder.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/FoldingRangeBuilder.kt
@@ -72,26 +72,29 @@ internal object FoldingRangeBuilder {
         var blockStartLine = -1
         var blockEndLine = -1
 
-        for (token in tokens) {
-            if (token.tokenType == TokenType.COMMENT) {
-                val line = token.lexeme.location.start.line
-                if (blockStartLine < 0 || line != blockEndLine + 1) {
-                    if (blockStartLine >= 0 && blockEndLine > blockStartLine) {
-                        ranges.add(StructuralRange(blockStartLine, blockEndLine, StructuralRangeKind.COMMENT))
-                    }
-                    blockStartLine = line
-                }
-                blockEndLine = line
-            } else if (token.tokenType != TokenType.WHITESPACE) {
-                if (blockStartLine >= 0 && blockEndLine > blockStartLine) {
-                    ranges.add(StructuralRange(blockStartLine, blockEndLine, StructuralRangeKind.COMMENT))
-                }
-                blockStartLine = -1
+        fun flushBlock() {
+            if (blockStartLine >= 0 && blockEndLine > blockStartLine) {
+                ranges.add(StructuralRange(blockStartLine, blockEndLine, StructuralRangeKind.COMMENT))
             }
         }
 
-        if (blockStartLine >= 0 && blockEndLine > blockStartLine) {
-            ranges.add(StructuralRange(blockStartLine, blockEndLine, StructuralRangeKind.COMMENT))
+        for (token in tokens) {
+            when {
+                token.tokenType == TokenType.COMMENT -> {
+                    val line = token.lexeme.location.start.line
+                    if (blockStartLine < 0 || line != blockEndLine + 1) {
+                        flushBlock()
+                        blockStartLine = line
+                    }
+                    blockEndLine = line
+                }
+                token.tokenType != TokenType.WHITESPACE -> {
+                    flushBlock()
+                    blockStartLine = -1
+                }
+            }
         }
+
+        flushBlock()
     }
 }

--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/SelectionRangeBuilder.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/SelectionRangeBuilder.kt
@@ -38,34 +38,7 @@ internal object SelectionRangeBuilder {
         val range = value.toRange()
 
         when (value) {
-            is KsonObject -> {
-                for ((_, prop) in value.propertyMap) {
-                    val keyLoc = prop.propName.location
-                    val valueLoc = prop.propValue.location
-
-                    val propertyRange = Range(
-                        keyLoc.start.line, keyLoc.start.column,
-                        valueLoc.end.line, valueLoc.end.column
-                    )
-
-                    if (containsPosition(propertyRange, cursor)) {
-                        val descendedIntoValue = collectAncestors(prop.propValue, cursor, ancestors)
-
-                        if (!descendedIntoValue) {
-                            // Cursor is on the key itself
-                            val keyRange = prop.propName.toRange()
-                            if (containsPosition(keyRange, cursor)) {
-                                ancestors.add(keyRange)
-                            }
-                        }
-
-                        ancestors.add(propertyRange)
-                        ancestors.add(range)
-                        return true
-                    }
-                }
-            }
-
+            is KsonObject -> if (collectObjectAncestors(value, cursor, ancestors, range)) return true
             is KsonList -> {
                 for (element in value.elements) {
                     if (collectAncestors(element, cursor, ancestors)) {
@@ -86,6 +59,36 @@ internal object SelectionRangeBuilder {
         // Leaf node or cursor is on container delimiters (e.g. { or })
         ancestors.add(range)
         return true
+    }
+
+    private fun collectObjectAncestors(
+        value: KsonObject,
+        cursor: Coordinates,
+        ancestors: MutableList<Range>,
+        containerRange: Range,
+    ): Boolean {
+        for ((_, prop) in value.propertyMap) {
+            val keyLoc = prop.propName.location
+            val valueLoc = prop.propValue.location
+            val propertyRange = Range(
+                keyLoc.start.line, keyLoc.start.column,
+                valueLoc.end.line, valueLoc.end.column
+            )
+            if (!containsPosition(propertyRange, cursor)) continue
+
+            val descendedIntoValue = collectAncestors(prop.propValue, cursor, ancestors)
+            if (!descendedIntoValue) {
+                // Cursor is on the key itself
+                val keyRange = prop.propName.toRange()
+                if (containsPosition(keyRange, cursor)) {
+                    ancestors.add(keyRange)
+                }
+            }
+            ancestors.add(propertyRange)
+            ancestors.add(containerRange)
+            return true
+        }
+        return false
     }
 
     private fun deduplicate(ranges: List<Range>): List<Range> {

--- a/src/commonMain/kotlin/org/kson/ast/Ast.kt
+++ b/src/commonMain/kotlin/org/kson/ast/Ast.kt
@@ -213,22 +213,23 @@ class KsonRootImpl(
                 }
 
                 if (compileTarget.preserveComments && documentEndComments.isNotEmpty()) {
-                    val endComments = documentEndComments.joinToString("\n")
-                    ksonDocument += if (ksonDocument.endsWith(endComments)) {
-                        // endComments are already embedded in the document, likely as part of a trailing error
-                        ""
-                    } else {
-                        if (compileTarget is Kson && compileTarget.formatConfig.formattingStyle == COMPACT) {
-                            "\n" + endComments
-                        } else {
-                            "\n\n" + endComments
-                        }
-                    }
+                    ksonDocument += appendedEndComments(ksonDocument, compileTarget)
                 }
 
                 ksonDocument
             }
         }
+    }
+
+    private fun appendedEndComments(ksonDocument: String, compileTarget: CompileTarget): String {
+        val endComments = documentEndComments.joinToString("\n")
+        if (ksonDocument.endsWith(endComments)) {
+            // endComments are already embedded in the document, likely as part of a trailing error
+            return ""
+        }
+        val isCompactKson = compileTarget is Kson && compileTarget.formatConfig.formattingStyle == COMPACT
+        val separator = if (isCompactKson) "\n" else "\n\n"
+        return separator + endComments
     }
 }
 
@@ -386,10 +387,11 @@ class ObjectPropertyNodeImpl(
     }
 
     private fun delimitedObjectProperty(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
-        val delimitedPropertyIndent = if (value is ListNode || value is ObjectNode ||
-            // check if we're compiling an embed block to an object
-            (compileTarget is Json && value is EmbedBlockNode && compileTarget.retainEmbedTags)
-        ) {
+        // check if we're compiling an embed block to an object
+        val isEmbedBlockAsJsonObject =
+            compileTarget is Json && value is EmbedBlockNode && compileTarget.retainEmbedTags
+        val valueProvidesOwnIndent = value is ListNode || value is ObjectNode || isEmbedBlockAsJsonObject
+        val delimitedPropertyIndent = if (valueProvidesOwnIndent) {
             // For delimited lists and objects, don't increase their indent here - they provide their own indent nest
             indent.clone(true)
         } else {
@@ -401,12 +403,12 @@ class ObjectPropertyNodeImpl(
     }
 
     private fun undelimitedObjectProperty(indent: Indent, nextNode: AstNode?, compileTarget: CompileTarget): String {
-        return if (
-            (value is ListNode && value.elements.isNotEmpty()) ||
-            (value is ObjectNode && value.properties.isNotEmpty()) ||
-            // check if we're compiling an embed block to an object
-            (compileTarget is Yaml && value is EmbedBlockNode && compileTarget.retainEmbedTags)
-        ) {
+        val hasNonEmptyListValue = value is ListNode && value.elements.isNotEmpty()
+        val hasNonEmptyObjectValue = value is ObjectNode && value.properties.isNotEmpty()
+        // check if we're compiling an embed block to an object
+        val isEmbedBlockAsYamlObject =
+            compileTarget is Yaml && value is EmbedBlockNode && compileTarget.retainEmbedTags
+        return if (hasNonEmptyListValue || hasNonEmptyObjectValue || isEmbedBlockAsYamlObject) {
             // For non-empty lists and objects, put the value on the next line
             key.toSourceWithNext(indent, value, compileTarget) + "\n" +
                     value.toSourceWithNext(indent.next(false), nextNode, compileTarget)

--- a/src/commonMain/kotlin/org/kson/ast/EmbedBlockResolver.kt
+++ b/src/commonMain/kotlin/org/kson/ast/EmbedBlockResolver.kt
@@ -44,10 +44,7 @@ fun resolveEmbedBlocks(
     for (rule in rules) {
         val matchingValues = KsonValueWalker.navigateWithJsonPointerGlob(rootValue, rule.pathPattern)
         for (value in matchingValues) {
-            if (value is KsonString) {
-                if (value.value.length < rule.minLength) {
-                    continue
-                }
+            if (value is KsonString && value.value.length >= rule.minLength) {
                 stringResult[value.stringNode] = rule
             }
         }

--- a/src/commonMain/kotlin/org/kson/parser/Lexer.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Lexer.kt
@@ -297,6 +297,7 @@ class Lexer(source: String, gapFree: Boolean = false) {
 
     companion object {
         val ignoredTokens = setOf(WHITESPACE, COMMENT)
+        private val commentlessTokenTypes = setOf(COMMENT, WHITESPACE, EMBED_PREAMBLE_NEWLINE, STRING_CONTENT)
     }
 
     private val sourceScanner = SourceScanner(source)
@@ -518,12 +519,12 @@ class Lexer(source: String, gapFree: Boolean = false) {
          * in case the user is mistakenly just starting it with a digit.  We'll give a helpful error
          * in [NumberParser]
          */
-        while (StringUnquoted.isUnquotedBodyChar(sourceScanner.peek())
-            || sourceScanner.peek() == '+'
-            || sourceScanner.peek() == '-'
-            || sourceScanner.peek() == '.') sourceScanner.advance()
+        while (looksLikeNumberChar(sourceScanner.peek())) sourceScanner.advance()
         addLiteralToken(NUMBER)
     }
+
+    private fun looksLikeNumberChar(char: Char?): Boolean =
+        char != null && (StringUnquoted.isUnquotedBodyChar(char) || char == '+' || char == '-' || char == '.')
 
     /**
      * Convenience method for adding a [tokenType] [Token] with a "literal" value---i.e. its value is the
@@ -561,12 +562,7 @@ class Lexer(source: String, gapFree: Boolean = false) {
      */
     private data class CommentMetadata(val comments: List<String>, val lookaheadTokens: List<Token>)
     private fun commentMetadataForCurrentToken(currentTokenType: TokenType): CommentMetadata {
-        // comments don't get associated with these types
-        if (currentTokenType == COMMENT
-            || currentTokenType == WHITESPACE
-            || currentTokenType == EMBED_PREAMBLE_NEWLINE
-            || currentTokenType == STRING_CONTENT
-        ) {
+        if (currentTokenType in commentlessTokenTypes) {
             return CommentMetadata(emptyList(), emptyList())
         }
 

--- a/src/commonMain/kotlin/org/kson/parser/Parser.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Parser.kt
@@ -50,6 +50,10 @@ import org.kson.stdlibx.exceptions.FatalParseException
  */
 class Parser(private val builder: AstBuilder, private val maxNestingLevel: Int = DEFAULT_MAX_NESTING_LEVEL) {
 
+    companion object {
+        private val reservedKeywordTokens = setOf(NULL, TRUE, FALSE)
+    }
+
     /**
      * root -> ksonValue <end-of-file>
      */
@@ -538,10 +542,8 @@ class Parser(private val builder: AstBuilder, private val maxNestingLevel: Int =
         val keywordMark = builder.mark()
 
         // helpful errors for keywords that clash with reserved words
-        if ((builder.getTokenType() == NULL
-                    || builder.getTokenType() == TRUE
-                    || builder.getTokenType() == FALSE
-                ) && builder.lookAhead(1) == COLON) {
+        val isReservedWordKey = builder.getTokenType() in reservedKeywordTokens && builder.lookAhead(1) == COLON
+        if (isReservedWordKey) {
             val reservedWord = builder.getTokenText()
             builder.advanceLexer()
             keywordMark.error(OBJECT_KEYWORD_RESERVED_WORD.create(reservedWord))

--- a/src/commonMain/kotlin/org/kson/parser/behavior/quotedstring/KsonStringValidator.kt
+++ b/src/commonMain/kotlin/org/kson/parser/behavior/quotedstring/KsonStringValidator.kt
@@ -43,31 +43,9 @@ class KsonStringValidator {
 
     private fun validateNode(node: KsonValueNode, messageSink: MessageSink) {
         when (node) {
-            is ObjectNode -> {
-                node.properties.forEach { property ->
-                    if (property is ObjectPropertyNodeImpl) {
-                        // Validate the key if it's a quoted string
-                        if (property.key is ObjectKeyNodeImpl) {
-                            val keyNode = property.key.key
-                            if (keyNode is QuotedStringNode) {
-                                validateQuotedString(keyNode, messageSink)
-                            }
-                        }
-                        // Recursively validate the value
-                        validateNode(property.value, messageSink)
-                    }
-                }
-            }
-            is ListNode -> {
-                node.elements.forEach { element ->
-                    if (element is ListElementNodeImpl) {
-                        validateNode(element.value, messageSink)
-                    }
-                }
-            }
-            is QuotedStringNode -> {
-                validateQuotedString(node, messageSink)
-            }
+            is ObjectNode -> validateObjectProperties(node, messageSink)
+            is ListNode -> validateListElements(node, messageSink)
+            is QuotedStringNode -> validateQuotedString(node, messageSink)
             is EmbedBlockNode -> {
                 val tagNode = node.embedTagNode
                 if (tagNode is QuotedStringNode) {
@@ -79,6 +57,29 @@ class KsonStringValidator {
             is NumberNode, is TrueNode, is FalseNode, is NullNode,
             is KsonValueNodeError -> {
                 // No string validation needed
+            }
+        }
+    }
+
+    private fun validateObjectProperties(node: ObjectNode, messageSink: MessageSink) {
+        node.properties.forEach { property ->
+            if (property !is ObjectPropertyNodeImpl) return@forEach
+            // Validate the key if it's a quoted string
+            if (property.key is ObjectKeyNodeImpl) {
+                val keyNode = property.key.key
+                if (keyNode is QuotedStringNode) {
+                    validateQuotedString(keyNode, messageSink)
+                }
+            }
+            // Recursively validate the value
+            validateNode(property.value, messageSink)
+        }
+    }
+
+    private fun validateListElements(node: ListNode, messageSink: MessageSink) {
+        node.elements.forEach { element ->
+            if (element is ListElementNodeImpl) {
+                validateNode(element.value, messageSink)
             }
         }
     }
@@ -108,57 +109,75 @@ class KsonStringValidator {
                 continue
             }
 
-            // Check for escape sequences
-            if (char == '\\') {
-                val escapeStartLocation = scanner.currentLocation()
-                scanner.advance() // consume backslash
-
-                if (scanner.eof()) {
-                    // Incomplete escape at end of string
-                    messageSink.error(escapeStartLocation, MessageType.STRING_BAD_ESCAPE.create("\\"))
-                    break
-                }
-
-                val nextChar = scanner.peek()
-
-                if (nextChar == 'u') {
-                    // Unicode escape - must be \uXXXX where X is hex digit
-                    // Collect up to 5 more chars (\u + 4 hex digits)
-                    val escapeBuilder = StringBuilder("\\")
-                    var charsConsumed = 0
-                    while (!scanner.eof() && charsConsumed < 5 && !isWhitespace(scanner.peek())) {
-                        escapeBuilder.append(scanner.peek())
-                        scanner.advance()
-                        charsConsumed++
-                    }
-
-                    val escapeText = escapeBuilder.toString()
-                    if (!isValidUnicodeEscape(escapeText)) {
-                        val errorLocation = Location.create(
-                            escapeStartLocation.start.line, escapeStartLocation.start.column,
-                            escapeStartLocation.start.line, escapeStartLocation.start.column + escapeText.length,
-                            escapeStartLocation.startOffset, escapeStartLocation.startOffset + escapeText.length
-                        )
-                        messageSink.error(errorLocation, MessageType.STRING_BAD_UNICODE_ESCAPE.create(escapeText))
-                    }
-                } else {
-                    // Regular escape - check if it's valid
-                    if (!isValidStringEscape(nextChar)) {
-                        val escapeText = "\\$nextChar"
-                        val errorLocation = Location.create(
-                            escapeStartLocation.start.line, escapeStartLocation.start.column,
-                            escapeStartLocation.start.line, escapeStartLocation.start.column + 2,
-                            escapeStartLocation.startOffset, escapeStartLocation.startOffset + 2
-                        )
-                        messageSink.error(errorLocation, MessageType.STRING_BAD_ESCAPE.create(escapeText))
-                    }
-                    scanner.advance() // consume the escaped character
-                }
-            } else {
-                // Regular character - just advance
+            if (char != '\\') {
                 scanner.advance()
+                continue
             }
+
+            validateEscapeSequence(scanner, messageSink)
         }
+    }
+
+    private fun validateEscapeSequence(scanner: StringContentScanner, messageSink: MessageSink) {
+        val escapeStartLocation = scanner.currentLocation()
+        scanner.advance() // consume backslash
+
+        if (scanner.eof()) {
+            // Incomplete escape at end of string
+            messageSink.error(escapeStartLocation, MessageType.STRING_BAD_ESCAPE.create("\\"))
+            return
+        }
+
+        val nextChar = scanner.peek()
+        if (nextChar == 'u') {
+            validateUnicodeEscape(scanner, escapeStartLocation, messageSink)
+        } else {
+            validateRegularEscape(scanner, nextChar, escapeStartLocation, messageSink)
+        }
+    }
+
+    private fun validateUnicodeEscape(
+        scanner: StringContentScanner,
+        escapeStartLocation: Location,
+        messageSink: MessageSink
+    ) {
+        // Unicode escape - must be \uXXXX where X is hex digit
+        // Collect up to 5 more chars (\u + 4 hex digits)
+        val escapeBuilder = StringBuilder("\\")
+        var charsConsumed = 0
+        while (!scanner.eof() && charsConsumed < 5 && !isWhitespace(scanner.peek())) {
+            escapeBuilder.append(scanner.peek())
+            scanner.advance()
+            charsConsumed++
+        }
+
+        val escapeText = escapeBuilder.toString()
+        if (!isValidUnicodeEscape(escapeText)) {
+            val errorLocation = Location.create(
+                escapeStartLocation.start.line, escapeStartLocation.start.column,
+                escapeStartLocation.start.line, escapeStartLocation.start.column + escapeText.length,
+                escapeStartLocation.startOffset, escapeStartLocation.startOffset + escapeText.length
+            )
+            messageSink.error(errorLocation, MessageType.STRING_BAD_UNICODE_ESCAPE.create(escapeText))
+        }
+    }
+
+    private fun validateRegularEscape(
+        scanner: StringContentScanner,
+        nextChar: Char,
+        escapeStartLocation: Location,
+        messageSink: MessageSink
+    ) {
+        if (!isValidStringEscape(nextChar)) {
+            val escapeText = "\\$nextChar"
+            val errorLocation = Location.create(
+                escapeStartLocation.start.line, escapeStartLocation.start.column,
+                escapeStartLocation.start.line, escapeStartLocation.start.column + 2,
+                escapeStartLocation.startOffset, escapeStartLocation.startOffset + 2
+            )
+            messageSink.error(errorLocation, MessageType.STRING_BAD_ESCAPE.create(escapeText))
+        }
+        scanner.advance() // consume the escaped character
     }
 
     private fun isWhitespace(char: Char?): Boolean {

--- a/src/commonMain/kotlin/org/kson/parser/behavior/quotedstring/QuotedStringContentTransformer.kt
+++ b/src/commonMain/kotlin/org/kson/parser/behavior/quotedstring/QuotedStringContentTransformer.kt
@@ -91,57 +91,58 @@ private fun unescapeAndTrackEscapes(content: String): Pair<String, List<EscapeIn
     var i = 0
     while (i < content.length) {
         val char = content[i]
-
-        if (char == '\\' && i + 1 < content.length) {
-            val rawStart = i
-            when (val escaped = content[i + 1]) {
-                '"', '\\', '/', '\'' -> {
-                    sb.append(escaped)
-                    escapes.add(EscapeInfo(rawStart, 2, 1))
-                    i += 2
-                }
-                'b' -> {
-                    sb.append('\b')
-                    escapes.add(EscapeInfo(rawStart, 2, 1))
-                    i += 2
-                }
-                'f' -> {
-                    sb.append('\u000C')
-                    escapes.add(EscapeInfo(rawStart, 2, 1))
-                    i += 2
-                }
-                'n' -> {
-                    sb.append('\n')
-                    escapes.add(EscapeInfo(rawStart, 2, 1))
-                    i += 2
-                }
-                'r' -> {
-                    sb.append('\r')
-                    escapes.add(EscapeInfo(rawStart, 2, 1))
-                    i += 2
-                }
-                't' -> {
-                    sb.append('\t')
-                    escapes.add(EscapeInfo(rawStart, 2, 1))
-                    i += 2
-                }
-                'u' -> {
-                    val (chars, consumed) = handleUnicodeEscape(content.substring(i))
-                    for (c in chars) {
-                        sb.append(c)
-                    }
-                    escapes.add(EscapeInfo(rawStart, consumed, chars.size))
-                    i += consumed
-                }
-                else -> {
-                    // Unknown escape sequence, append backslash as is
-                    sb.append(char)
-                    i++
-                }
-            }
-        } else {
+        val isStartOfEscape = char == '\\' && i + 1 < content.length
+        if (!isStartOfEscape) {
             sb.append(char)
             i++
+            continue
+        }
+
+        val rawStart = i
+        when (val escaped = content[i + 1]) {
+            '"', '\\', '/', '\'' -> {
+                sb.append(escaped)
+                escapes.add(EscapeInfo(rawStart, 2, 1))
+                i += 2
+            }
+            'b' -> {
+                sb.append('\b')
+                escapes.add(EscapeInfo(rawStart, 2, 1))
+                i += 2
+            }
+            'f' -> {
+                sb.append('\u000C')
+                escapes.add(EscapeInfo(rawStart, 2, 1))
+                i += 2
+            }
+            'n' -> {
+                sb.append('\n')
+                escapes.add(EscapeInfo(rawStart, 2, 1))
+                i += 2
+            }
+            'r' -> {
+                sb.append('\r')
+                escapes.add(EscapeInfo(rawStart, 2, 1))
+                i += 2
+            }
+            't' -> {
+                sb.append('\t')
+                escapes.add(EscapeInfo(rawStart, 2, 1))
+                i += 2
+            }
+            'u' -> {
+                val (chars, consumed) = handleUnicodeEscape(content.substring(i))
+                for (c in chars) {
+                    sb.append(c)
+                }
+                escapes.add(EscapeInfo(rawStart, consumed, chars.size))
+                i += consumed
+            }
+            else -> {
+                // Unknown escape sequence, append backslash as is
+                sb.append(char)
+                i++
+            }
         }
     }
 

--- a/src/commonMain/kotlin/org/kson/schema/SchemaIdLookup.kt
+++ b/src/commonMain/kotlin/org/kson/schema/SchemaIdLookup.kt
@@ -179,40 +179,10 @@ class SchemaIdLookup(val schemaRootValue: KsonValue) {
 
         for (token in documentPathTokens) {
             val nextNodes = mutableListOf<ResolvedRef>()
-
             for ((node, baseUri) in currentNodes) {
-                if (node !is KsonObject) {
-                    continue
-                }
-
-                // Track $id changes for proper URI resolution
-                var updatedBaseUri = baseUri
-                node.propertyLookup[$$"$id"]?.let { idValue ->
-                    if (idValue is KsonString) {
-                        val fullyQualifiedId = resolveUri(idValue.value, baseUri)
-                        updatedBaseUri = fullyQualifiedId.toString()
-                    }
-                }
-
-                // Determine if this is an array index or property name
-                val isArrayIndex = token.toIntOrNull() != null
-
-                val navigatedNodes = if (isArrayIndex) {
-                    // Array navigation: go to "items" schema
-                    // We ignore the actual index - all array elements use the same schema
-                    navigateArrayItems(node, updatedBaseUri)
-                } else {
-                    // Object navigation: go to "properties" wrapper, then the property
-                    navigateObjectProperty(node, token, updatedBaseUri)
-                }
-
-                // Resolve $ref for each navigated node
-                for (navNode in navigatedNodes) {
-                    val resolved = resolveRefIfPresent(navNode.resolvedValue, navNode.resolvedValueBaseUri)
-                    nextNodes.add(ResolvedRef(resolved.resolvedValue, resolved.resolvedValueBaseUri, navNode.resolutionType))
-                }
+                if (node !is KsonObject) continue
+                stepOneTokenIntoSchema(node, baseUri, token, nextNodes)
             }
-
             currentNodes = nextNodes
             if (currentNodes.isEmpty()) {
                 break
@@ -220,6 +190,39 @@ class SchemaIdLookup(val schemaRootValue: KsonValue) {
         }
 
         return currentNodes
+    }
+
+    private fun stepOneTokenIntoSchema(
+        node: KsonObject,
+        baseUri: String,
+        token: String,
+        out: MutableList<ResolvedRef>,
+    ) {
+        // Track $id changes for proper URI resolution
+        val idValue = node.propertyLookup[$$"$id"]
+        val updatedBaseUri = if (idValue is KsonString) {
+            resolveUri(idValue.value, baseUri).toString()
+        } else {
+            baseUri
+        }
+
+        // Determine if this is an array index or property name
+        val isArrayIndex = token.toIntOrNull() != null
+
+        val navigatedNodes = if (isArrayIndex) {
+            // Array navigation: go to "items" schema
+            // We ignore the actual index - all array elements use the same schema
+            navigateArrayItems(node, updatedBaseUri)
+        } else {
+            // Object navigation: go to "properties" wrapper, then the property
+            navigateObjectProperty(node, token, updatedBaseUri)
+        }
+
+        // Resolve $ref for each navigated node
+        for (navNode in navigatedNodes) {
+            val resolved = resolveRefIfPresent(navNode.resolvedValue, navNode.resolvedValueBaseUri)
+            out.add(ResolvedRef(resolved.resolvedValue, resolved.resolvedValueBaseUri, navNode.resolutionType))
+        }
     }
 
     /**
@@ -242,10 +245,8 @@ class SchemaIdLookup(val schemaRootValue: KsonValue) {
         }
 
         // If no items found directly, search through combinators
-        if (results.isEmpty() &&
-            (schemaNode.propertyLookup.containsKey("allOf") ||
-             schemaNode.propertyLookup.containsKey("anyOf") ||
-             schemaNode.propertyLookup.containsKey("oneOf"))) {
+        val hasCombinator = schemaNode.propertyLookup.keys.any { it in combinatorKeywords }
+        if (results.isEmpty() && hasCombinator) {
             results.addAll(navigateThroughCombinators(
                 schemaNode = schemaNode,
                 currentBaseUri = currentBaseUri,
@@ -397,6 +398,8 @@ class SchemaIdLookup(val schemaRootValue: KsonValue) {
     }
 
     companion object {
+        private val combinatorKeywords = setOf("allOf", "anyOf", "oneOf")
+
         /**
          * Recursively walks a schema value to collect all `$id` entries with fully-qualified URIs.
          *
@@ -626,13 +629,10 @@ private fun updateBaseUriAlongPath(current: KsonValue, pointer: JsonPointer, cur
     var updatedBaseUri = currentBaseUri
 
     for (token in pointer.tokens) {
-        // Update base URI if current node has a $id property
-        if (node is KsonObject) {
-            node.propertyLookup["\$id"]?.let { idValue ->
-                if (idValue is KsonString) {
-                    updatedBaseUri = SchemaIdLookup.resolveUri(idValue.value, updatedBaseUri).toString()
-                }
-            }
+        // Update base URI if current node has an $id property
+        val idValue = (node as? KsonObject)?.propertyLookup["\$id"]
+        if (idValue is KsonString) {
+            updatedBaseUri = SchemaIdLookup.resolveUri(idValue.value, updatedBaseUri).toString()
         }
 
         // Navigate to next node

--- a/src/commonMain/kotlin/org/kson/schema/SchemaParser.kt
+++ b/src/commonMain/kotlin/org/kson/schema/SchemaParser.kt
@@ -51,6 +51,7 @@ object SchemaParser {
         }
     }
 
+    @Suppress("NestedBlockDepth") // baselined as LongMethod/CyclomaticComplexMethod; a full refactor is its own story
     private fun parseObjectSchema(
         schemaObject: KsonObject,
         messageSink: MessageSink,

--- a/src/commonMain/kotlin/org/kson/schema/validators/PropertiesValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/PropertiesValidator.kt
@@ -32,16 +32,7 @@ class PropertiesValidator(private val propertySchemas: Map<KsonString, JsonSchem
         // Then validate pattern properties - need to check ALL patterns for each property
         compiledPatterns?.let { patterns ->
             objectProperties.forEach { (propertyName, propertyValue) ->
-                var matchedAnyPattern = false
-
-                patterns.forEach { (regex, schema) ->
-                    if (regex.containsMatchIn(propertyName)) {
-                        matchedAnyPattern = true
-                        schema?.validate(propertyValue, messageSink)
-                    }
-                }
-
-                if (matchedAnyPattern) {
+                if (validatePatternMatches(propertyName, propertyValue, patterns, messageSink)) {
                     seenKeys.add(propertyName)
                 }
             }
@@ -50,6 +41,22 @@ class PropertiesValidator(private val propertySchemas: Map<KsonString, JsonSchem
         // Finally, validate additional properties
         val remainingProperties = node.propertyMap.filter { !seenKeys.contains(it.key) }
         additionalPropertiesValidator?.validateProperties(remainingProperties, node.location, messageSink)
+    }
+
+    private fun validatePatternMatches(
+        propertyName: String,
+        propertyValue: org.kson.value.KsonValue,
+        patterns: List<CompiledPatternSchema>,
+        messageSink: MessageSink,
+    ): Boolean {
+        var matchedAnyPattern = false
+        patterns.forEach { (regex, schema) ->
+            if (regex.containsMatchIn(propertyName)) {
+                matchedAnyPattern = true
+                schema?.validate(propertyValue, messageSink)
+            }
+        }
+        return matchedAnyPattern
     }
 }
 

--- a/src/commonMain/kotlin/org/kson/schema/validators/TypeValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/TypeValidator.kt
@@ -34,11 +34,11 @@ class TypeValidator(private val allowedTypes: List<String>, private val property
       is EmbedBlock -> "string"
     }
 
-    if (!allowedTypes.contains(nodeType)
-      // if our node is an integer, this type is valid if the more-general "number" is an allowedType
-      && !(nodeType == "integer" && allowedTypes.contains("number"))
-      // embed blocks are strings, but also validate as objects so schemas can constrain their tag/content
-      && !(ksonValue is EmbedBlock && allowedTypes.contains("object"))) {
+    // if our node is an integer, this type is valid if the more-general "number" is an allowedType
+    val integerAcceptedAsNumber = nodeType == "integer" && allowedTypes.contains("number")
+    // embed blocks are strings, but also validate as objects so schemas can constrain their tag/content
+    val embedAcceptedAsObject = ksonValue is EmbedBlock && allowedTypes.contains("object")
+    if (!allowedTypes.contains(nodeType) && !integerAcceptedAsNumber && !embedAcceptedAsObject) {
       messageSink.error(ksonValue.location, MessageType.SCHEMA_VALUE_TYPE_MISMATCH.create(propertyName ?: "", allowedTypes.joinToString(), nodeType))
       return false
     }

--- a/src/commonMain/kotlin/org/kson/tools/Formatter.kt
+++ b/src/commonMain/kotlin/org/kson/tools/Formatter.kt
@@ -94,6 +94,7 @@ class IndentFormatter(
         "This formatter is no long a good general purpose formatter. " +
                 "See the TODO in this class's doc for details"
     )
+    @Suppress("NestedBlockDepth")
     private fun indent(source: String, snippetNestingLevel: Int? = null): String {
         if (source.isBlank() && snippetNestingLevel == null) return ""
         val tokens = Lexer(source, gapFree = true).tokenize()
@@ -275,12 +276,14 @@ class IndentFormatter(
         val indent = indentType.indentString.repeat(nestingLevel)
         val lines = content.split('\n')
 
+        val contentHasTrailingNewline = content.endsWith('\n')
         return lines.mapIndexed { index, line ->
             /**
              * If [content] ends in a newline, the next line does not belong to it,
              * so don't indent it unless our caller demands it
              */
-            if (!keepTrailingIndent && index == lines.lastIndex && line.isEmpty() && content.endsWith('\n')) {
+            val isDanglingTrailingLine = index == lines.lastIndex && line.isEmpty() && contentHasTrailingNewline
+            if (!keepTrailingIndent && isDanglingTrailingLine) {
                 line
             } else {
                 indent + line
@@ -293,6 +296,7 @@ class IndentFormatter(
      * Note: trims leading whitespace tokens/lines, and may gather multiple lines of underlying source in one logical
      *   "token line" when appropriate
      */
+    @Suppress("NestedBlockDepth") // this helper is only used by the @Deprecated `indent` above
     private fun splitTokenLines(tokens: List<Token>): MutableList<List<Token>> {
         val tokenLines = mutableListOf<List<Token>>()
         var currentLine = mutableListOf<Token>()

--- a/src/commonMain/kotlin/org/kson/validation/IndentValidator.kt
+++ b/src/commonMain/kotlin/org/kson/validation/IndentValidator.kt
@@ -33,42 +33,53 @@ class IndentValidator {
                                     messageType: MessageType,
                                     messageSink: MessageSink) {
         when (node) {
-            is ObjectNode -> {
-                node.properties.forEach { property ->
-                    if (property.location.start.column < minNestingColumn) {
-                        messageSink.error(property.location.trimToFirstLine(), messageType.create())
-                    }
-
-                    if (property is ObjectPropertyNodeImpl) {
-                        validateNodeNesting(property.value, property.key.location.start.column + 1,
-                            OBJECT_PROPERTY_NESTING_ISSUE, messageSink)
-                    }
-                }
-            }
-            is ListNode -> {
-                node.elements.forEach { element ->
-                    if (element.location.start.column < minNestingColumn) {
-                        messageSink.error(element.location.trimToFirstLine(), messageType.create())
-                    }
-
-                    if (element is ListElementNodeImpl) {
-                        val minListNestingColumn = if (element.location.startOffset < element.value.location.startOffset) {
-                            // this list element starts before its value, i.e. has a dash, so ensure its value is nested
-                            element.location.start.column + 1
-                        } else {
-                            // this list element has no dash, so no extra nesting is needed
-                            element.location.start.column
-                        }
-                        validateNodeNesting(element.value, minListNestingColumn, DASH_LIST_ITEMS_NESTING_ISSUE, messageSink)
-                    }
-                }
-            }
+            is ObjectNode -> validateObjectNodeNesting(node, minNestingColumn, messageType, messageSink)
+            is ListNode -> validateListNodeNesting(node, minNestingColumn, messageType, messageSink)
             is EmbedBlockNode, is UnquotedStringNode, is QuotedStringNode,
             is NumberNode, is TrueNode, is FalseNode, is NullNode,
             is KsonValueNodeError -> {
                 if (node.location.start.column < minNestingColumn) {
                     messageSink.error(node.location.trimToFirstLine(), messageType.create())
                 }
+            }
+        }
+    }
+
+    private fun validateObjectNodeNesting(
+        node: ObjectNode,
+        minNestingColumn: Int,
+        messageType: MessageType,
+        messageSink: MessageSink,
+    ) {
+        node.properties.forEach { property ->
+            if (property.location.start.column < minNestingColumn) {
+                messageSink.error(property.location.trimToFirstLine(), messageType.create())
+            }
+            if (property is ObjectPropertyNodeImpl) {
+                validateNodeNesting(property.value, property.key.location.start.column + 1,
+                    OBJECT_PROPERTY_NESTING_ISSUE, messageSink)
+            }
+        }
+    }
+
+    private fun validateListNodeNesting(
+        node: ListNode,
+        minNestingColumn: Int,
+        messageType: MessageType,
+        messageSink: MessageSink,
+    ) {
+        node.elements.forEach { element ->
+            if (element.location.start.column < minNestingColumn) {
+                messageSink.error(element.location.trimToFirstLine(), messageType.create())
+            }
+            if (element is ListElementNodeImpl) {
+                // an element with a dash has location offset before its value, so its value must sit one column deeper
+                val minListNestingColumn = if (element.location.startOffset < element.value.location.startOffset) {
+                    element.location.start.column + 1
+                } else {
+                    element.location.start.column
+                }
+                validateNodeNesting(element.value, minListNestingColumn, DASH_LIST_ITEMS_NESTING_ISSUE, messageSink)
             }
         }
     }

--- a/tooling/jetbrains/detekt-baseline.xml
+++ b/tooling/jetbrains/detekt-baseline.xml
@@ -2,7 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>CyclomaticComplexMethod:KsonEnterHandlerDelegate.kt$KsonEnterHandlerDelegate$@Suppress("SameReturnValue") // Only need to return `Continue` right now. private fun preprocessEnter( file: PsiFile, editor: Editor, offset: Int, ): Result</ID>
     <ID>CyclomaticComplexMethod:KsonSyntaxHighlighter.kt$KsonSyntaxHighlighter$override fun getTokenHighlights(elementType: IElementType): Array&lt;TextAttributesKey></ID>
     <ID>LongMethod:KsonBackspaceHandlerDelegateTest.kt$KsonBackspaceHandlerDelegateTest$fun testDeleteEmptyEmbedDelimitersPairs()</ID>
     <ID>LongMethod:KsonTypedHandlerDelegateTest.kt$KsonTypedHandlerDelegateTest$fun testEmbedDelimiterAutoInsert()</ID>

--- a/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/editor/KsonEnterHandlerDelegate.kt
+++ b/tooling/jetbrains/src/main/kotlin/org/kson/jetbrains/editor/KsonEnterHandlerDelegate.kt
@@ -17,6 +17,15 @@ import org.kson.jetbrains.util.getIndentType
 import org.kson.jetbrains.util.getLineIndentLevel
 
 class KsonEnterHandlerDelegate : EnterHandlerDelegate {
+    companion object {
+        private val matchingDelimiterPairs = setOf(
+            '{' to '}',
+            '[' to ']',
+            '<' to '>',
+            '>' to '<',
+        )
+    }
+
     override fun preprocessEnter(
         file: PsiFile, editor: Editor, caretOffset: Ref<Int>, caretAdvance: Ref<Int>, dataContext: DataContext,
         originalHandler: EditorActionHandler?
@@ -84,14 +93,11 @@ class KsonEnterHandlerDelegate : EnterHandlerDelegate {
              * ]
              * ```
              */
-            if ((before == '{' && after == '}') ||
-                (before == '[' && after == ']') ||
-                (before == '<' && after == '>') ||
-                // TODO this is to help indenting tags in injected xml-like languages, which should not be our
-                //   responsibility, but it seems Kotlin has the same workaround [https://github.com/JetBrains/intellij-community/blob/4d2499e460bd6ab6425de24517d0050b65a78f99/plugins/kotlin/base/code-insight/minimal/src/org/jetbrains/kotlin/idea/editor/KotlinMultilineStringEnterHandler.kt#L82].
-                //   Can we figure out how to delegate to the injected language?
-                (before == '>' && after == '<')
-            ) {
+            // TODO the '>' / '<' pair is to help indenting tags in injected xml-like languages, which should not be our
+            //   responsibility, but it seems Kotlin has the same workaround [https://github.com/JetBrains/intellij-community/blob/4d2499e460bd6ab6425de24517d0050b65a78f99/plugins/kotlin/base/code-insight/minimal/src/org/jetbrains/kotlin/idea/editor/KotlinMultilineStringEnterHandler.kt#L82].
+            //   Can we figure out how to delegate to the injected language?
+            val caretBetweenMatchingDelimiters = (before to after) in matchingDelimiterPairs
+            if (caretBetweenMatchingDelimiters) {
                 // Remove any whitespace we found between the delimiters
                 if (afterIndex > offset) {
                     document.deleteString(offset, afterIndex)


### PR DESCRIPTION
Follow up refactor detekted by the static code analysis of #378

Detekt update two thresholds to accommodate existing code. Both rules are exactly the kind that tend to surface bugs—a stray extra boolean term or another level of nesting is precisely how parser/validator logic quietly goes wrong—so we'd rather see the warnings and fix the code than loosen the bar.

Baselines regenerated to match the two methods whose signatures changed
from the new @Suppress annotations.
