### PR TITLE
Prevent formatter from throwing on malformed input with embed rules

### DIFF
--- a/src/commonMain/kotlin/org/kson/ast/EmbedBlockResolver.kt
+++ b/src/commonMain/kotlin/org/kson/ast/EmbedBlockResolver.kt
@@ -2,8 +2,8 @@ package org.kson.ast
 
 import org.kson.tools.InternalEmbedRule
 import org.kson.value.KsonString
+import org.kson.value.KsonValue
 import org.kson.value.navigation.json_pointer.ExperimentalJsonPointerGlobLanguage
-import org.kson.value.toKsonValue
 import org.kson.walker.KsonValueWalker
 import org.kson.walker.navigateWithJsonPointerGlob
 
@@ -23,23 +23,22 @@ data class EmbedBlockResolution(
 /**
  * Resolves which string nodes should be formatted as embed blocks based on the provided rules.
  *
- * This function pre-processes the AST to build a map of StringNodes to their matching embed rules,
+ * This function pre-processes the parsed value to build a map of StringNodes to their matching embed rules,
  * eliminating the need to thread path context through the serialization process.
  *
  * Only StringNode instances need tracking - EmbedBlockNode instances are already embed blocks
  * and will format correctly using their existing tags.
  *
- * @param root The root of the AST to process
+ * @param rootValue The root [KsonValue] to process
  * @param rules The embed block rules to match against document paths
  * @return An EmbedBlockResolution containing the map of StringNodes to their matching rules
  */
 @OptIn(ExperimentalJsonPointerGlobLanguage::class)
 fun resolveEmbedBlocks(
-    root: KsonRoot,
+    rootValue: KsonValue,
     rules: List<InternalEmbedRule>
 ): EmbedBlockResolution {
     if (rules.isEmpty()) return EmbedBlockResolution.EMPTY
-    val rootValue = root.toKsonValue()
     val stringResult = mutableMapOf<StringNode, InternalEmbedRule>()
     for (rule in rules) {
         val matchingValues = KsonValueWalker.navigateWithJsonPointerGlob(rootValue, rule.pathPattern)

--- a/src/commonMain/kotlin/org/kson/tools/Formatter.kt
+++ b/src/commonMain/kotlin/org/kson/tools/Formatter.kt
@@ -24,9 +24,9 @@ fun format(ksonSource: String, formatterConfig: KsonFormatterConfig = KsonFormat
 
     val astParseResult = parseToAst(ksonSource, CoreCompileConfig(ignoreErrors = true))
 
-    // Pre-process: find all nodes that should be formatted as embed blocks
-    val embedBlockResolution = if (formatterConfig.embedBlockRules.isNotEmpty() && !astParseResult.hasErrors()) {
-        resolveEmbedBlocks(astParseResult.ast, formatterConfig.embedBlockRules)
+    val ksonValue = astParseResult.ksonValue
+    val embedBlockResolution = if (formatterConfig.embedBlockRules.isNotEmpty() && ksonValue != null) {
+        resolveEmbedBlocks(ksonValue, formatterConfig.embedBlockRules)
     } else {
         EmbedBlockResolution.EMPTY
     }

--- a/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
+++ b/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
@@ -2368,4 +2368,18 @@ class FormatterTest {
             embedBlockRules = listOf(embedRule("/scripts/build")),
         )
     }
+
+    @Test
+    fun testMalformedInputWithEmbedRulesDoesNotThrow() {
+        // Regression: format() used to throw ShouldNotHappenException when the AST contained hidden
+        // AstNodeError nodes (parsed with ignoreErrors = true) while embed block rules were active.
+        val malformedInput = "version: v1name: namepipeline:  g1:    tasks:      task1:"
+        val withRules = format(
+            malformedInput,
+            KsonFormatterConfig(embedBlockRules = listOf(embedRule("/pipeline/**/tasks/*")))
+        )
+        val withoutRules = format(malformedInput, KsonFormatterConfig())
+        // With unrecoverable parse state, the embed rules fall back to a no-op — output matches the rule-free path.
+        assertEquals(withoutRules, withRules)
+    }
 }


### PR DESCRIPTION
The formatter parses with `ignoreErrors = true`, which can leave hidden `AstNodeError` nodes in a tree where `hasErrors()` still returns false. `resolveEmbedBlocks` called `root.toKsonValue()` directly, so those hidden errors surfaced as a `ShouldNotHappenException` that escaped `format()` instead of falling back to the original source. This only reproduced when embed block rules were configured.

Take a `KsonValue` in `resolveEmbedBlocks` instead of a `KsonRoot`, and have the caller source it from `AstParseResult.ksonValue` — which already catches the conversion exception and returns null. The new `ksonValue != null` guard is strictly stronger than the previous `!hasErrors()` check.