### PR TITLE
Derive LSP distribution id from package.json `name`

### DIFF
--- a/tooling/language-server-protocol/src/core/KsonSettings.ts
+++ b/tooling/language-server-protocol/src/core/KsonSettings.ts
@@ -2,23 +2,29 @@ import {LSPAny} from "vscode-languageserver";
 import {FormatOptions, FormattingStyle, IndentType} from "kson";
 
 /**
- * Configuration settings for the Kson language server
+ * Configuration settings for the Kson language server.
+ *
+ * These are the already-unwrapped settings — the server has stripped the
+ * configuration namespace (e.g. "kson") before calling
+ * {@link ksonSettingsWithDefaults}.
  */
 export interface KsonSettings {
-    kson: {
-        formatOptions: FormatOptions;
-        codeLensEnabled: boolean;
-    };
+    formatOptions: FormatOptions;
+    codeLensEnabled: boolean;
 }
 
 /**
  * Create new [KsonSettings] from LSP settings, applying defaults where needed.
+ *
+ * Input is the object returned by `connection.workspace.getConfiguration(ns)`,
+ * so the shape is `{ format?: {...}, codeLens?: {...} }` without any outer
+ * namespace key.
  */
 export function ksonSettingsWithDefaults(settings?: LSPAny): Required<KsonSettings> {
     // Create IndentType based on the provided settings
     let indentType: IndentType;
-    if (settings?.kson?.format) {
-        const format = settings.kson.format;
+    if (settings?.format) {
+        const format = settings.format;
         if (format.insertSpaces === false) {
             indentType = IndentType.Tabs;
         } else {
@@ -33,9 +39,9 @@ export function ksonSettingsWithDefaults(settings?: LSPAny): Required<KsonSettin
 
     // Create FormattingStyle based on the provided settings
     let formatStyle: FormattingStyle
-    if (settings?.kson?.format?.formattingStyle) {
+    if (settings?.format?.formattingStyle) {
         // Map lowercase string to uppercase enum value exhaustively
-        const style = settings.kson.format.formattingStyle.toLowerCase();
+        const style = settings.format.formattingStyle.toLowerCase();
         switch (style) {
             case 'plain':
                 formatStyle = FormattingStyle.PLAIN;
@@ -53,12 +59,10 @@ export function ksonSettingsWithDefaults(settings?: LSPAny): Required<KsonSettin
     }
 
     // CodeLens enabled by default
-    const codeLensEnabled = settings?.kson?.codeLens?.enable !== false;
+    const codeLensEnabled = settings?.codeLens?.enable !== false;
 
     return {
-        kson: {
-            formatOptions: new FormatOptions(indentType, formatStyle),
-            codeLensEnabled
-        }
+        formatOptions: new FormatOptions(indentType, formatStyle),
+        codeLensEnabled
     };
 }

--- a/tooling/language-server-protocol/src/core/commands/CommandExecutor.base.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandExecutor.base.ts
@@ -58,7 +58,7 @@ export abstract class CommandExecutorBase {
             case CommandType.DELIMITED_FORMAT:
             case CommandType.COMPACT_FORMAT:
             case CommandType.CLASSIC_FORMAT: {
-                const indentType = this.getConfiguration().kson.formatOptions.indentType;
+                const indentType = this.getConfiguration().formatOptions.indentType;
 
                 return this.executeFormat(commandArgs.documentUri, document, new FormatOptions(
                     indentType,

--- a/tooling/language-server-protocol/src/core/commands/CommandType.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandType.ts
@@ -1,41 +1,57 @@
 /**
- * Enum defining all available commands in the Kson Language Server
+ * Enum defining all commands the Kson Language Server can execute.
+ *
+ * Values are unqualified ids used internally as discriminators. On the wire,
+ * they are prefixed with the active distribution id via {@link toWireCommandId}
+ * and stripped again in {@link fromWireCommandId}.
  */
 export enum CommandType {
-    /**
-     * Format the document as plain Kson
-     */
-    PLAIN_FORMAT = 'kson.plainFormat',
+    /** Format the document as plain Kson */
+    PLAIN_FORMAT = 'plainFormat',
 
-    /**
-     * Format the document as delimited Kson
-     */
-    DELIMITED_FORMAT = 'kson.delimitedFormat',
+    /** Format the document as delimited Kson */
+    DELIMITED_FORMAT = 'delimitedFormat',
 
-    /**
-     * Format the document as compact Kson
-     */
-    COMPACT_FORMAT = 'kson.compactFormat',
+    /** Format the document as compact Kson */
+    COMPACT_FORMAT = 'compactFormat',
 
-     /**
-     * Format the document as classic Kson
-     */
-    CLASSIC_FORMAT = 'kson.classicFormat',
+    /** Format the document as classic Kson */
+    CLASSIC_FORMAT = 'classicFormat',
 
-    /**
-     * Associate a schema with the current document
-     */
-    ASSOCIATE_SCHEMA = 'kson.associateSchema',
+    /** Associate a schema with the current document */
+    ASSOCIATE_SCHEMA = 'associateSchema',
 
-    /**
-     * Remove schema association from the current document
-     */
-    REMOVE_SCHEMA = 'kson.removeSchema'
+    /** Remove schema association from the current document */
+    REMOVE_SCHEMA = 'removeSchema',
 }
 
 /**
- * Get all available command IDs
+ * Get all unqualified command ids.
  */
-export function getAllCommandIds(): string[] {
+export function getAllCommandIds(): CommandType[] {
     return Object.values(CommandType);
+}
+
+/**
+ * Build the VSCode/LSP wire id for a command by prepending the active
+ * distribution id.
+ */
+export function toWireCommandId(commandId: CommandType | string, distributionId: string): string {
+    return `${distributionId}.${commandId}`;
+}
+
+/**
+ * Parse a wire command id back to its {@link CommandType}, or return
+ * `undefined` if the id is not prefixed by `distributionId` or doesn't
+ * resolve to a known command.
+ */
+export function fromWireCommandId(wireId: string, distributionId: string): CommandType | undefined {
+    const prefix = `${distributionId}.`;
+    if (!wireId.startsWith(prefix)) {
+        return undefined;
+    }
+    const unqualified = wireId.slice(prefix.length);
+    return (Object.values(CommandType) as string[]).includes(unqualified)
+        ? (unqualified as CommandType)
+        : undefined;
 }

--- a/tooling/language-server-protocol/src/core/features/DiagnosticService.ts
+++ b/tooling/language-server-protocol/src/core/features/DiagnosticService.ts
@@ -14,6 +14,8 @@ import {KsonTooling, DiagnosticMessage, DiagnosticSeverity as KtSeverity} from '
  */
 export class DiagnosticService {
 
+    constructor(private readonly distributionId: string) {}
+
     createDocumentDiagnosticReport(document: KsonDocument | null | undefined): DocumentDiagnosticReport {
         const diagnostics = document ? this.getDiagnostics(document) : [];
         return {
@@ -32,20 +34,20 @@ export class DiagnosticService {
             .validateDocument(toolingDoc, schemaToolingDoc ?? null)
             .asJsReadonlyArrayView();
 
-        return messages.map(msg => toDiagnostic(msg));
+        return messages.map(msg => this.toDiagnostic(msg));
     }
-}
 
-function toDiagnostic(msg: DiagnosticMessage): Diagnostic {
-    return {
-        range: {
-            start: {line: msg.range.startLine, character: msg.range.startColumn},
-            end: {line: msg.range.endLine, character: msg.range.endColumn}
-        },
-        severity: msg.severity === KtSeverity.ERROR
-            ? DiagnosticSeverity.Error
-            : DiagnosticSeverity.Warning,
-        source: 'kson',
-        message: msg.message
-    };
+    private toDiagnostic(msg: DiagnosticMessage): Diagnostic {
+        return {
+            range: {
+                start: {line: msg.range.startLine, character: msg.range.startColumn},
+                end: {line: msg.range.endLine, character: msg.range.endColumn}
+            },
+            severity: msg.severity === KtSeverity.ERROR
+                ? DiagnosticSeverity.Error
+                : DiagnosticSeverity.Warning,
+            source: this.distributionId,
+            message: msg.message
+        };
+    }
 }

--- a/tooling/language-server-protocol/src/core/schema/BundledSchemaProvider.ts
+++ b/tooling/language-server-protocol/src/core/schema/BundledSchemaProvider.ts
@@ -151,9 +151,9 @@ export class BundledSchemaProvider implements SchemaProvider {
      * Checks if the URI ends with any registered extension (preceded by a dot).
      * If multiple extensions match, returns the longest one (most specific).
      *
-     * For example, with extensions ['kson', 'orchestra.kson']:
+     * For example, with extensions ['kson', 'ext.kson']:
      * - 'file:///test.kson' matches 'kson'
-     * - 'file:///test.orchestra.kson' matches 'orchestra.kson' (longer/more specific)
+     * - 'file:///test.ext.kson' matches 'ext.kson' (longer/more specific)
      *
      * @param uri The URI to match against available extensions
      * @returns The matched file extension, or undefined if none match

--- a/tooling/language-server-protocol/src/core/services/KsonTextDocumentService.ts
+++ b/tooling/language-server-protocol/src/core/services/KsonTextDocumentService.ts
@@ -38,6 +38,10 @@ import {FoldingRangeService} from '../features/FoldingRangeService.js';
 import {SelectionRangeService} from '../features/SelectionRangeService.js';
 import {CommandExecutorBase} from '../commands/CommandExecutor.base.js';
 import { CommandExecutorFactory } from '../commands/CommandExecutorFactory.js';
+import {
+    fromWireCommandId,
+    toWireCommandId,
+} from '../commands/CommandType.js';
 import {KsonSettings, ksonSettingsWithDefaults} from '../KsonSettings.js';
 
 
@@ -64,10 +68,11 @@ export class KsonTextDocumentService {
     constructor(
         private documentManager: KsonDocumentsManager,
         private createCommandExecutor: CommandExecutorFactory,
-        private workspaceRoot: string | null = null
+        private workspaceRoot: string | null = null,
+        private distributionId: string
     ) {
         this.formattingService = new FormattingService();
-        this.diagnosticService = new DiagnosticService();
+        this.diagnosticService = new DiagnosticService(distributionId);
         this.semanticTokensService = new SemanticTokensService();
         this.codeLensService = new CodeLensService();
         this.documentHighlightService = new DocumentHighlightService();
@@ -158,7 +163,7 @@ export class KsonTextDocumentService {
             if (!document) {
                 return [];
             }
-            return this.formattingService.formatDocument(document, this.configuration.kson.formatOptions);
+            return this.formattingService.formatDocument(document, this.configuration.formatOptions);
         } catch (error) {
             this.connection.console.error(`Error formatting document: ${error}`);
             return [];
@@ -183,14 +188,19 @@ export class KsonTextDocumentService {
 
     private async onCodeLens(params: CodeLensParams): Promise<CodeLens[]> {
         try {
-            if (!this.configuration.kson.codeLensEnabled) {
+            if (!this.configuration.codeLensEnabled) {
                 return [];
             }
             const document = this.documentManager.get(params.textDocument.uri);
             if (!document) {
                 return [];
             }
-            return this.codeLensService.getCodeLenses(document);
+            return this.codeLensService.getCodeLenses(document).map(lens => ({
+                ...lens,
+                command: lens.command
+                    ? {...lens.command, command: toWireCommandId(lens.command.command, this.distributionId)}
+                    : lens.command,
+            }));
         } catch (error) {
             this.connection.console.error(`Error providing code lenses: ${error}`);
             return [];
@@ -199,7 +209,10 @@ export class KsonTextDocumentService {
 
     private async onExecuteCommand(params: ExecuteCommandParams): Promise<any> {
         try {
-            return await this.commandExecutor.execute(params);
+            const commandType = fromWireCommandId(params.command, this.distributionId);
+            return await this.commandExecutor.execute(
+                commandType ? {...params, command: commandType} : params
+            );
         } catch (error) {
             this.connection.console.error(`Error executing command: ${error}`);
             this.connection.window.showErrorMessage(`Command execution failed: ${error}`);

--- a/tooling/language-server-protocol/src/index.ts
+++ b/tooling/language-server-protocol/src/index.ts
@@ -1,3 +1,4 @@
 // Common exports for kson-language-server package
 export type { BundledSchemaConfig, BundledMetaSchemaConfig } from './core/schema/BundledSchemaProvider.js';
 export type { KsonInitializationOptions } from './startKsonServer.js';
+export { CommandType, toWireCommandId } from './core/commands/CommandType.js';

--- a/tooling/language-server-protocol/src/startKsonServer.ts
+++ b/tooling/language-server-protocol/src/startKsonServer.ts
@@ -11,7 +11,7 @@ import {KsonDocumentsManager} from './core/document/KsonDocumentsManager.js';
 import {isKsonSchemaDocument} from './core/document/KsonSchemaDocument.js';
 import {KsonTextDocumentService} from './core/services/KsonTextDocumentService.js';
 import {KSON_LEGEND} from './core/features/SemanticTokensService.js';
-import {getAllCommandIds} from './core/commands/CommandType.js';
+import {getAllCommandIds, toWireCommandId} from './core/commands/CommandType.js';
 import { ksonSettingsWithDefaults } from './core/KsonSettings.js';
 import {SchemaProvider} from './core/schema/SchemaProvider.js';
 import {BundledSchemaProvider, BundledSchemaConfig, BundledMetaSchemaConfig} from './core/schema/BundledSchemaProvider.js';
@@ -29,6 +29,12 @@ export interface KsonInitializationOptions {
     bundledMetaSchemas?: BundledMetaSchemaConfig[];
     /** Whether bundled schemas are enabled */
     enableBundledSchemas?: boolean;
+    /**
+     * Identifier under which this server instance's host-visible artifacts are
+     * registered: command-id prefix on the wire, diagnostic source, and the
+     * configuration section pulled from the client. Defaults to "kson".
+     */
+    distributionId?: string;
 }
 
 type SchemaProviderFactory = (
@@ -48,9 +54,17 @@ export function startKsonServer(
     createSchemaProvider: SchemaProviderFactory,
     createCommandExecutor: CommandExecutorFactory
 ): void {
+    /**
+     * Default distribution id, used when the client hasn't supplied one via
+     * initializationOptions.
+     */
+    const DEFAULT_DISTRIBUTION_ID = "kson";
+
+
     // Variables to store state during initialization
     let workspaceRootUri: URI | undefined;
     let hasConfigurationCapability = false;
+    let distributionId: string;
 
     // Create logger that uses the connection
     const logger = {
@@ -80,6 +94,7 @@ export function startKsonServer(
         const bundledSchemas = initOptions?.bundledSchemas ?? [];
         const bundledMetaSchemas = initOptions?.bundledMetaSchemas ?? [];
         const enableBundledSchemas = initOptions?.enableBundledSchemas ?? true;
+        distributionId = initOptions?.distributionId ?? DEFAULT_DISTRIBUTION_ID;
 
         // Create the appropriate schema provider for this environment (file system or no-op)
         const fileSystemSchemaProvider = await createSchemaProvider(workspaceRootUri, logger);
@@ -116,7 +131,8 @@ export function startKsonServer(
         textDocumentService = new KsonTextDocumentService(
             documentManager,
             createCommandExecutor,
-            workspaceRoot
+            workspaceRoot,
+            distributionId
         );
 
         // Setup document handling and connect services
@@ -138,7 +154,7 @@ export function startKsonServer(
 
             // Diagnostics (pull model preferred)
             diagnosticProvider: {
-                identifier: 'kson',
+                identifier: distributionId,
                 interFileDependencies: false,
                 workspaceDiagnostics: false
             } as DiagnosticRegistrationOptions,
@@ -148,9 +164,10 @@ export function startKsonServer(
                 resolveProvider: false
             },
 
-            // Execute command
+            // Execute command — advertise ids prefixed by the active
+            // distribution id
             executeCommandProvider: {
-                commands: getAllCommandIds()
+                commands: getAllCommandIds().map(id => toWireCommandId(id, distributionId))
             },
 
             // Folding ranges
@@ -189,8 +206,8 @@ export function startKsonServer(
 
     // Pull configuration from the client
     async function pullConfiguration(): Promise<void> {
-        const settings = await connection.workspace.getConfiguration('kson');
-        const configuration = ksonSettingsWithDefaults({ kson: settings });
+        const settings = await connection.workspace.getConfiguration(distributionId);
+        const configuration = ksonSettingsWithDefaults(settings);
         textDocumentService.updateConfiguration(configuration);
     }
 
@@ -199,7 +216,7 @@ export function startKsonServer(
         if (hasConfigurationCapability) {
             // Register for configuration change notifications
             connection.client.register(DidChangeConfigurationNotification.type, {
-                section: 'kson'
+                section: distributionId
             });
             // Pull initial configuration
             await pullConfiguration();
@@ -271,21 +288,20 @@ export function startKsonServer(
         }
     });
 
-    // Handle configuration changes
+    // Handle configuration changes. Per LSP, the push model sends the full
+    // settings object, so our slice arrives at `change.settings.<distributionId>`.
     connection.onDidChangeConfiguration(async (change) => {
+        const scoped = change.settings?.[distributionId];
+
         if (hasConfigurationCapability) {
             // Pull configuration from the client (pull model)
             await pullConfiguration();
         } else {
-            // Fallback to reading pushed settings
-            const configuration = ksonSettingsWithDefaults(change.settings);
-            textDocumentService.updateConfiguration(configuration);
+            textDocumentService.updateConfiguration(ksonSettingsWithDefaults(scoped));
         }
 
-        // Check if bundled schema setting changed
-        if (bundledSchemaProvider && change.settings?.kson?.enableBundledSchemas !== undefined) {
-            const enabled = change.settings.kson.enableBundledSchemas;
-            bundledSchemaProvider.setEnabled(enabled);
+        if (bundledSchemaProvider && scoped?.enableBundledSchemas !== undefined) {
+            bundledSchemaProvider.setEnabled(scoped.enableBundledSchemas);
             notifySchemaChange();
         }
 

--- a/tooling/language-server-protocol/src/test/core/commands/CommandExecutor.test.ts
+++ b/tooling/language-server-protocol/src/test/core/commands/CommandExecutor.test.ts
@@ -11,7 +11,7 @@ import {
     TextEdit,
     ApplyWorkspaceEditResult, Range
 } from "vscode-languageserver";
-import {CommandType} from "../../../core/commands/CommandType";
+import {CommandType, toWireCommandId} from "../../../core/commands/CommandType";
 import {FormattingStyle} from "kson";
 import {RemoteWorkspace} from "vscode-languageserver/lib/common/server";
 import {createCommandExecutor} from "../../../core/commands/createCommandExecutor.node.js";
@@ -35,10 +35,12 @@ class WorkspaceConnectionStub extends ConnectionStub {
     }
 }
 
+const TEST_DISTRIBUTION_ID = 'test-ns';
+
 function createTestSetup() {
     const connection = new ConnectionStub();
     const documentsManager = new KsonDocumentsManager();
-    const service = new KsonTextDocumentService(documentsManager, createCommandExecutor);
+    const service = new KsonTextDocumentService(documentsManager, createCommandExecutor, null, TEST_DISTRIBUTION_ID);
     
     documentsManager.listen(connection);
     service.connect(connection);
@@ -76,7 +78,7 @@ function buildWorkspaceEdit(uri: string, replaceRange: Range, newText: string): 
 
 function buildCommandParams(command: CommandType, uri: string, style: FormattingStyle): ExecuteCommandParams {
     return {
-        command,
+        command: toWireCommandId(command, TEST_DISTRIBUTION_ID),
         arguments: [{ documentUri: uri, formattingStyle: style }]
     };
 }

--- a/tooling/language-server-protocol/src/test/core/commands/CommandType.test.ts
+++ b/tooling/language-server-protocol/src/test/core/commands/CommandType.test.ts
@@ -1,0 +1,33 @@
+import {describe, it} from 'mocha';
+import assert from 'assert';
+import {
+    CommandType,
+    fromWireCommandId,
+    getAllCommandIds,
+    toWireCommandId,
+} from '../../../core/commands/CommandType.js';
+
+describe('CommandType wire-prefix translation', () => {
+    it('toWireCommandId / fromWireCommandId round-trip every CommandType under any distribution id', () => {
+        for (const id of ['kson', 'config', 'a.b']) {
+            for (const cmd of getAllCommandIds()) {
+                const wire = toWireCommandId(cmd, id);
+                assert.strictEqual(wire, `${id}.${cmd}`);
+                assert.strictEqual(fromWireCommandId(wire, id), cmd);
+            }
+        }
+    });
+
+    it('fromWireCommandId returns undefined for unknown ids or wrong distribution id', () => {
+        assert.strictEqual(fromWireCommandId('config.bogus', 'config'), undefined);
+        assert.strictEqual(fromWireCommandId('other.plainFormat', 'config'), undefined);
+        assert.strictEqual(fromWireCommandId('plainFormat', 'config'), undefined);
+    });
+
+    it('CommandType values are unqualified (no dot)', () => {
+        for (const id of getAllCommandIds()) {
+            assert.ok(!id.includes('.'), `CommandType value '${id}' must not contain a dot`);
+        }
+        assert.strictEqual(CommandType.PLAIN_FORMAT, 'plainFormat');
+    });
+});

--- a/tooling/language-server-protocol/src/test/core/features/DiagnosticService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/DiagnosticService.test.ts
@@ -10,7 +10,8 @@ import {createKsonDocument} from '../../TestHelpers.js';
 
 
 describe('KSON Diagnostics', () => {
-    const diagnosticService = new DiagnosticService();
+    const TEST_DISTRIBUTION_ID = 'test-ns';
+    const diagnosticService = new DiagnosticService(TEST_DISTRIBUTION_ID);
 
     function getDiagnostics(content: string, schemaContent?: string): Diagnostic[] {
         const ksonDocument = createKsonDocument(content, schemaContent);
@@ -29,7 +30,7 @@ describe('KSON Diagnostics', () => {
         it('should report error for empty document', () => {
             const diagnostics = assertDiagnosticCount('', 1);
             assert.strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
-            assert.strictEqual(diagnostics[0].source, 'kson');
+            assert.strictEqual(diagnostics[0].source, TEST_DISTRIBUTION_ID);
         });
 
         it('should report no diagnostics for valid document', () => {
@@ -66,10 +67,10 @@ describe('KSON Diagnostics', () => {
             assert.strictEqual(diagnostics[1].severity, DiagnosticSeverity.Warning);
         });
 
-        it('should set source to kson on all diagnostics', () => {
+        it('should set source to the configured distribution id on all diagnostics', () => {
             const diagnostics = getDiagnostics('');
             for (const d of diagnostics) {
-                assert.strictEqual(d.source, 'kson');
+                assert.strictEqual(d.source, TEST_DISTRIBUTION_ID);
             }
         });
 
@@ -135,7 +136,7 @@ describe('KSON Diagnostics', () => {
             // Should still return at least the document parse errors, not crash
             assert.ok(diagnostics.length > 0, 'Should return document parse errors even when schema is invalid');
             for (const d of diagnostics) {
-                assert.strictEqual(d.source, 'kson');
+                assert.strictEqual(d.source, TEST_DISTRIBUTION_ID);
             }
         });
 
@@ -153,7 +154,7 @@ describe('KSON Diagnostics', () => {
         assert.ok(diagnostics.length > 0);
         // All diagnostics should come from parse errors only
         for (const d of diagnostics) {
-            assert.strictEqual(d.source, 'kson');
+            assert.strictEqual(d.source, TEST_DISTRIBUTION_ID);
         }
     });
 

--- a/tooling/language-server-protocol/src/test/core/features/FormattingService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/FormattingService.test.ts
@@ -22,19 +22,14 @@ describe('KSON Formatter', () => {
             KsonTooling.getInstance().parse(unformatted),
         );
 
-        const ksonSettings = ksonSettingsWithDefaults(
-            {
-                kson:
-                    {
-                        format: {
-                            insertSpaces: insertSpaces,
-                            tabSize: 2
-                        }
-                    }
+        const ksonSettings = ksonSettingsWithDefaults({
+            format: {
+                insertSpaces: insertSpaces,
+                tabSize: 2
             }
-        )
+        })
 
-        const edits = formattingService.formatDocument(ksonDocument, ksonSettings.kson.formatOptions);
+        const edits = formattingService.formatDocument(ksonDocument, ksonSettings.formatOptions);
         const formatted = applyEdits(document, edits);
 
         assert.strictEqual(formatted, expected, 'should have a matching formatted document');

--- a/tooling/language-server-protocol/src/test/core/schema/BundledSchemaProvider.test.ts
+++ b/tooling/language-server-protocol/src/test/core/schema/BundledSchemaProvider.test.ts
@@ -130,10 +130,10 @@ describe('BundledSchemaProvider', () => {
 
         it('should match multi-dot extensions correctly', () => {
             const ksonSchema = '{ "type": "kson" }';
-            const orchestraSchema = '{ "type": "orchestra" }';
+            const extSchema = '{ "type": "ext" }';
             const schemas: BundledSchemaConfig[] = [
                 { fileExtension: 'kson', schemaContent: ksonSchema },
-                { fileExtension: 'orchestra.kson', schemaContent: orchestraSchema }
+                { fileExtension: 'ext.kson', schemaContent: extSchema }
             ];
             const provider = new BundledSchemaProvider({ schemas, logger });
 
@@ -142,10 +142,10 @@ describe('BundledSchemaProvider', () => {
             assert.ok(simpleSchema);
             assert.strictEqual(simpleSchema!.getText(), ksonSchema);
 
-            // Multi-dot .orchestra.kson file should match the longer 'orchestra.kson' extension
-            const orchestraResult = provider.getSchemaForDocument('file:///my-config.orchestra.kson');
-            assert.ok(orchestraResult);
-            assert.strictEqual(orchestraResult!.getText(), orchestraSchema);
+            // Multi-dot .ext.kson file should match the longer 'ext.kson' extension
+            const extResult = provider.getSchemaForDocument('file:///my-config.ext.kson');
+            assert.ok(extResult);
+            assert.strictEqual(extResult!.getText(), extSchema);
         });
 
         it('should prefer longer extension when multiple match', () => {

--- a/tooling/language-server-protocol/src/test/core/services/KsonTextDocumentService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/services/KsonTextDocumentService.test.ts
@@ -15,6 +15,7 @@ import {ksonSettingsWithDefaults} from "../../../core/KsonSettings.js";
 import {pos} from "../../TestHelpers";
 
 describe('KsonTextDocumentService', () => {
+    const TEST_DISTRIBUTION_ID = 'test-ns';
     let connection: ConnectionStub;
     let service: KsonTextDocumentService;
     let documentsManager: KsonDocumentsManager;
@@ -23,7 +24,7 @@ describe('KsonTextDocumentService', () => {
     beforeEach(() => {
         connection = new ConnectionStub();
         documentsManager = new KsonDocumentsManager();
-        service = new KsonTextDocumentService(documentsManager, createCommandExecutor);
+        service = new KsonTextDocumentService(documentsManager, createCommandExecutor, null, TEST_DISTRIBUTION_ID);
 
         documentsManager.listen(connection);
         service.connect(connection)
@@ -95,7 +96,7 @@ describe('KsonTextDocumentService', () => {
 
             assert.strictEqual(result.items.length, 1, "Should have exactly 1 diagnostic for trailing token");
             assert.strictEqual(result.items[0].severity, DiagnosticSeverity.Error);
-            assert.strictEqual(result.items[0].source, 'kson');
+            assert.strictEqual(result.items[0].source, TEST_DISTRIBUTION_ID);
         });
 
         it('should return empty items when document is not found', async () => {
@@ -127,7 +128,7 @@ describe('KsonTextDocumentService', () => {
         it('should return empty array when codeLens is disabled', async () => {
             openDocument('key: value');
 
-            const config = ksonSettingsWithDefaults({kson: {codeLens: {enable: false}}});
+            const config = ksonSettingsWithDefaults({codeLens: {enable: false}});
             service.updateConfiguration(config);
 
             const result = await connection.requestCodeLens(TEST_URI);

--- a/tooling/lsp-clients/vscode/src/client/browser/ksonClientMain.ts
+++ b/tooling/lsp-clients/vscode/src/client/browser/ksonClientMain.ts
@@ -12,6 +12,7 @@ import { registerBundledSchemaContentProvider } from '../common/BundledSchemaCon
 export async function activate(context: vscode.ExtensionContext) {
     // Initialize language configuration from package.json
     initializeLanguageConfig(context.extension.packageJSON);
+    const name = context.extension.packageJSON.name;
 
     // Create log output channel
     const logOutputChannel = vscode.window.createOutputChannel('Kson Language Server', { log: true });
@@ -35,7 +36,8 @@ export async function activate(context: vscode.ExtensionContext) {
         const clientOptions = createClientOptions(logOutputChannel, {
             bundledSchemas,
             bundledMetaSchemas,
-            enableBundledSchemas: areBundledSchemasEnabled()
+            enableBundledSchemas: areBundledSchemasEnabled(name),
+            distributionId: name
         });
 
         // In test environments, we need to support the vscode-test-web scheme
@@ -53,8 +55,8 @@ export async function activate(context: vscode.ExtensionContext) {
         }
 
         const languageClient = new LanguageClient(
-            'kson-browser',
-            'KSON Language Server (Browser)',
+            `${name}-browser`,
+            `${name} Language Server (Browser)`,
             clientOptions,
             worker
         );

--- a/tooling/lsp-clients/vscode/src/client/common/StatusBarManager.ts
+++ b/tooling/lsp-clients/vscode/src/client/common/StatusBarManager.ts
@@ -26,7 +26,7 @@ export class StatusBarManager {
             vscode.StatusBarAlignment.Right,
             100
         );
-        this.statusBarItem.command = 'kson.selectSchema';
+        this.statusBarItem.command = `${client.name}.selectSchema`;
     }
 
     /**

--- a/tooling/lsp-clients/vscode/src/client/node/ksonClientMain.ts
+++ b/tooling/lsp-clients/vscode/src/client/node/ksonClientMain.ts
@@ -13,6 +13,7 @@ import {StatusBarManager} from '../common/StatusBarManager';
 import { isKsonLanguage, initializeLanguageConfig } from '../../config/languageConfig';
 import { loadBundledSchemas, loadBundledMetaSchemas, areBundledSchemasEnabled } from '../../config/bundledSchemaLoader';
 import { registerBundledSchemaContentProvider } from '../common/BundledSchemaContentProvider';
+import { CommandType, toWireCommandId } from 'kson-language-server';
 
 /**
  * Node.js-specific activation function for the KSON extension.
@@ -21,6 +22,7 @@ import { registerBundledSchemaContentProvider } from '../common/BundledSchemaCon
 export async function activate(context: vscode.ExtensionContext) {
     // Initialize language configuration from package.json
     initializeLanguageConfig(context.extension.packageJSON);
+    const name = context.extension.packageJSON.name;
 
     // Create log output channel
     const logOutputChannel = vscode.window.createOutputChannel('Kson Language Server', {log: true});
@@ -53,9 +55,10 @@ export async function activate(context: vscode.ExtensionContext) {
         const clientOptions: LanguageClientOptions = createClientOptions(logOutputChannel, {
             bundledSchemas,
             bundledMetaSchemas,
-            enableBundledSchemas: areBundledSchemasEnabled()
+            enableBundledSchemas: areBundledSchemasEnabled(name),
+            distributionId: name
         });
-        const languageClient = new LanguageClient("kson", serverOptions, clientOptions, false)
+        const languageClient = new LanguageClient(name, serverOptions, clientOptions, false)
 
         await languageClient.start();
 
@@ -85,7 +88,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         // Register the schema selection command
         context.subscriptions.push(
-            vscode.commands.registerCommand('kson.selectSchema', async () => {
+            vscode.commands.registerCommand(`${name}.selectSchema`, async () => {
                 const editor = vscode.window.activeTextEditor;
                 if (!editor || !isKsonLanguage(editor.document.languageId)) {
                     vscode.window.showWarningMessage('Please open a KSON file first.');
@@ -133,7 +136,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     // Execute the remove schema command via LSP
                     try {
                         await languageClient.sendRequest('workspace/executeCommand', {
-                            command: 'kson.removeSchema',
+                            command: toWireCommandId(CommandType.REMOVE_SCHEMA, name),
                             arguments: [{
                                 documentUri: editor.document.uri.toString()
                             }]
@@ -151,7 +154,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     try {
                         // Execute the associate schema command via LSP
                         await languageClient.sendRequest('workspace/executeCommand', {
-                            command: 'kson.associateSchema',
+                            command: toWireCommandId(CommandType.ASSOCIATE_SCHEMA, name),
                             arguments: [{
                                 documentUri: editor.document.uri.toString(),
                                 schemaPath: schemaPath

--- a/tooling/lsp-clients/vscode/src/config/bundledSchemaLoader.ts
+++ b/tooling/lsp-clients/vscode/src/config/bundledSchemaLoader.ts
@@ -115,7 +115,7 @@ async function loadSchemaFile(
 /**
  * Check if bundled schemas are enabled via VS Code settings.
  */
-export function areBundledSchemasEnabled(): boolean {
-    const config = vscode.workspace.getConfiguration('kson');
+export function areBundledSchemasEnabled(name: string): boolean {
+    const config = vscode.workspace.getConfiguration(name);
     return config.get<boolean>('enableBundledSchemas', true);
 }

--- a/tooling/lsp-clients/vscode/test/suite/language-config.test.ts
+++ b/tooling/lsp-clients/vscode/test/suite/language-config.test.ts
@@ -117,4 +117,5 @@ describe('Language Configuration Tests', () => {
             assert.ok(config.bundledSchemas.some(s => s.fileExtension === 'config'));
         });
     });
+
 });


### PR DESCRIPTION
The VSCode extension hard-coded "kson" as the prefix for its command ids, configuration section, and diagnostic source — duplicating `name`, which the manifest already has to declare and which VSCode guarantees unique per publisher. Read it from `packageJSON.name` and thread it as `distributionId` through the LSP init options, so the manifest's contribution keys and the runtime namespace can't drift apart. `KsonSettings` is unwrapped in the same pass—the server now strips the outer namespace key, so the type is `{ formatOptions, codeLensEnabled }` instead of `{ kson: {...} }`.