### PR TITLE
Read VSCode extension namespace from the manifest

### DIFF
--- a/src/commonMain/kotlin/org/kson/ast/EmbedBlockResolver.kt
+++ b/src/commonMain/kotlin/org/kson/ast/EmbedBlockResolver.kt
@@ -2,8 +2,8 @@ package org.kson.ast
 
 import org.kson.tools.InternalEmbedRule
 import org.kson.value.KsonString
+import org.kson.value.KsonValue
 import org.kson.value.navigation.json_pointer.ExperimentalJsonPointerGlobLanguage
-import org.kson.value.toKsonValue
 import org.kson.walker.KsonValueWalker
 import org.kson.walker.navigateWithJsonPointerGlob
 
@@ -23,23 +23,22 @@ data class EmbedBlockResolution(
 /**
  * Resolves which string nodes should be formatted as embed blocks based on the provided rules.
  *
- * This function pre-processes the AST to build a map of StringNodes to their matching embed rules,
+ * This function pre-processes the parsed value to build a map of StringNodes to their matching embed rules,
  * eliminating the need to thread path context through the serialization process.
  *
  * Only StringNode instances need tracking - EmbedBlockNode instances are already embed blocks
  * and will format correctly using their existing tags.
  *
- * @param root The root of the AST to process
+ * @param rootValue The root [KsonValue] to process
  * @param rules The embed block rules to match against document paths
  * @return An EmbedBlockResolution containing the map of StringNodes to their matching rules
  */
 @OptIn(ExperimentalJsonPointerGlobLanguage::class)
 fun resolveEmbedBlocks(
-    root: KsonRoot,
+    rootValue: KsonValue,
     rules: List<InternalEmbedRule>
 ): EmbedBlockResolution {
     if (rules.isEmpty()) return EmbedBlockResolution.EMPTY
-    val rootValue = root.toKsonValue()
     val stringResult = mutableMapOf<StringNode, InternalEmbedRule>()
     for (rule in rules) {
         val matchingValues = KsonValueWalker.navigateWithJsonPointerGlob(rootValue, rule.pathPattern)

--- a/src/commonMain/kotlin/org/kson/tools/Formatter.kt
+++ b/src/commonMain/kotlin/org/kson/tools/Formatter.kt
@@ -24,9 +24,9 @@ fun format(ksonSource: String, formatterConfig: KsonFormatterConfig = KsonFormat
 
     val astParseResult = parseToAst(ksonSource, CoreCompileConfig(ignoreErrors = true))
 
-    // Pre-process: find all nodes that should be formatted as embed blocks
-    val embedBlockResolution = if (formatterConfig.embedBlockRules.isNotEmpty() && !astParseResult.hasErrors()) {
-        resolveEmbedBlocks(astParseResult.ast, formatterConfig.embedBlockRules)
+    val ksonValue = astParseResult.ksonValue
+    val embedBlockResolution = if (formatterConfig.embedBlockRules.isNotEmpty() && ksonValue != null) {
+        resolveEmbedBlocks(ksonValue, formatterConfig.embedBlockRules)
     } else {
         EmbedBlockResolution.EMPTY
     }

--- a/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
+++ b/src/commonTest/kotlin/org/kson/tools/FormatterTest.kt
@@ -2368,4 +2368,18 @@ class FormatterTest {
             embedBlockRules = listOf(embedRule("/scripts/build")),
         )
     }
+
+    @Test
+    fun testMalformedInputWithEmbedRulesDoesNotThrow() {
+        // Regression: format() used to throw ShouldNotHappenException when the AST contained hidden
+        // AstNodeError nodes (parsed with ignoreErrors = true) while embed block rules were active.
+        val malformedInput = "version: v1name: namepipeline:  g1:    tasks:      task1:"
+        val withRules = format(
+            malformedInput,
+            KsonFormatterConfig(embedBlockRules = listOf(embedRule("/pipeline/**/tasks/*")))
+        )
+        val withoutRules = format(malformedInput, KsonFormatterConfig())
+        // With unrecoverable parse state, the embed rules fall back to a no-op — output matches the rule-free path.
+        assertEquals(withoutRules, withRules)
+    }
 }

--- a/tooling/language-server-protocol/src/core/KsonSettings.ts
+++ b/tooling/language-server-protocol/src/core/KsonSettings.ts
@@ -2,23 +2,29 @@ import {LSPAny} from "vscode-languageserver";
 import {FormatOptions, FormattingStyle, IndentType} from "kson";
 
 /**
- * Configuration settings for the Kson language server
+ * Configuration settings for the Kson language server.
+ *
+ * These are the already-unwrapped settings — the server has stripped the
+ * configuration namespace (e.g. "kson") before calling
+ * {@link ksonSettingsWithDefaults}.
  */
 export interface KsonSettings {
-    kson: {
-        formatOptions: FormatOptions;
-        codeLensEnabled: boolean;
-    };
+    formatOptions: FormatOptions;
+    codeLensEnabled: boolean;
 }
 
 /**
  * Create new [KsonSettings] from LSP settings, applying defaults where needed.
+ *
+ * Input is the object returned by `connection.workspace.getConfiguration(ns)`,
+ * so the shape is `{ format?: {...}, codeLens?: {...} }` without any outer
+ * namespace key.
  */
 export function ksonSettingsWithDefaults(settings?: LSPAny): Required<KsonSettings> {
     // Create IndentType based on the provided settings
     let indentType: IndentType;
-    if (settings?.kson?.format) {
-        const format = settings.kson.format;
+    if (settings?.format) {
+        const format = settings.format;
         if (format.insertSpaces === false) {
             indentType = IndentType.Tabs;
         } else {
@@ -33,9 +39,9 @@ export function ksonSettingsWithDefaults(settings?: LSPAny): Required<KsonSettin
 
     // Create FormattingStyle based on the provided settings
     let formatStyle: FormattingStyle
-    if (settings?.kson?.format?.formattingStyle) {
+    if (settings?.format?.formattingStyle) {
         // Map lowercase string to uppercase enum value exhaustively
-        const style = settings.kson.format.formattingStyle.toLowerCase();
+        const style = settings.format.formattingStyle.toLowerCase();
         switch (style) {
             case 'plain':
                 formatStyle = FormattingStyle.PLAIN;
@@ -53,12 +59,10 @@ export function ksonSettingsWithDefaults(settings?: LSPAny): Required<KsonSettin
     }
 
     // CodeLens enabled by default
-    const codeLensEnabled = settings?.kson?.codeLens?.enable !== false;
+    const codeLensEnabled = settings?.codeLens?.enable !== false;
 
     return {
-        kson: {
-            formatOptions: new FormatOptions(indentType, formatStyle),
-            codeLensEnabled
-        }
+        formatOptions: new FormatOptions(indentType, formatStyle),
+        codeLensEnabled
     };
 }

--- a/tooling/language-server-protocol/src/core/commands/CommandExecutor.base.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandExecutor.base.ts
@@ -58,7 +58,7 @@ export abstract class CommandExecutorBase {
             case CommandType.DELIMITED_FORMAT:
             case CommandType.COMPACT_FORMAT:
             case CommandType.CLASSIC_FORMAT: {
-                const indentType = this.getConfiguration().kson.formatOptions.indentType;
+                const indentType = this.getConfiguration().formatOptions.indentType;
 
                 return this.executeFormat(commandArgs.documentUri, document, new FormatOptions(
                     indentType,

--- a/tooling/language-server-protocol/src/core/commands/CommandType.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandType.ts
@@ -1,41 +1,68 @@
 /**
- * Enum defining all available commands in the Kson Language Server
+ * Enum defining all commands the Kson Language Server can execute.
+ *
+ * Values are **unqualified** ids used as internal discriminators (executor
+ * switch, {@link ./CommandParameters} keys). The VSCode/LSP wire form prepends
+ * the active configuration namespace via {@link toWireCommandId} and is
+ * stripped again in {@link fromWireCommandId}, so a client built under a
+ * non-default namespace (e.g. `config.plainFormat`) can coexist with the
+ * base `kson` extension in the same VSCode host without command-registration
+ * collisions.
  */
 export enum CommandType {
-    /**
-     * Format the document as plain Kson
-     */
-    PLAIN_FORMAT = 'kson.plainFormat',
+    /** Format the document as plain Kson */
+    PLAIN_FORMAT = 'plainFormat',
 
-    /**
-     * Format the document as delimited Kson
-     */
-    DELIMITED_FORMAT = 'kson.delimitedFormat',
+    /** Format the document as delimited Kson */
+    DELIMITED_FORMAT = 'delimitedFormat',
 
-    /**
-     * Format the document as compact Kson
-     */
-    COMPACT_FORMAT = 'kson.compactFormat',
+    /** Format the document as compact Kson */
+    COMPACT_FORMAT = 'compactFormat',
 
-     /**
-     * Format the document as classic Kson
-     */
-    CLASSIC_FORMAT = 'kson.classicFormat',
+    /** Format the document as classic Kson */
+    CLASSIC_FORMAT = 'classicFormat',
 
-    /**
-     * Associate a schema with the current document
-     */
-    ASSOCIATE_SCHEMA = 'kson.associateSchema',
+    /** Associate a schema with the current document */
+    ASSOCIATE_SCHEMA = 'associateSchema',
 
-    /**
-     * Remove schema association from the current document
-     */
-    REMOVE_SCHEMA = 'kson.removeSchema'
+    /** Remove schema association from the current document */
+    REMOVE_SCHEMA = 'removeSchema',
 }
 
 /**
- * Get all available command IDs
+ * Default configuration namespace used by the base kson extension and by the
+ * server when the client hasn't specified otherwise via initializationOptions.
+ * Commands and client settings both live under this prefix on the wire.
  */
-export function getAllCommandIds(): string[] {
+export const DEFAULT_CONFIG_NAMESPACE = 'kson';
+
+/**
+ * Get all unqualified command ids.
+ */
+export function getAllCommandIds(): CommandType[] {
     return Object.values(CommandType);
+}
+
+/**
+ * Build the VSCode/LSP wire id for a command by prepending the active
+ * configuration namespace.
+ */
+export function toWireCommandId(commandId: CommandType | string, namespace: string): string {
+    return `${namespace}.${commandId}`;
+}
+
+/**
+ * Parse a wire command id back to its {@link CommandType}, or return
+ * `undefined` if the id is not namespaced under `namespace` or doesn't resolve
+ * to a known command.
+ */
+export function fromWireCommandId(wireId: string, namespace: string): CommandType | undefined {
+    const prefix = `${namespace}.`;
+    if (!wireId.startsWith(prefix)) {
+        return undefined;
+    }
+    const unqualified = wireId.slice(prefix.length);
+    return (Object.values(CommandType) as string[]).includes(unqualified)
+        ? (unqualified as CommandType)
+        : undefined;
 }

--- a/tooling/language-server-protocol/src/core/commands/CommandType.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandType.ts
@@ -1,13 +1,9 @@
 /**
  * Enum defining all commands the Kson Language Server can execute.
  *
- * Values are **unqualified** ids used as internal discriminators (executor
- * switch, {@link ./CommandParameters} keys). The VSCode/LSP wire form prepends
- * the active configuration namespace via {@link toWireCommandId} and is
- * stripped again in {@link fromWireCommandId}, so a client built under a
- * non-default namespace (e.g. `config.plainFormat`) can coexist with the
- * base `kson` extension in the same VSCode host without command-registration
- * collisions.
+ * Values are unqualified ids used internally as discriminators. On the wire,
+ * they are prefixed with the active distribution id via {@link toWireCommandId}
+ * and stripped again in {@link fromWireCommandId}.
  */
 export enum CommandType {
     /** Format the document as plain Kson */
@@ -30,13 +26,6 @@ export enum CommandType {
 }
 
 /**
- * Default configuration namespace used by the base kson extension and by the
- * server when the client hasn't specified otherwise via initializationOptions.
- * Commands and client settings both live under this prefix on the wire.
- */
-export const DEFAULT_CONFIG_NAMESPACE = 'kson';
-
-/**
  * Get all unqualified command ids.
  */
 export function getAllCommandIds(): CommandType[] {
@@ -45,19 +34,19 @@ export function getAllCommandIds(): CommandType[] {
 
 /**
  * Build the VSCode/LSP wire id for a command by prepending the active
- * configuration namespace.
+ * distribution id.
  */
-export function toWireCommandId(commandId: CommandType | string, namespace: string): string {
-    return `${namespace}.${commandId}`;
+export function toWireCommandId(commandId: CommandType | string, distributionId: string): string {
+    return `${distributionId}.${commandId}`;
 }
 
 /**
  * Parse a wire command id back to its {@link CommandType}, or return
- * `undefined` if the id is not namespaced under `namespace` or doesn't resolve
- * to a known command.
+ * `undefined` if the id is not prefixed by `distributionId` or doesn't
+ * resolve to a known command.
  */
-export function fromWireCommandId(wireId: string, namespace: string): CommandType | undefined {
-    const prefix = `${namespace}.`;
+export function fromWireCommandId(wireId: string, distributionId: string): CommandType | undefined {
+    const prefix = `${distributionId}.`;
     if (!wireId.startsWith(prefix)) {
         return undefined;
     }

--- a/tooling/language-server-protocol/src/core/features/DiagnosticService.ts
+++ b/tooling/language-server-protocol/src/core/features/DiagnosticService.ts
@@ -7,12 +7,15 @@ import {
 import {KsonDocument} from '../document/KsonDocument';
 import {isKsonSchemaDocument} from '../document/KsonSchemaDocument';
 import {KsonTooling, DiagnosticMessage, DiagnosticSeverity as KtSeverity} from 'kson-tooling';
+import {DEFAULT_CONFIG_NAMESPACE} from '../commands/CommandType.js';
 
 /**
  * Service responsible for providing diagnostic information for Kson documents.
  * Delegates to Kotlin's KsonTooling for validation.
  */
 export class DiagnosticService {
+
+    constructor(private readonly configNamespace: string = DEFAULT_CONFIG_NAMESPACE) {}
 
     createDocumentDiagnosticReport(document: KsonDocument | null | undefined): DocumentDiagnosticReport {
         const diagnostics = document ? this.getDiagnostics(document) : [];
@@ -32,20 +35,20 @@ export class DiagnosticService {
             .validateDocument(toolingDoc, schemaToolingDoc ?? null)
             .asJsReadonlyArrayView();
 
-        return messages.map(msg => toDiagnostic(msg));
+        return messages.map(msg => this.toDiagnostic(msg));
     }
-}
 
-function toDiagnostic(msg: DiagnosticMessage): Diagnostic {
-    return {
-        range: {
-            start: {line: msg.range.startLine, character: msg.range.startColumn},
-            end: {line: msg.range.endLine, character: msg.range.endColumn}
-        },
-        severity: msg.severity === KtSeverity.ERROR
-            ? DiagnosticSeverity.Error
-            : DiagnosticSeverity.Warning,
-        source: 'kson',
-        message: msg.message
-    };
+    private toDiagnostic(msg: DiagnosticMessage): Diagnostic {
+        return {
+            range: {
+                start: {line: msg.range.startLine, character: msg.range.startColumn},
+                end: {line: msg.range.endLine, character: msg.range.endColumn}
+            },
+            severity: msg.severity === KtSeverity.ERROR
+                ? DiagnosticSeverity.Error
+                : DiagnosticSeverity.Warning,
+            source: this.configNamespace,
+            message: msg.message
+        };
+    }
 }

--- a/tooling/language-server-protocol/src/core/features/DiagnosticService.ts
+++ b/tooling/language-server-protocol/src/core/features/DiagnosticService.ts
@@ -7,7 +7,6 @@ import {
 import {KsonDocument} from '../document/KsonDocument';
 import {isKsonSchemaDocument} from '../document/KsonSchemaDocument';
 import {KsonTooling, DiagnosticMessage, DiagnosticSeverity as KtSeverity} from 'kson-tooling';
-import {DEFAULT_CONFIG_NAMESPACE} from '../commands/CommandType.js';
 
 /**
  * Service responsible for providing diagnostic information for Kson documents.
@@ -15,7 +14,7 @@ import {DEFAULT_CONFIG_NAMESPACE} from '../commands/CommandType.js';
  */
 export class DiagnosticService {
 
-    constructor(private readonly configNamespace: string = DEFAULT_CONFIG_NAMESPACE) {}
+    constructor(private readonly configNamespace: string) {}
 
     createDocumentDiagnosticReport(document: KsonDocument | null | undefined): DocumentDiagnosticReport {
         const diagnostics = document ? this.getDiagnostics(document) : [];

--- a/tooling/language-server-protocol/src/core/features/DiagnosticService.ts
+++ b/tooling/language-server-protocol/src/core/features/DiagnosticService.ts
@@ -14,7 +14,7 @@ import {KsonTooling, DiagnosticMessage, DiagnosticSeverity as KtSeverity} from '
  */
 export class DiagnosticService {
 
-    constructor(private readonly configNamespace: string) {}
+    constructor(private readonly distributionId: string) {}
 
     createDocumentDiagnosticReport(document: KsonDocument | null | undefined): DocumentDiagnosticReport {
         const diagnostics = document ? this.getDiagnostics(document) : [];
@@ -46,7 +46,7 @@ export class DiagnosticService {
             severity: msg.severity === KtSeverity.ERROR
                 ? DiagnosticSeverity.Error
                 : DiagnosticSeverity.Warning,
-            source: this.configNamespace,
+            source: this.distributionId,
             message: msg.message
         };
     }

--- a/tooling/language-server-protocol/src/core/services/KsonTextDocumentService.ts
+++ b/tooling/language-server-protocol/src/core/services/KsonTextDocumentService.ts
@@ -38,6 +38,11 @@ import {FoldingRangeService} from '../features/FoldingRangeService.js';
 import {SelectionRangeService} from '../features/SelectionRangeService.js';
 import {CommandExecutorBase} from '../commands/CommandExecutor.base.js';
 import { CommandExecutorFactory } from '../commands/CommandExecutorFactory.js';
+import {
+    DEFAULT_CONFIG_NAMESPACE,
+    fromWireCommandId,
+    toWireCommandId,
+} from '../commands/CommandType.js';
 import {KsonSettings, ksonSettingsWithDefaults} from '../KsonSettings.js';
 
 
@@ -64,10 +69,11 @@ export class KsonTextDocumentService {
     constructor(
         private documentManager: KsonDocumentsManager,
         private createCommandExecutor: CommandExecutorFactory,
-        private workspaceRoot: string | null = null
+        private workspaceRoot: string | null = null,
+        private configNamespace: string = DEFAULT_CONFIG_NAMESPACE
     ) {
         this.formattingService = new FormattingService();
-        this.diagnosticService = new DiagnosticService();
+        this.diagnosticService = new DiagnosticService(configNamespace);
         this.semanticTokensService = new SemanticTokensService();
         this.codeLensService = new CodeLensService();
         this.documentHighlightService = new DocumentHighlightService();
@@ -158,7 +164,7 @@ export class KsonTextDocumentService {
             if (!document) {
                 return [];
             }
-            return this.formattingService.formatDocument(document, this.configuration.kson.formatOptions);
+            return this.formattingService.formatDocument(document, this.configuration.formatOptions);
         } catch (error) {
             this.connection.console.error(`Error formatting document: ${error}`);
             return [];
@@ -183,14 +189,19 @@ export class KsonTextDocumentService {
 
     private async onCodeLens(params: CodeLensParams): Promise<CodeLens[]> {
         try {
-            if (!this.configuration.kson.codeLensEnabled) {
+            if (!this.configuration.codeLensEnabled) {
                 return [];
             }
             const document = this.documentManager.get(params.textDocument.uri);
             if (!document) {
                 return [];
             }
-            return this.codeLensService.getCodeLenses(document);
+            return this.codeLensService.getCodeLenses(document).map(lens => ({
+                ...lens,
+                command: lens.command
+                    ? {...lens.command, command: toWireCommandId(lens.command.command, this.configNamespace)}
+                    : lens.command,
+            }));
         } catch (error) {
             this.connection.console.error(`Error providing code lenses: ${error}`);
             return [];
@@ -199,7 +210,10 @@ export class KsonTextDocumentService {
 
     private async onExecuteCommand(params: ExecuteCommandParams): Promise<any> {
         try {
-            return await this.commandExecutor.execute(params);
+            const commandType = fromWireCommandId(params.command, this.configNamespace);
+            return await this.commandExecutor.execute(
+                commandType ? {...params, command: commandType} : params
+            );
         } catch (error) {
             this.connection.console.error(`Error executing command: ${error}`);
             this.connection.window.showErrorMessage(`Command execution failed: ${error}`);

--- a/tooling/language-server-protocol/src/core/services/KsonTextDocumentService.ts
+++ b/tooling/language-server-protocol/src/core/services/KsonTextDocumentService.ts
@@ -39,7 +39,6 @@ import {SelectionRangeService} from '../features/SelectionRangeService.js';
 import {CommandExecutorBase} from '../commands/CommandExecutor.base.js';
 import { CommandExecutorFactory } from '../commands/CommandExecutorFactory.js';
 import {
-    DEFAULT_CONFIG_NAMESPACE,
     fromWireCommandId,
     toWireCommandId,
 } from '../commands/CommandType.js';
@@ -70,7 +69,7 @@ export class KsonTextDocumentService {
         private documentManager: KsonDocumentsManager,
         private createCommandExecutor: CommandExecutorFactory,
         private workspaceRoot: string | null = null,
-        private configNamespace: string = DEFAULT_CONFIG_NAMESPACE
+        private configNamespace: string
     ) {
         this.formattingService = new FormattingService();
         this.diagnosticService = new DiagnosticService(configNamespace);

--- a/tooling/language-server-protocol/src/core/services/KsonTextDocumentService.ts
+++ b/tooling/language-server-protocol/src/core/services/KsonTextDocumentService.ts
@@ -69,10 +69,10 @@ export class KsonTextDocumentService {
         private documentManager: KsonDocumentsManager,
         private createCommandExecutor: CommandExecutorFactory,
         private workspaceRoot: string | null = null,
-        private configNamespace: string
+        private distributionId: string
     ) {
         this.formattingService = new FormattingService();
-        this.diagnosticService = new DiagnosticService(configNamespace);
+        this.diagnosticService = new DiagnosticService(distributionId);
         this.semanticTokensService = new SemanticTokensService();
         this.codeLensService = new CodeLensService();
         this.documentHighlightService = new DocumentHighlightService();
@@ -198,7 +198,7 @@ export class KsonTextDocumentService {
             return this.codeLensService.getCodeLenses(document).map(lens => ({
                 ...lens,
                 command: lens.command
-                    ? {...lens.command, command: toWireCommandId(lens.command.command, this.configNamespace)}
+                    ? {...lens.command, command: toWireCommandId(lens.command.command, this.distributionId)}
                     : lens.command,
             }));
         } catch (error) {
@@ -209,7 +209,7 @@ export class KsonTextDocumentService {
 
     private async onExecuteCommand(params: ExecuteCommandParams): Promise<any> {
         try {
-            const commandType = fromWireCommandId(params.command, this.configNamespace);
+            const commandType = fromWireCommandId(params.command, this.distributionId);
             return await this.commandExecutor.execute(
                 commandType ? {...params, command: commandType} : params
             );

--- a/tooling/language-server-protocol/src/index.ts
+++ b/tooling/language-server-protocol/src/index.ts
@@ -1,3 +1,4 @@
 // Common exports for kson-language-server package
 export type { BundledSchemaConfig, BundledMetaSchemaConfig } from './core/schema/BundledSchemaProvider.js';
 export type { KsonInitializationOptions } from './startKsonServer.js';
+export { CommandType, DEFAULT_CONFIG_NAMESPACE, toWireCommandId } from './core/commands/CommandType.js';

--- a/tooling/language-server-protocol/src/index.ts
+++ b/tooling/language-server-protocol/src/index.ts
@@ -1,4 +1,4 @@
 // Common exports for kson-language-server package
 export type { BundledSchemaConfig, BundledMetaSchemaConfig } from './core/schema/BundledSchemaProvider.js';
 export type { KsonInitializationOptions } from './startKsonServer.js';
-export { CommandType, DEFAULT_CONFIG_NAMESPACE, toWireCommandId } from './core/commands/CommandType.js';
+export { CommandType, toWireCommandId } from './core/commands/CommandType.js';

--- a/tooling/language-server-protocol/src/startKsonServer.ts
+++ b/tooling/language-server-protocol/src/startKsonServer.ts
@@ -11,7 +11,7 @@ import {KsonDocumentsManager} from './core/document/KsonDocumentsManager.js';
 import {isKsonSchemaDocument} from './core/document/KsonSchemaDocument.js';
 import {KsonTextDocumentService} from './core/services/KsonTextDocumentService.js';
 import {KSON_LEGEND} from './core/features/SemanticTokensService.js';
-import {getAllCommandIds} from './core/commands/CommandType.js';
+import {DEFAULT_CONFIG_NAMESPACE, getAllCommandIds, toWireCommandId} from './core/commands/CommandType.js';
 import { ksonSettingsWithDefaults } from './core/KsonSettings.js';
 import {SchemaProvider} from './core/schema/SchemaProvider.js';
 import {BundledSchemaProvider, BundledSchemaConfig, BundledMetaSchemaConfig} from './core/schema/BundledSchemaProvider.js';
@@ -29,6 +29,13 @@ export interface KsonInitializationOptions {
     bundledMetaSchemas?: BundledMetaSchemaConfig[];
     /** Whether bundled schemas are enabled */
     enableBundledSchemas?: boolean;
+    /**
+     * Prefix for the client's configuration keys (defaults to "kson"). The
+     * server uses this when pulling settings from the client, so a client
+     * built under a different namespace reads `<ns>.format.*` /
+     * `<ns>.codeLens.*` instead of the base `kson.*`.
+     */
+    configNamespace?: string;
 }
 
 type SchemaProviderFactory = (
@@ -51,6 +58,7 @@ export function startKsonServer(
     // Variables to store state during initialization
     let workspaceRootUri: URI | undefined;
     let hasConfigurationCapability = false;
+    let configNamespace = DEFAULT_CONFIG_NAMESPACE;
 
     // Create logger that uses the connection
     const logger = {
@@ -80,6 +88,7 @@ export function startKsonServer(
         const bundledSchemas = initOptions?.bundledSchemas ?? [];
         const bundledMetaSchemas = initOptions?.bundledMetaSchemas ?? [];
         const enableBundledSchemas = initOptions?.enableBundledSchemas ?? true;
+        configNamespace = initOptions?.configNamespace ?? DEFAULT_CONFIG_NAMESPACE;
 
         // Create the appropriate schema provider for this environment (file system or no-op)
         const fileSystemSchemaProvider = await createSchemaProvider(workspaceRootUri, logger);
@@ -116,7 +125,8 @@ export function startKsonServer(
         textDocumentService = new KsonTextDocumentService(
             documentManager,
             createCommandExecutor,
-            workspaceRoot
+            workspaceRoot,
+            configNamespace
         );
 
         // Setup document handling and connect services
@@ -138,7 +148,7 @@ export function startKsonServer(
 
             // Diagnostics (pull model preferred)
             diagnosticProvider: {
-                identifier: 'kson',
+                identifier: configNamespace,
                 interFileDependencies: false,
                 workspaceDiagnostics: false
             } as DiagnosticRegistrationOptions,
@@ -148,9 +158,11 @@ export function startKsonServer(
                 resolveProvider: false
             },
 
-            // Execute command
+            // Execute command — advertise ids under the active namespace so a
+            // client built under a non-default namespace doesn't collide with
+            // the base `kson.*` registrations in VSCode's global command registry.
             executeCommandProvider: {
-                commands: getAllCommandIds()
+                commands: getAllCommandIds().map(id => toWireCommandId(id, configNamespace))
             },
 
             // Folding ranges
@@ -189,8 +201,8 @@ export function startKsonServer(
 
     // Pull configuration from the client
     async function pullConfiguration(): Promise<void> {
-        const settings = await connection.workspace.getConfiguration('kson');
-        const configuration = ksonSettingsWithDefaults({ kson: settings });
+        const settings = await connection.workspace.getConfiguration(configNamespace);
+        const configuration = ksonSettingsWithDefaults(settings);
         textDocumentService.updateConfiguration(configuration);
     }
 
@@ -199,7 +211,7 @@ export function startKsonServer(
         if (hasConfigurationCapability) {
             // Register for configuration change notifications
             connection.client.register(DidChangeConfigurationNotification.type, {
-                section: 'kson'
+                section: configNamespace
             });
             // Pull initial configuration
             await pullConfiguration();
@@ -271,21 +283,20 @@ export function startKsonServer(
         }
     });
 
-    // Handle configuration changes
+    // Handle configuration changes. Per LSP, the push model sends the full
+    // settings object, so our slice arrives at `change.settings.<ns>`.
     connection.onDidChangeConfiguration(async (change) => {
+        const scoped = change.settings?.[configNamespace];
+
         if (hasConfigurationCapability) {
             // Pull configuration from the client (pull model)
             await pullConfiguration();
         } else {
-            // Fallback to reading pushed settings
-            const configuration = ksonSettingsWithDefaults(change.settings);
-            textDocumentService.updateConfiguration(configuration);
+            textDocumentService.updateConfiguration(ksonSettingsWithDefaults(scoped));
         }
 
-        // Check if bundled schema setting changed
-        if (bundledSchemaProvider && change.settings?.kson?.enableBundledSchemas !== undefined) {
-            const enabled = change.settings.kson.enableBundledSchemas;
-            bundledSchemaProvider.setEnabled(enabled);
+        if (bundledSchemaProvider && scoped?.enableBundledSchemas !== undefined) {
+            bundledSchemaProvider.setEnabled(scoped.enableBundledSchemas);
             notifySchemaChange();
         }
 

--- a/tooling/language-server-protocol/src/startKsonServer.ts
+++ b/tooling/language-server-protocol/src/startKsonServer.ts
@@ -58,7 +58,7 @@ export function startKsonServer(
     // Variables to store state during initialization
     let workspaceRootUri: URI | undefined;
     let hasConfigurationCapability = false;
-    let configNamespace = DEFAULT_CONFIG_NAMESPACE;
+    let configNamespace: string;
 
     // Create logger that uses the connection
     const logger = {

--- a/tooling/language-server-protocol/src/startKsonServer.ts
+++ b/tooling/language-server-protocol/src/startKsonServer.ts
@@ -11,7 +11,7 @@ import {KsonDocumentsManager} from './core/document/KsonDocumentsManager.js';
 import {isKsonSchemaDocument} from './core/document/KsonSchemaDocument.js';
 import {KsonTextDocumentService} from './core/services/KsonTextDocumentService.js';
 import {KSON_LEGEND} from './core/features/SemanticTokensService.js';
-import {DEFAULT_CONFIG_NAMESPACE, getAllCommandIds, toWireCommandId} from './core/commands/CommandType.js';
+import {getAllCommandIds, toWireCommandId} from './core/commands/CommandType.js';
 import { ksonSettingsWithDefaults } from './core/KsonSettings.js';
 import {SchemaProvider} from './core/schema/SchemaProvider.js';
 import {BundledSchemaProvider, BundledSchemaConfig, BundledMetaSchemaConfig} from './core/schema/BundledSchemaProvider.js';
@@ -30,12 +30,11 @@ export interface KsonInitializationOptions {
     /** Whether bundled schemas are enabled */
     enableBundledSchemas?: boolean;
     /**
-     * Prefix for the client's configuration keys (defaults to "kson"). The
-     * server uses this when pulling settings from the client, so a client
-     * built under a different namespace reads `<ns>.format.*` /
-     * `<ns>.codeLens.*` instead of the base `kson.*`.
+     * Identifier under which this server instance's host-visible artifacts are
+     * registered: command-id prefix on the wire, diagnostic source, and the
+     * configuration section pulled from the client. Defaults to "kson".
      */
-    configNamespace?: string;
+    distributionId?: string;
 }
 
 type SchemaProviderFactory = (
@@ -55,10 +54,17 @@ export function startKsonServer(
     createSchemaProvider: SchemaProviderFactory,
     createCommandExecutor: CommandExecutorFactory
 ): void {
+    /**
+     * Default distribution id, used when the client hasn't supplied one via
+     * initializationOptions.
+     */
+    const DEFAULT_DISTRIBUTION_ID = "kson";
+
+
     // Variables to store state during initialization
     let workspaceRootUri: URI | undefined;
     let hasConfigurationCapability = false;
-    let configNamespace: string;
+    let distributionId: string;
 
     // Create logger that uses the connection
     const logger = {
@@ -88,7 +94,7 @@ export function startKsonServer(
         const bundledSchemas = initOptions?.bundledSchemas ?? [];
         const bundledMetaSchemas = initOptions?.bundledMetaSchemas ?? [];
         const enableBundledSchemas = initOptions?.enableBundledSchemas ?? true;
-        configNamespace = initOptions?.configNamespace ?? DEFAULT_CONFIG_NAMESPACE;
+        distributionId = initOptions?.distributionId ?? DEFAULT_DISTRIBUTION_ID;
 
         // Create the appropriate schema provider for this environment (file system or no-op)
         const fileSystemSchemaProvider = await createSchemaProvider(workspaceRootUri, logger);
@@ -126,7 +132,7 @@ export function startKsonServer(
             documentManager,
             createCommandExecutor,
             workspaceRoot,
-            configNamespace
+            distributionId
         );
 
         // Setup document handling and connect services
@@ -148,7 +154,7 @@ export function startKsonServer(
 
             // Diagnostics (pull model preferred)
             diagnosticProvider: {
-                identifier: configNamespace,
+                identifier: distributionId,
                 interFileDependencies: false,
                 workspaceDiagnostics: false
             } as DiagnosticRegistrationOptions,
@@ -158,11 +164,10 @@ export function startKsonServer(
                 resolveProvider: false
             },
 
-            // Execute command — advertise ids under the active namespace so a
-            // client built under a non-default namespace doesn't collide with
-            // the base `kson.*` registrations in VSCode's global command registry.
+            // Execute command — advertise ids prefixed by the active
+            // distribution id
             executeCommandProvider: {
-                commands: getAllCommandIds().map(id => toWireCommandId(id, configNamespace))
+                commands: getAllCommandIds().map(id => toWireCommandId(id, distributionId))
             },
 
             // Folding ranges
@@ -201,7 +206,7 @@ export function startKsonServer(
 
     // Pull configuration from the client
     async function pullConfiguration(): Promise<void> {
-        const settings = await connection.workspace.getConfiguration(configNamespace);
+        const settings = await connection.workspace.getConfiguration(distributionId);
         const configuration = ksonSettingsWithDefaults(settings);
         textDocumentService.updateConfiguration(configuration);
     }
@@ -211,7 +216,7 @@ export function startKsonServer(
         if (hasConfigurationCapability) {
             // Register for configuration change notifications
             connection.client.register(DidChangeConfigurationNotification.type, {
-                section: configNamespace
+                section: distributionId
             });
             // Pull initial configuration
             await pullConfiguration();
@@ -284,9 +289,9 @@ export function startKsonServer(
     });
 
     // Handle configuration changes. Per LSP, the push model sends the full
-    // settings object, so our slice arrives at `change.settings.<ns>`.
+    // settings object, so our slice arrives at `change.settings.<distributionId>`.
     connection.onDidChangeConfiguration(async (change) => {
-        const scoped = change.settings?.[configNamespace];
+        const scoped = change.settings?.[distributionId];
 
         if (hasConfigurationCapability) {
             // Pull configuration from the client (pull model)

--- a/tooling/language-server-protocol/src/test/core/commands/CommandExecutor.test.ts
+++ b/tooling/language-server-protocol/src/test/core/commands/CommandExecutor.test.ts
@@ -11,7 +11,7 @@ import {
     TextEdit,
     ApplyWorkspaceEditResult, Range
 } from "vscode-languageserver";
-import {CommandType} from "../../../core/commands/CommandType";
+import {CommandType, toWireCommandId} from "../../../core/commands/CommandType";
 import {FormattingStyle} from "kson";
 import {RemoteWorkspace} from "vscode-languageserver/lib/common/server";
 import {createCommandExecutor} from "../../../core/commands/createCommandExecutor.node.js";
@@ -35,10 +35,12 @@ class WorkspaceConnectionStub extends ConnectionStub {
     }
 }
 
+const TEST_NAMESPACE = 'test-ns';
+
 function createTestSetup() {
     const connection = new ConnectionStub();
     const documentsManager = new KsonDocumentsManager();
-    const service = new KsonTextDocumentService(documentsManager, createCommandExecutor);
+    const service = new KsonTextDocumentService(documentsManager, createCommandExecutor, null, TEST_NAMESPACE);
     
     documentsManager.listen(connection);
     service.connect(connection);
@@ -76,7 +78,7 @@ function buildWorkspaceEdit(uri: string, replaceRange: Range, newText: string): 
 
 function buildCommandParams(command: CommandType, uri: string, style: FormattingStyle): ExecuteCommandParams {
     return {
-        command,
+        command: toWireCommandId(command, TEST_NAMESPACE),
         arguments: [{ documentUri: uri, formattingStyle: style }]
     };
 }

--- a/tooling/language-server-protocol/src/test/core/commands/CommandExecutor.test.ts
+++ b/tooling/language-server-protocol/src/test/core/commands/CommandExecutor.test.ts
@@ -35,12 +35,12 @@ class WorkspaceConnectionStub extends ConnectionStub {
     }
 }
 
-const TEST_NAMESPACE = 'test-ns';
+const TEST_DISTRIBUTION_ID = 'test-ns';
 
 function createTestSetup() {
     const connection = new ConnectionStub();
     const documentsManager = new KsonDocumentsManager();
-    const service = new KsonTextDocumentService(documentsManager, createCommandExecutor, null, TEST_NAMESPACE);
+    const service = new KsonTextDocumentService(documentsManager, createCommandExecutor, null, TEST_DISTRIBUTION_ID);
     
     documentsManager.listen(connection);
     service.connect(connection);
@@ -78,7 +78,7 @@ function buildWorkspaceEdit(uri: string, replaceRange: Range, newText: string): 
 
 function buildCommandParams(command: CommandType, uri: string, style: FormattingStyle): ExecuteCommandParams {
     return {
-        command: toWireCommandId(command, TEST_NAMESPACE),
+        command: toWireCommandId(command, TEST_DISTRIBUTION_ID),
         arguments: [{ documentUri: uri, formattingStyle: style }]
     };
 }

--- a/tooling/language-server-protocol/src/test/core/commands/CommandType.test.ts
+++ b/tooling/language-server-protocol/src/test/core/commands/CommandType.test.ts
@@ -1,0 +1,34 @@
+import {describe, it} from 'mocha';
+import assert from 'assert';
+import {
+    CommandType,
+    DEFAULT_CONFIG_NAMESPACE,
+    fromWireCommandId,
+    getAllCommandIds,
+    toWireCommandId,
+} from '../../../core/commands/CommandType.js';
+
+describe('CommandType wire-namespace translation', () => {
+    it('toWireCommandId / fromWireCommandId round-trip every CommandType under any namespace', () => {
+        for (const ns of [DEFAULT_CONFIG_NAMESPACE, 'config', 'a.b']) {
+            for (const id of getAllCommandIds()) {
+                const wire = toWireCommandId(id, ns);
+                assert.strictEqual(wire, `${ns}.${id}`);
+                assert.strictEqual(fromWireCommandId(wire, ns), id);
+            }
+        }
+    });
+
+    it('fromWireCommandId returns undefined for unknown ids or wrong namespace', () => {
+        assert.strictEqual(fromWireCommandId('config.bogus', 'config'), undefined);
+        assert.strictEqual(fromWireCommandId('other.plainFormat', 'config'), undefined);
+        assert.strictEqual(fromWireCommandId('plainFormat', 'config'), undefined);
+    });
+
+    it('CommandType values are unqualified (no dot)', () => {
+        for (const id of getAllCommandIds()) {
+            assert.ok(!id.includes('.'), `CommandType value '${id}' must not contain a dot`);
+        }
+        assert.strictEqual(CommandType.PLAIN_FORMAT, 'plainFormat');
+    });
+});

--- a/tooling/language-server-protocol/src/test/core/commands/CommandType.test.ts
+++ b/tooling/language-server-protocol/src/test/core/commands/CommandType.test.ts
@@ -2,24 +2,23 @@ import {describe, it} from 'mocha';
 import assert from 'assert';
 import {
     CommandType,
-    DEFAULT_CONFIG_NAMESPACE,
     fromWireCommandId,
     getAllCommandIds,
     toWireCommandId,
 } from '../../../core/commands/CommandType.js';
 
-describe('CommandType wire-namespace translation', () => {
-    it('toWireCommandId / fromWireCommandId round-trip every CommandType under any namespace', () => {
-        for (const ns of [DEFAULT_CONFIG_NAMESPACE, 'config', 'a.b']) {
-            for (const id of getAllCommandIds()) {
-                const wire = toWireCommandId(id, ns);
-                assert.strictEqual(wire, `${ns}.${id}`);
-                assert.strictEqual(fromWireCommandId(wire, ns), id);
+describe('CommandType wire-prefix translation', () => {
+    it('toWireCommandId / fromWireCommandId round-trip every CommandType under any distribution id', () => {
+        for (const id of ['kson', 'config', 'a.b']) {
+            for (const cmd of getAllCommandIds()) {
+                const wire = toWireCommandId(cmd, id);
+                assert.strictEqual(wire, `${id}.${cmd}`);
+                assert.strictEqual(fromWireCommandId(wire, id), cmd);
             }
         }
     });
 
-    it('fromWireCommandId returns undefined for unknown ids or wrong namespace', () => {
+    it('fromWireCommandId returns undefined for unknown ids or wrong distribution id', () => {
         assert.strictEqual(fromWireCommandId('config.bogus', 'config'), undefined);
         assert.strictEqual(fromWireCommandId('other.plainFormat', 'config'), undefined);
         assert.strictEqual(fromWireCommandId('plainFormat', 'config'), undefined);

--- a/tooling/language-server-protocol/src/test/core/features/DiagnosticService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/DiagnosticService.test.ts
@@ -10,7 +10,8 @@ import {createKsonDocument} from '../../TestHelpers.js';
 
 
 describe('KSON Diagnostics', () => {
-    const diagnosticService = new DiagnosticService();
+    const TEST_NAMESPACE = 'test-ns';
+    const diagnosticService = new DiagnosticService(TEST_NAMESPACE);
 
     function getDiagnostics(content: string, schemaContent?: string): Diagnostic[] {
         const ksonDocument = createKsonDocument(content, schemaContent);
@@ -29,7 +30,7 @@ describe('KSON Diagnostics', () => {
         it('should report error for empty document', () => {
             const diagnostics = assertDiagnosticCount('', 1);
             assert.strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
-            assert.strictEqual(diagnostics[0].source, 'kson');
+            assert.strictEqual(diagnostics[0].source, TEST_NAMESPACE);
         });
 
         it('should report no diagnostics for valid document', () => {
@@ -66,10 +67,10 @@ describe('KSON Diagnostics', () => {
             assert.strictEqual(diagnostics[1].severity, DiagnosticSeverity.Warning);
         });
 
-        it('should set source to kson on all diagnostics', () => {
+        it('should set source to the configured namespace on all diagnostics', () => {
             const diagnostics = getDiagnostics('');
             for (const d of diagnostics) {
-                assert.strictEqual(d.source, 'kson');
+                assert.strictEqual(d.source, TEST_NAMESPACE);
             }
         });
 
@@ -135,7 +136,7 @@ describe('KSON Diagnostics', () => {
             // Should still return at least the document parse errors, not crash
             assert.ok(diagnostics.length > 0, 'Should return document parse errors even when schema is invalid');
             for (const d of diagnostics) {
-                assert.strictEqual(d.source, 'kson');
+                assert.strictEqual(d.source, TEST_NAMESPACE);
             }
         });
 
@@ -153,7 +154,7 @@ describe('KSON Diagnostics', () => {
         assert.ok(diagnostics.length > 0);
         // All diagnostics should come from parse errors only
         for (const d of diagnostics) {
-            assert.strictEqual(d.source, 'kson');
+            assert.strictEqual(d.source, TEST_NAMESPACE);
         }
     });
 

--- a/tooling/language-server-protocol/src/test/core/features/DiagnosticService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/DiagnosticService.test.ts
@@ -10,8 +10,8 @@ import {createKsonDocument} from '../../TestHelpers.js';
 
 
 describe('KSON Diagnostics', () => {
-    const TEST_NAMESPACE = 'test-ns';
-    const diagnosticService = new DiagnosticService(TEST_NAMESPACE);
+    const TEST_DISTRIBUTION_ID = 'test-ns';
+    const diagnosticService = new DiagnosticService(TEST_DISTRIBUTION_ID);
 
     function getDiagnostics(content: string, schemaContent?: string): Diagnostic[] {
         const ksonDocument = createKsonDocument(content, schemaContent);
@@ -30,7 +30,7 @@ describe('KSON Diagnostics', () => {
         it('should report error for empty document', () => {
             const diagnostics = assertDiagnosticCount('', 1);
             assert.strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
-            assert.strictEqual(diagnostics[0].source, TEST_NAMESPACE);
+            assert.strictEqual(diagnostics[0].source, TEST_DISTRIBUTION_ID);
         });
 
         it('should report no diagnostics for valid document', () => {
@@ -67,10 +67,10 @@ describe('KSON Diagnostics', () => {
             assert.strictEqual(diagnostics[1].severity, DiagnosticSeverity.Warning);
         });
 
-        it('should set source to the configured namespace on all diagnostics', () => {
+        it('should set source to the configured distribution id on all diagnostics', () => {
             const diagnostics = getDiagnostics('');
             for (const d of diagnostics) {
-                assert.strictEqual(d.source, TEST_NAMESPACE);
+                assert.strictEqual(d.source, TEST_DISTRIBUTION_ID);
             }
         });
 
@@ -136,7 +136,7 @@ describe('KSON Diagnostics', () => {
             // Should still return at least the document parse errors, not crash
             assert.ok(diagnostics.length > 0, 'Should return document parse errors even when schema is invalid');
             for (const d of diagnostics) {
-                assert.strictEqual(d.source, TEST_NAMESPACE);
+                assert.strictEqual(d.source, TEST_DISTRIBUTION_ID);
             }
         });
 
@@ -154,7 +154,7 @@ describe('KSON Diagnostics', () => {
         assert.ok(diagnostics.length > 0);
         // All diagnostics should come from parse errors only
         for (const d of diagnostics) {
-            assert.strictEqual(d.source, TEST_NAMESPACE);
+            assert.strictEqual(d.source, TEST_DISTRIBUTION_ID);
         }
     });
 

--- a/tooling/language-server-protocol/src/test/core/features/FormattingService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/FormattingService.test.ts
@@ -22,19 +22,14 @@ describe('KSON Formatter', () => {
             KsonTooling.getInstance().parse(unformatted),
         );
 
-        const ksonSettings = ksonSettingsWithDefaults(
-            {
-                kson:
-                    {
-                        format: {
-                            insertSpaces: insertSpaces,
-                            tabSize: 2
-                        }
-                    }
+        const ksonSettings = ksonSettingsWithDefaults({
+            format: {
+                insertSpaces: insertSpaces,
+                tabSize: 2
             }
-        )
+        })
 
-        const edits = formattingService.formatDocument(ksonDocument, ksonSettings.kson.formatOptions);
+        const edits = formattingService.formatDocument(ksonDocument, ksonSettings.formatOptions);
         const formatted = applyEdits(document, edits);
 
         assert.strictEqual(formatted, expected, 'should have a matching formatted document');

--- a/tooling/language-server-protocol/src/test/core/services/KsonTextDocumentService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/services/KsonTextDocumentService.test.ts
@@ -127,7 +127,7 @@ describe('KsonTextDocumentService', () => {
         it('should return empty array when codeLens is disabled', async () => {
             openDocument('key: value');
 
-            const config = ksonSettingsWithDefaults({kson: {codeLens: {enable: false}}});
+            const config = ksonSettingsWithDefaults({codeLens: {enable: false}});
             service.updateConfiguration(config);
 
             const result = await connection.requestCodeLens(TEST_URI);

--- a/tooling/language-server-protocol/src/test/core/services/KsonTextDocumentService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/services/KsonTextDocumentService.test.ts
@@ -15,6 +15,7 @@ import {ksonSettingsWithDefaults} from "../../../core/KsonSettings.js";
 import {pos} from "../../TestHelpers";
 
 describe('KsonTextDocumentService', () => {
+    const TEST_NAMESPACE = 'test-ns';
     let connection: ConnectionStub;
     let service: KsonTextDocumentService;
     let documentsManager: KsonDocumentsManager;
@@ -23,7 +24,7 @@ describe('KsonTextDocumentService', () => {
     beforeEach(() => {
         connection = new ConnectionStub();
         documentsManager = new KsonDocumentsManager();
-        service = new KsonTextDocumentService(documentsManager, createCommandExecutor);
+        service = new KsonTextDocumentService(documentsManager, createCommandExecutor, null, TEST_NAMESPACE);
 
         documentsManager.listen(connection);
         service.connect(connection)
@@ -95,7 +96,7 @@ describe('KsonTextDocumentService', () => {
 
             assert.strictEqual(result.items.length, 1, "Should have exactly 1 diagnostic for trailing token");
             assert.strictEqual(result.items[0].severity, DiagnosticSeverity.Error);
-            assert.strictEqual(result.items[0].source, 'kson');
+            assert.strictEqual(result.items[0].source, TEST_NAMESPACE);
         });
 
         it('should return empty items when document is not found', async () => {

--- a/tooling/language-server-protocol/src/test/core/services/KsonTextDocumentService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/services/KsonTextDocumentService.test.ts
@@ -15,7 +15,7 @@ import {ksonSettingsWithDefaults} from "../../../core/KsonSettings.js";
 import {pos} from "../../TestHelpers";
 
 describe('KsonTextDocumentService', () => {
-    const TEST_NAMESPACE = 'test-ns';
+    const TEST_DISTRIBUTION_ID = 'test-ns';
     let connection: ConnectionStub;
     let service: KsonTextDocumentService;
     let documentsManager: KsonDocumentsManager;
@@ -24,7 +24,7 @@ describe('KsonTextDocumentService', () => {
     beforeEach(() => {
         connection = new ConnectionStub();
         documentsManager = new KsonDocumentsManager();
-        service = new KsonTextDocumentService(documentsManager, createCommandExecutor, null, TEST_NAMESPACE);
+        service = new KsonTextDocumentService(documentsManager, createCommandExecutor, null, TEST_DISTRIBUTION_ID);
 
         documentsManager.listen(connection);
         service.connect(connection)
@@ -96,7 +96,7 @@ describe('KsonTextDocumentService', () => {
 
             assert.strictEqual(result.items.length, 1, "Should have exactly 1 diagnostic for trailing token");
             assert.strictEqual(result.items[0].severity, DiagnosticSeverity.Error);
-            assert.strictEqual(result.items[0].source, TEST_NAMESPACE);
+            assert.strictEqual(result.items[0].source, TEST_DISTRIBUTION_ID);
         });
 
         it('should return empty items when document is not found', async () => {

--- a/tooling/lsp-clients/vscode/package.json
+++ b/tooling/lsp-clients/vscode/package.json
@@ -2,6 +2,7 @@
   "name": "kson",
   "displayName": "KSON",
   "description": "Provides language support for the Kson data format.",
+  "ksonConfigNamespace": "kson",
   "authors": [
     {
       "name": "KSON",

--- a/tooling/lsp-clients/vscode/package.json
+++ b/tooling/lsp-clients/vscode/package.json
@@ -2,7 +2,6 @@
   "name": "kson",
   "displayName": "KSON",
   "description": "Provides language support for the Kson data format.",
-  "ksonConfigNamespace": "kson",
   "authors": [
     {
       "name": "KSON",

--- a/tooling/lsp-clients/vscode/src/client/browser/ksonClientMain.ts
+++ b/tooling/lsp-clients/vscode/src/client/browser/ksonClientMain.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/browser';
 import { createClientOptions } from '../../config/clientOptions';
-import { initializeLanguageConfig } from '../../config/languageConfig';
+import { initializeLanguageConfig, getConfigNamespace } from '../../config/languageConfig';
 import { loadBundledSchemas, loadBundledMetaSchemas, areBundledSchemasEnabled } from '../../config/bundledSchemaLoader';
 import { registerBundledSchemaContentProvider } from '../common/BundledSchemaContentProvider';
 
@@ -12,6 +12,7 @@ import { registerBundledSchemaContentProvider } from '../common/BundledSchemaCon
 export async function activate(context: vscode.ExtensionContext) {
     // Initialize language configuration from package.json
     initializeLanguageConfig(context.extension.packageJSON);
+    const configNamespace = getConfigNamespace();
 
     // Create log output channel
     const logOutputChannel = vscode.window.createOutputChannel('Kson Language Server', { log: true });
@@ -35,7 +36,8 @@ export async function activate(context: vscode.ExtensionContext) {
         const clientOptions = createClientOptions(logOutputChannel, {
             bundledSchemas,
             bundledMetaSchemas,
-            enableBundledSchemas: areBundledSchemasEnabled()
+            enableBundledSchemas: areBundledSchemasEnabled(),
+            configNamespace
         });
 
         // In test environments, we need to support the vscode-test-web scheme
@@ -53,7 +55,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
 
         const languageClient = new LanguageClient(
-            'kson-browser',
+            `${configNamespace}-browser`,
             'KSON Language Server (Browser)',
             clientOptions,
             worker

--- a/tooling/lsp-clients/vscode/src/client/browser/ksonClientMain.ts
+++ b/tooling/lsp-clients/vscode/src/client/browser/ksonClientMain.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/browser';
 import { createClientOptions } from '../../config/clientOptions';
-import { initializeLanguageConfig, getConfigNamespace } from '../../config/languageConfig';
+import { initializeLanguageConfig } from '../../config/languageConfig';
 import { loadBundledSchemas, loadBundledMetaSchemas, areBundledSchemasEnabled } from '../../config/bundledSchemaLoader';
 import { registerBundledSchemaContentProvider } from '../common/BundledSchemaContentProvider';
 
@@ -12,7 +12,7 @@ import { registerBundledSchemaContentProvider } from '../common/BundledSchemaCon
 export async function activate(context: vscode.ExtensionContext) {
     // Initialize language configuration from package.json
     initializeLanguageConfig(context.extension.packageJSON);
-    const configNamespace = getConfigNamespace();
+    const name = context.extension.packageJSON.name;
 
     // Create log output channel
     const logOutputChannel = vscode.window.createOutputChannel('Kson Language Server', { log: true });
@@ -36,8 +36,8 @@ export async function activate(context: vscode.ExtensionContext) {
         const clientOptions = createClientOptions(logOutputChannel, {
             bundledSchemas,
             bundledMetaSchemas,
-            enableBundledSchemas: areBundledSchemasEnabled(),
-            configNamespace
+            enableBundledSchemas: areBundledSchemasEnabled(name),
+            distributionId: name
         });
 
         // In test environments, we need to support the vscode-test-web scheme
@@ -55,8 +55,8 @@ export async function activate(context: vscode.ExtensionContext) {
         }
 
         const languageClient = new LanguageClient(
-            `${configNamespace}-browser`,
-            'KSON Language Server (Browser)',
+            `${name}-browser`,
+            `${name} Language Server (Browser)`,
             clientOptions,
             worker
         );

--- a/tooling/lsp-clients/vscode/src/client/common/StatusBarManager.ts
+++ b/tooling/lsp-clients/vscode/src/client/common/StatusBarManager.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import {BaseLanguageClient} from 'vscode-languageclient';
 import * as path from 'path';
-import { isKsonLanguage } from '../../config/languageConfig';
+import { isKsonLanguage, getConfigNamespace } from '../../config/languageConfig';
 
 /**
  * Response from the LSP server for schema information
@@ -26,7 +26,7 @@ export class StatusBarManager {
             vscode.StatusBarAlignment.Right,
             100
         );
-        this.statusBarItem.command = 'kson.selectSchema';
+        this.statusBarItem.command = `${getConfigNamespace()}.selectSchema`;
     }
 
     /**

--- a/tooling/lsp-clients/vscode/src/client/common/StatusBarManager.ts
+++ b/tooling/lsp-clients/vscode/src/client/common/StatusBarManager.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import {BaseLanguageClient} from 'vscode-languageclient';
 import * as path from 'path';
-import { isKsonLanguage, getConfigNamespace } from '../../config/languageConfig';
+import { isKsonLanguage } from '../../config/languageConfig';
 
 /**
  * Response from the LSP server for schema information
@@ -26,7 +26,7 @@ export class StatusBarManager {
             vscode.StatusBarAlignment.Right,
             100
         );
-        this.statusBarItem.command = `${getConfigNamespace()}.selectSchema`;
+        this.statusBarItem.command = `${client.name}.selectSchema`;
     }
 
     /**

--- a/tooling/lsp-clients/vscode/src/client/node/ksonClientMain.ts
+++ b/tooling/lsp-clients/vscode/src/client/node/ksonClientMain.ts
@@ -10,9 +10,10 @@ import {
     createClientOptions
 } from '../../config/clientOptions';
 import {StatusBarManager} from '../common/StatusBarManager';
-import { isKsonLanguage, initializeLanguageConfig } from '../../config/languageConfig';
+import { isKsonLanguage, initializeLanguageConfig, getConfigNamespace } from '../../config/languageConfig';
 import { loadBundledSchemas, loadBundledMetaSchemas, areBundledSchemasEnabled } from '../../config/bundledSchemaLoader';
 import { registerBundledSchemaContentProvider } from '../common/BundledSchemaContentProvider';
+import { CommandType, toWireCommandId } from 'kson-language-server';
 
 /**
  * Node.js-specific activation function for the KSON extension.
@@ -21,6 +22,7 @@ import { registerBundledSchemaContentProvider } from '../common/BundledSchemaCon
 export async function activate(context: vscode.ExtensionContext) {
     // Initialize language configuration from package.json
     initializeLanguageConfig(context.extension.packageJSON);
+    const configNamespace = getConfigNamespace();
 
     // Create log output channel
     const logOutputChannel = vscode.window.createOutputChannel('Kson Language Server', {log: true});
@@ -53,9 +55,10 @@ export async function activate(context: vscode.ExtensionContext) {
         const clientOptions: LanguageClientOptions = createClientOptions(logOutputChannel, {
             bundledSchemas,
             bundledMetaSchemas,
-            enableBundledSchemas: areBundledSchemasEnabled()
+            enableBundledSchemas: areBundledSchemasEnabled(),
+            configNamespace
         });
-        const languageClient = new LanguageClient("kson", serverOptions, clientOptions, false)
+        const languageClient = new LanguageClient(configNamespace, serverOptions, clientOptions, false)
 
         await languageClient.start();
 
@@ -85,7 +88,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         // Register the schema selection command
         context.subscriptions.push(
-            vscode.commands.registerCommand('kson.selectSchema', async () => {
+            vscode.commands.registerCommand(`${configNamespace}.selectSchema`, async () => {
                 const editor = vscode.window.activeTextEditor;
                 if (!editor || !isKsonLanguage(editor.document.languageId)) {
                     vscode.window.showWarningMessage('Please open a KSON file first.');
@@ -133,7 +136,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     // Execute the remove schema command via LSP
                     try {
                         await languageClient.sendRequest('workspace/executeCommand', {
-                            command: 'kson.removeSchema',
+                            command: toWireCommandId(CommandType.REMOVE_SCHEMA, configNamespace),
                             arguments: [{
                                 documentUri: editor.document.uri.toString()
                             }]
@@ -151,7 +154,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     try {
                         // Execute the associate schema command via LSP
                         await languageClient.sendRequest('workspace/executeCommand', {
-                            command: 'kson.associateSchema',
+                            command: toWireCommandId(CommandType.ASSOCIATE_SCHEMA, configNamespace),
                             arguments: [{
                                 documentUri: editor.document.uri.toString(),
                                 schemaPath: schemaPath

--- a/tooling/lsp-clients/vscode/src/client/node/ksonClientMain.ts
+++ b/tooling/lsp-clients/vscode/src/client/node/ksonClientMain.ts
@@ -10,7 +10,7 @@ import {
     createClientOptions
 } from '../../config/clientOptions';
 import {StatusBarManager} from '../common/StatusBarManager';
-import { isKsonLanguage, initializeLanguageConfig, getConfigNamespace } from '../../config/languageConfig';
+import { isKsonLanguage, initializeLanguageConfig } from '../../config/languageConfig';
 import { loadBundledSchemas, loadBundledMetaSchemas, areBundledSchemasEnabled } from '../../config/bundledSchemaLoader';
 import { registerBundledSchemaContentProvider } from '../common/BundledSchemaContentProvider';
 import { CommandType, toWireCommandId } from 'kson-language-server';
@@ -22,7 +22,7 @@ import { CommandType, toWireCommandId } from 'kson-language-server';
 export async function activate(context: vscode.ExtensionContext) {
     // Initialize language configuration from package.json
     initializeLanguageConfig(context.extension.packageJSON);
-    const configNamespace = getConfigNamespace();
+    const name = context.extension.packageJSON.name;
 
     // Create log output channel
     const logOutputChannel = vscode.window.createOutputChannel('Kson Language Server', {log: true});
@@ -55,10 +55,10 @@ export async function activate(context: vscode.ExtensionContext) {
         const clientOptions: LanguageClientOptions = createClientOptions(logOutputChannel, {
             bundledSchemas,
             bundledMetaSchemas,
-            enableBundledSchemas: areBundledSchemasEnabled(),
-            configNamespace
+            enableBundledSchemas: areBundledSchemasEnabled(name),
+            distributionId: name
         });
-        const languageClient = new LanguageClient(configNamespace, serverOptions, clientOptions, false)
+        const languageClient = new LanguageClient(name, serverOptions, clientOptions, false)
 
         await languageClient.start();
 
@@ -88,7 +88,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         // Register the schema selection command
         context.subscriptions.push(
-            vscode.commands.registerCommand(`${configNamespace}.selectSchema`, async () => {
+            vscode.commands.registerCommand(`${name}.selectSchema`, async () => {
                 const editor = vscode.window.activeTextEditor;
                 if (!editor || !isKsonLanguage(editor.document.languageId)) {
                     vscode.window.showWarningMessage('Please open a KSON file first.');
@@ -136,7 +136,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     // Execute the remove schema command via LSP
                     try {
                         await languageClient.sendRequest('workspace/executeCommand', {
-                            command: toWireCommandId(CommandType.REMOVE_SCHEMA, configNamespace),
+                            command: toWireCommandId(CommandType.REMOVE_SCHEMA, name),
                             arguments: [{
                                 documentUri: editor.document.uri.toString()
                             }]
@@ -154,7 +154,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     try {
                         // Execute the associate schema command via LSP
                         await languageClient.sendRequest('workspace/executeCommand', {
-                            command: toWireCommandId(CommandType.ASSOCIATE_SCHEMA, configNamespace),
+                            command: toWireCommandId(CommandType.ASSOCIATE_SCHEMA, name),
                             arguments: [{
                                 documentUri: editor.document.uri.toString(),
                                 schemaPath: schemaPath

--- a/tooling/lsp-clients/vscode/src/config/bundledSchemaLoader.ts
+++ b/tooling/lsp-clients/vscode/src/config/bundledSchemaLoader.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getLanguageConfiguration, BundledSchemaMapping } from './languageConfig';
+import { getLanguageConfiguration, getConfigNamespace, BundledSchemaMapping } from './languageConfig';
 
 import type { BundledSchemaConfig, BundledMetaSchemaConfig } from 'kson-language-server';
 export type { BundledSchemaConfig, BundledMetaSchemaConfig };
@@ -116,6 +116,6 @@ async function loadSchemaFile(
  * Check if bundled schemas are enabled via VS Code settings.
  */
 export function areBundledSchemasEnabled(): boolean {
-    const config = vscode.workspace.getConfiguration('kson');
+    const config = vscode.workspace.getConfiguration(getConfigNamespace());
     return config.get<boolean>('enableBundledSchemas', true);
 }

--- a/tooling/lsp-clients/vscode/src/config/bundledSchemaLoader.ts
+++ b/tooling/lsp-clients/vscode/src/config/bundledSchemaLoader.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getLanguageConfiguration, getConfigNamespace, BundledSchemaMapping } from './languageConfig';
+import { getLanguageConfiguration, BundledSchemaMapping } from './languageConfig';
 
 import type { BundledSchemaConfig, BundledMetaSchemaConfig } from 'kson-language-server';
 export type { BundledSchemaConfig, BundledMetaSchemaConfig };
@@ -115,7 +115,7 @@ async function loadSchemaFile(
 /**
  * Check if bundled schemas are enabled via VS Code settings.
  */
-export function areBundledSchemasEnabled(): boolean {
-    const config = vscode.workspace.getConfiguration(getConfigNamespace());
+export function areBundledSchemasEnabled(name: string): boolean {
+    const config = vscode.workspace.getConfiguration(name);
     return config.get<boolean>('enableBundledSchemas', true);
 }

--- a/tooling/lsp-clients/vscode/src/config/languageConfig.ts
+++ b/tooling/lsp-clients/vscode/src/config/languageConfig.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_CONFIG_NAMESPACE } from 'kson-language-server';
+
 /**
  * Configuration for bundled schemas mapped by file extension.
  */
@@ -13,7 +15,26 @@ export interface LanguageConfiguration {
     fileExtensions: string[];
     /** Bundled schema mappings extracted from package.json */
     bundledSchemas: BundledSchemaMapping[];
+    /**
+     * Prefix for VSCode commands and configuration keys (e.g. "kson").
+     * Read from {@link CONFIG_NAMESPACE_MANIFEST_FIELD}, defaulting to "kson".
+     */
+    configNamespace: string;
 }
+
+/**
+ * Root-level package.json field naming the namespace for VSCode commands and
+ * configuration keys. A build toolchain that produces a non-default extension
+ * (e.g. a derived one using a different `languageId`) sets this so the derived
+ * extension doesn't collide with the base kson extension on install.
+ *
+ * A derived extension's manifest must keep three things in sync: (1) set
+ * `ksonConfigNamespace` to the new namespace; (2) rewrite static contribution
+ * keys — `contributes.commands[].command` ids and `contributes.configuration.properties`
+ * keys — to live under that prefix instead of `kson.*`. Runtime call sites all
+ * route through {@link getConfigNamespace}, so no source changes are required.
+ */
+const CONFIG_NAMESPACE_MANIFEST_FIELD = 'ksonConfigNamespace';
 
 let cachedConfig: LanguageConfiguration | null = null;
 
@@ -32,6 +53,15 @@ export function getLanguageConfiguration(): LanguageConfiguration {
  */
 export function isKsonLanguage(languageId: string): boolean {
     return getLanguageConfiguration().languageIds.includes(languageId);
+}
+
+/**
+ * Namespace prefix for this extension's commands and configuration keys at
+ * runtime. Contribution keys in package.json (commands, configuration
+ * properties) are static and must be rewritten separately when forking.
+ */
+export function getConfigNamespace(): string {
+    return getLanguageConfiguration().configNamespace;
 }
 
 /**
@@ -55,7 +85,10 @@ export function initializeLanguageConfig(packageJson: any): void {
             .flatMap((lang: any) => lang.extensions || [])
             .filter(Boolean)
             .map((ext: string) => ext.replace(/^\./, '')),
-        bundledSchemas
+        bundledSchemas,
+        configNamespace:
+            packageJson?.[CONFIG_NAMESPACE_MANIFEST_FIELD]
+            || DEFAULT_CONFIG_NAMESPACE
     };
 }
 

--- a/tooling/lsp-clients/vscode/src/config/languageConfig.ts
+++ b/tooling/lsp-clients/vscode/src/config/languageConfig.ts
@@ -13,27 +13,7 @@ export interface LanguageConfiguration {
     fileExtensions: string[];
     /** Bundled schema mappings extracted from package.json */
     bundledSchemas: BundledSchemaMapping[];
-    /**
-     * Prefix for VSCode commands and configuration keys (e.g. "kson").
-     * Required; read from {@link CONFIG_NAMESPACE_MANIFEST_FIELD}.
-     */
-    configNamespace: string;
 }
-
-/**
- * Root-level package.json field naming the namespace for VSCode commands and
- * configuration keys. A build toolchain that produces a non-default extension
- * (e.g. a derived one using a different `languageId`) sets this so the derived
- * extension doesn't collide with the base kson extension on install.
- *
- * Every manifest must set this field; a derived extension keeps two things
- * in sync: (1) set `ksonConfigNamespace` to its namespace (required — the base
- * `kson` extension also sets this explicitly); (2) rewrite static contribution
- * keys — `contributes.commands[].command` ids and `contributes.configuration.properties`
- * keys — to live under that prefix instead of `kson.*`. Runtime call sites all
- * route through {@link getConfigNamespace}, so no source changes are required.
- */
-const CONFIG_NAMESPACE_MANIFEST_FIELD = 'ksonConfigNamespace';
 
 let cachedConfig: LanguageConfiguration | null = null;
 
@@ -55,29 +35,11 @@ export function isKsonLanguage(languageId: string): boolean {
 }
 
 /**
- * Namespace prefix for this extension's commands and configuration keys at
- * runtime. Contribution keys in package.json (commands, configuration
- * properties) are static and must be rewritten separately when forking.
- */
-export function getConfigNamespace(): string {
-    return getLanguageConfiguration().configNamespace;
-}
-
-/**
  * Initialize language configuration from extension's package.json.
  * Call this early in the activate function.
  */
 export function initializeLanguageConfig(packageJson: any): void {
     const languages = packageJson?.contributes?.languages || [];
-
-    const configNamespace = packageJson?.[CONFIG_NAMESPACE_MANIFEST_FIELD];
-    if (!configNamespace) {
-        throw new Error(
-            `Missing required package.json field "${CONFIG_NAMESPACE_MANIFEST_FIELD}". ` +
-            `A fork must declare this field at the top level of its manifest to name the ` +
-            `namespace under which its commands and configuration keys live.`
-        );
-    }
 
     // Extract bundled schema mappings using file extension from lang.extensions[0]
     const bundledSchemas: BundledSchemaMapping[] = languages
@@ -93,8 +55,7 @@ export function initializeLanguageConfig(packageJson: any): void {
             .flatMap((lang: any) => lang.extensions || [])
             .filter(Boolean)
             .map((ext: string) => ext.replace(/^\./, '')),
-        bundledSchemas,
-        configNamespace
+        bundledSchemas
     };
 }
 

--- a/tooling/lsp-clients/vscode/src/config/languageConfig.ts
+++ b/tooling/lsp-clients/vscode/src/config/languageConfig.ts
@@ -1,5 +1,3 @@
-import { DEFAULT_CONFIG_NAMESPACE } from 'kson-language-server';
-
 /**
  * Configuration for bundled schemas mapped by file extension.
  */
@@ -17,7 +15,7 @@ export interface LanguageConfiguration {
     bundledSchemas: BundledSchemaMapping[];
     /**
      * Prefix for VSCode commands and configuration keys (e.g. "kson").
-     * Read from {@link CONFIG_NAMESPACE_MANIFEST_FIELD}, defaulting to "kson".
+     * Required; read from {@link CONFIG_NAMESPACE_MANIFEST_FIELD}.
      */
     configNamespace: string;
 }
@@ -28,8 +26,9 @@ export interface LanguageConfiguration {
  * (e.g. a derived one using a different `languageId`) sets this so the derived
  * extension doesn't collide with the base kson extension on install.
  *
- * A derived extension's manifest must keep three things in sync: (1) set
- * `ksonConfigNamespace` to the new namespace; (2) rewrite static contribution
+ * Every manifest must set this field; a derived extension keeps two things
+ * in sync: (1) set `ksonConfigNamespace` to its namespace (required — the base
+ * `kson` extension also sets this explicitly); (2) rewrite static contribution
  * keys — `contributes.commands[].command` ids and `contributes.configuration.properties`
  * keys — to live under that prefix instead of `kson.*`. Runtime call sites all
  * route through {@link getConfigNamespace}, so no source changes are required.
@@ -71,6 +70,15 @@ export function getConfigNamespace(): string {
 export function initializeLanguageConfig(packageJson: any): void {
     const languages = packageJson?.contributes?.languages || [];
 
+    const configNamespace = packageJson?.[CONFIG_NAMESPACE_MANIFEST_FIELD];
+    if (!configNamespace) {
+        throw new Error(
+            `Missing required package.json field "${CONFIG_NAMESPACE_MANIFEST_FIELD}". ` +
+            `A fork must declare this field at the top level of its manifest to name the ` +
+            `namespace under which its commands and configuration keys live.`
+        );
+    }
+
     // Extract bundled schema mappings using file extension from lang.extensions[0]
     const bundledSchemas: BundledSchemaMapping[] = languages
         .filter((lang: any) => lang.extensions?.[0] && lang.bundledSchema)
@@ -86,9 +94,7 @@ export function initializeLanguageConfig(packageJson: any): void {
             .filter(Boolean)
             .map((ext: string) => ext.replace(/^\./, '')),
         bundledSchemas,
-        configNamespace:
-            packageJson?.[CONFIG_NAMESPACE_MANIFEST_FIELD]
-            || DEFAULT_CONFIG_NAMESPACE
+        configNamespace
     };
 }
 

--- a/tooling/lsp-clients/vscode/test/suite/language-config.test.ts
+++ b/tooling/lsp-clients/vscode/test/suite/language-config.test.ts
@@ -1,5 +1,5 @@
 import { assert } from './assert';
-import { initializeLanguageConfig, getLanguageConfiguration, isKsonLanguage, resetLanguageConfiguration } from '../../src/config/languageConfig';
+import { initializeLanguageConfig, getLanguageConfiguration, getConfigNamespace, isKsonLanguage, resetLanguageConfiguration } from '../../src/config/languageConfig';
 
 describe('Language Configuration Tests', () => {
 
@@ -117,4 +117,27 @@ describe('Language Configuration Tests', () => {
             assert.ok(config.bundledSchemas.some(s => s.fileExtension === 'config'));
         });
     });
+
+    describe('configNamespace', () => {
+        it('Should default to "kson" when no languages are declared and no field is set', () => {
+            initWithLanguages([]);
+            assert.strictEqual(getConfigNamespace(), 'kson');
+        });
+
+        it('Should use the ksonConfigNamespace manifest field when present', () => {
+            initializeLanguageConfig({
+                ksonConfigNamespace: 'config',
+                contributes: { languages: [{ id: 'config', extensions: ['.config'] }] }
+            });
+            assert.strictEqual(getConfigNamespace(), 'config');
+        });
+
+        it('Should prefer the manifest field over languages[0].id', () => {
+            initializeLanguageConfig({
+                ksonConfigNamespace: 'config',
+                contributes: { languages: [{ id: 'different', extensions: ['.different'] }] }
+            });
+            assert.strictEqual(getConfigNamespace(), 'config');
+        });
+    })
 });

--- a/tooling/lsp-clients/vscode/test/suite/language-config.test.ts
+++ b/tooling/lsp-clients/vscode/test/suite/language-config.test.ts
@@ -7,7 +7,7 @@ describe('Language Configuration Tests', () => {
     afterEach(() => resetLanguageConfiguration());
 
     function initWithLanguages(languages: any[]) {
-        initializeLanguageConfig({ contributes: { languages } });
+        initializeLanguageConfig({ ksonConfigNamespace: 'kson', contributes: { languages } });
     }
 
     describe('getLanguageConfiguration', () => {
@@ -119,9 +119,15 @@ describe('Language Configuration Tests', () => {
     });
 
     describe('configNamespace', () => {
-        it('Should default to "kson" when no languages are declared and no field is set', () => {
-            initWithLanguages([]);
-            assert.strictEqual(getConfigNamespace(), 'kson');
+        it('Should throw when the ksonConfigNamespace manifest field is missing', () => {
+            let caught: Error | null = null;
+            try {
+                initializeLanguageConfig({ contributes: { languages: [{ id: 'kson', extensions: ['.kson'] }] } });
+            } catch (e) {
+                caught = e as Error;
+            }
+            assert.ok(caught, 'expected initializeLanguageConfig to throw');
+            assert.ok(caught!.message.includes('ksonConfigNamespace'), `error message should name the field, got: ${caught!.message}`);
         });
 
         it('Should use the ksonConfigNamespace manifest field when present', () => {

--- a/tooling/lsp-clients/vscode/test/suite/language-config.test.ts
+++ b/tooling/lsp-clients/vscode/test/suite/language-config.test.ts
@@ -1,5 +1,5 @@
 import { assert } from './assert';
-import { initializeLanguageConfig, getLanguageConfiguration, getConfigNamespace, isKsonLanguage, resetLanguageConfiguration } from '../../src/config/languageConfig';
+import { initializeLanguageConfig, getLanguageConfiguration, isKsonLanguage, resetLanguageConfiguration } from '../../src/config/languageConfig';
 
 describe('Language Configuration Tests', () => {
 
@@ -7,7 +7,7 @@ describe('Language Configuration Tests', () => {
     afterEach(() => resetLanguageConfiguration());
 
     function initWithLanguages(languages: any[]) {
-        initializeLanguageConfig({ ksonConfigNamespace: 'kson', contributes: { languages } });
+        initializeLanguageConfig({ contributes: { languages } });
     }
 
     describe('getLanguageConfiguration', () => {
@@ -118,32 +118,4 @@ describe('Language Configuration Tests', () => {
         });
     });
 
-    describe('configNamespace', () => {
-        it('Should throw when the ksonConfigNamespace manifest field is missing', () => {
-            let caught: Error | null = null;
-            try {
-                initializeLanguageConfig({ contributes: { languages: [{ id: 'kson', extensions: ['.kson'] }] } });
-            } catch (e) {
-                caught = e as Error;
-            }
-            assert.ok(caught, 'expected initializeLanguageConfig to throw');
-            assert.ok(caught!.message.includes('ksonConfigNamespace'), `error message should name the field, got: ${caught!.message}`);
-        });
-
-        it('Should use the ksonConfigNamespace manifest field when present', () => {
-            initializeLanguageConfig({
-                ksonConfigNamespace: 'config',
-                contributes: { languages: [{ id: 'config', extensions: ['.config'] }] }
-            });
-            assert.strictEqual(getConfigNamespace(), 'config');
-        });
-
-        it('Should prefer the manifest field over languages[0].id', () => {
-            initializeLanguageConfig({
-                ksonConfigNamespace: 'config',
-                contributes: { languages: [{ id: 'different', extensions: ['.different'] }] }
-            });
-            assert.strictEqual(getConfigNamespace(), 'config');
-        });
-    })
 });


### PR DESCRIPTION
The upstream kson extension hard-coded "kson" as the prefix for its contributed command ids (kson.selectSchema) and configuration properties (kson.format.*, kson.codeLens.enable, kson.trace.server, ...).

The client now reads the namespace from a `ksonConfigNamespace` top-level manifest field, falling back to "kson", and passes it to the server via initializationOptions. CommandType enum values are unqualified ids (plainFormat, compactFormat, ...) with the wire prefix applied at the LSP boundary via toWireCommandId / fromWireCommandId — both exported so the client doesn't hand-build wire ids either. KsonSettings is flattened to drop the fixed { kson: {...} } wrapper and a single unwrapPushedSettings helper handles both namespaced and already-scoped push payloads.