### PR TITLE
Remove stale npm_run_monaco dev workflow

### DIFF
--- a/tooling/lsp-clients/build.gradle.kts
+++ b/tooling/lsp-clients/build.gradle.kts
@@ -21,11 +21,6 @@ tasks {
         dependsOn(npmInstall)
     }
 
-    register<PixiExecTask>("npm_run_monaco") {
-        command=listOf("npm", "run", "monaco")
-        dependsOn(npmInstall)
-    }
-
     val test = register<PixiExecTask>("npm_run_test") {
         command=listOf("npm", "run", "test")
         dependsOn(npmInstall)
@@ -50,7 +45,7 @@ tasks {
                 println("@kson/monaco-editor built successfully!")
                 println("  Output: ${distDir.absolutePath}")
                 println()
-                println("Dev server:  ./gradlew tooling:lsp-clients:npm_run_monaco")
+                println("Try it:      ./gradlew tooling:lsp-clients:npm_run_demoIframe")
                 println("Full docs:   tooling/lsp-clients/monaco/readme.md")
                 println("=".repeat(60))
             }

--- a/tooling/lsp-clients/monaco/package.json
+++ b/tooling/lsp-clients/monaco/package.json
@@ -5,9 +5,7 @@
   "description": "Monaco editor with KSON language support and LSP integration",
   "type": "module",
   "scripts": {
-    "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
     "test": "vitest run",
     "build:iframe": "vite build --config vite.iframe.config.ts && vite build --config vite.iframe-client.config.ts"
   },

--- a/tooling/lsp-clients/monaco/readme.md
+++ b/tooling/lsp-clients/monaco/readme.md
@@ -149,8 +149,8 @@ Demos and dev commands for working in the source repo:
 # React demo — attachKsonLsp inside @monaco-editor/react
 ./gradlew tooling:lsp-clients:npm_run_demoReact
 
-# Dev server (vite, with HMR)
-./gradlew tooling:lsp-clients:npm_run_monaco
+# Iframe demo
+./gradlew tooling:lsp-clients:npm_run_demoIframe
 
 # Build library
 ./gradlew tooling:lsp-clients:npm_run_buildMonaco

--- a/tooling/lsp-clients/monaco/vite.config.ts
+++ b/tooling/lsp-clients/monaco/vite.config.ts
@@ -51,8 +51,4 @@ export default defineConfig({
             },
         },
     },
-    server: {
-        port: 5173,
-        open: false,
-    },
 });

--- a/tooling/lsp-clients/package.json
+++ b/tooling/lsp-clients/package.json
@@ -17,8 +17,7 @@
     "compile": "npm run compile -w shared && npm run compile -w vscode",
     "clean": "npm run clean --workspaces --if-present",
     "test": "npm run compile && npm run test --workspaces --if-present",
-    "vscode": "npm run compile && npm run vscode -w vscode",
-    "monaco": "npm run compile && npm run dev -w monaco"
+    "vscode": "npm run compile && npm run vscode -w vscode"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/tooling/lsp-clients/readme.md
+++ b/tooling/lsp-clients/readme.md
@@ -2,12 +2,14 @@
 
 This project contains clients of the [Language Server Protocol](../language-server-protocol). Currently, we have
 a [Monaco](./monaco) client and a [VS Code](./vscode) client.
-The monaco clients can be run with the following gradlew tasks:
+
+The VS Code client can be run with:
 
 ```shell
-./gradlew tooling:lsp-clients:npm_run_monaco
 ./gradlew tooling:lsp-clients:npm_run_vscode
 ```
+
+The Monaco client ships as a library; for a runnable editor see the external [demos](./demos/readme.md).
 
 ## Features
 


### PR DESCRIPTION
The monaco package is a library build with no root `index.html` since #385, so `npm run dev -w monaco` served nothing. Drop the `npm_run_monaco` Gradle task and npm script, remove the orphaned `dev`/`preview` vite scripts and dead dev-server config from the monaco package, and repoint the docs and build output at the external demos (`npm_run_demoLibrary`).