### PR TITLE
Use a user-data-dir in temp space while testing vscode tooling

### DIFF
--- a/tooling/lsp-clients/vscode/test/runTests.ts
+++ b/tooling/lsp-clients/vscode/test/runTests.ts
@@ -1,3 +1,4 @@
+import * as os from 'os';
 import * as path from 'path';
 import {runTests as runBrowserTests} from '@vscode/test-web';
 import {
@@ -53,11 +54,13 @@ async function main() {
             const vscodeExecutablePath = await downloadAndUnzipVSCode('stable');
             console.log('VS Code download complete.');
 
+            const userDataDir = path.join(os.tmpdir(), 'vscode-kson-userdata');
+
             await runNodeTests({
                 vscodeExecutablePath,
                 extensionDevelopmentPath,
                 extensionTestsPath: extensionNodeTestsPath,
-                launchArgs: [testWorkspacePath]
+                launchArgs: [testWorkspacePath, '--user-data-dir', userDataDir]
             });
         }
 


### PR DESCRIPTION
Running the vscode tests causes userdata to be stored near the test itself. When kson is cloned into a deep subdirectory (or just a long path) and we issue a build & test the userdata may be stored in a path that's longer than 103 characters causing a warning that in fact fails the tests. Using os.tmpdir() instead stores the user data in a subdirectory of a platform-specific location such as /tmp, /usr/tmp, C:\temp, etc. allowing us to expect short enough paths to avoid this warning.