### PR TITLE
Honor Monaco and VS Code editor indentation when formatting

### DIFF
--- a/tooling/language-server-protocol/src/core/KsonSettings.ts
+++ b/tooling/language-server-protocol/src/core/KsonSettings.ts
@@ -1,5 +1,6 @@
 import {LSPAny} from "vscode-languageserver";
 import {FormattingStyle} from "kson";
+import {formattingStyleFromId} from "./formattingStyle.js";
 
 /**
  * Configuration settings for the Kson language server.
@@ -24,26 +25,11 @@ export interface KsonSettings {
  * namespace key.
  */
 export function ksonSettingsWithDefaults(settings?: LSPAny): Required<KsonSettings> {
-    // Create FormattingStyle based on the provided settings
-    let formatStyle: FormattingStyle
-    if (settings?.format?.formattingStyle) {
-        // Map lowercase string to uppercase enum value exhaustively
-        const style = settings.format.formattingStyle.toLowerCase();
-        switch (style) {
-            case 'plain':
-                formatStyle = FormattingStyle.PLAIN;
-                break;
-            case 'delimited':
-                formatStyle = FormattingStyle.DELIMITED;
-                break;
-            default:
-                // Default to PLAIN for any unrecognized value
-                formatStyle = FormattingStyle.PLAIN;
-                break;
-        }
-    } else {
-        formatStyle = FormattingStyle.PLAIN;
-    }
+    // Map the configured style string to the FormattingStyle enum, defaulting to
+    // PLAIN when absent/unrecognized. The VS Code config enum only surfaces
+    // "plain"/"delimited", but this shares the command path's mapper, so a
+    // hand-edited settings.json value of "compact"/"classic" is also honored.
+    const formatStyle: FormattingStyle = formattingStyleFromId(settings?.format?.formattingStyle);
 
     // CodeLens enabled by default
     const codeLensEnabled = settings?.codeLens?.enable !== false;

--- a/tooling/language-server-protocol/src/core/KsonSettings.ts
+++ b/tooling/language-server-protocol/src/core/KsonSettings.ts
@@ -1,5 +1,5 @@
 import {LSPAny} from "vscode-languageserver";
-import {FormatOptions, FormattingStyle, IndentType} from "kson";
+import {FormattingStyle} from "kson";
 
 /**
  * Configuration settings for the Kson language server.
@@ -7,9 +7,12 @@ import {FormatOptions, FormattingStyle, IndentType} from "kson";
  * These are the already-unwrapped settings — the server has stripped the
  * configuration namespace (e.g. "kson") before calling
  * {@link ksonSettingsWithDefaults}.
+ *
+ * Indentation is intentionally absent here: it is driven per-request by the
+ * editor's `FormattingOptions` (the "Spaces/Tabs" toggle), not by config.
  */
 export interface KsonSettings {
-    formatOptions: FormatOptions;
+    formattingStyle: FormattingStyle;
     codeLensEnabled: boolean;
 }
 
@@ -21,22 +24,6 @@ export interface KsonSettings {
  * namespace key.
  */
 export function ksonSettingsWithDefaults(settings?: LSPAny): Required<KsonSettings> {
-    // Create IndentType based on the provided settings
-    let indentType: IndentType;
-    if (settings?.format) {
-        const format = settings.format;
-        if (format.insertSpaces === false) {
-            indentType = IndentType.Tabs;
-        } else {
-            // Default to spaces with the specified or default tab size
-            const tabSize = format.tabSize ?? 2;
-            indentType = new IndentType.Spaces(tabSize);
-        }
-    } else {
-        // Use the default from the Kotlin library
-        indentType = new IndentType.Spaces(2);
-    }
-
     // Create FormattingStyle based on the provided settings
     let formatStyle: FormattingStyle
     if (settings?.format?.formattingStyle) {
@@ -62,7 +49,7 @@ export function ksonSettingsWithDefaults(settings?: LSPAny): Required<KsonSettin
     const codeLensEnabled = settings?.codeLens?.enable !== false;
 
     return {
-        formatOptions: new FormatOptions(indentType, formatStyle),
+        formattingStyle: formatStyle,
         codeLensEnabled
     };
 }

--- a/tooling/language-server-protocol/src/core/commands/CommandExecutor.base.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandExecutor.base.ts
@@ -8,6 +8,7 @@ import {FormattingService} from '../features/FormattingService.js';
 import {CommandType} from './CommandType.js';
 import {CommandParameters, isValidCommand} from './CommandParameters.js';
 import {FormatOptions, IndentType} from 'kson';
+import {formattingStyleFromId} from '../formattingStyle.js';
 import {KsonDocument} from "../document/KsonDocument.js";
 
 /**
@@ -66,7 +67,7 @@ export abstract class CommandExecutorBase {
 
                 return this.executeFormat(commandArgs.documentUri, document, new FormatOptions(
                     indentType,
-                    formatArgs.formattingStyle,
+                    formattingStyleFromId(formatArgs.formattingStyle),
                 ));
             }
             case CommandType.ASSOCIATE_SCHEMA: {

--- a/tooling/language-server-protocol/src/core/commands/CommandExecutor.base.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandExecutor.base.ts
@@ -7,8 +7,7 @@ import {KsonDocumentsManager} from '../document/KsonDocumentsManager.js';
 import {FormattingService} from '../features/FormattingService.js';
 import {CommandType} from './CommandType.js';
 import {CommandParameters, isValidCommand} from './CommandParameters.js';
-import {FormatOptions} from 'kson';
-import type {KsonSettings} from '../KsonSettings.js';
+import {FormatOptions, IndentType} from 'kson';
 import {KsonDocument} from "../document/KsonDocument.js";
 
 /**
@@ -20,7 +19,6 @@ export abstract class CommandExecutorBase {
         protected connection: Connection,
         protected documentManager: KsonDocumentsManager,
         protected formattingService: FormattingService,
-        protected getConfiguration: () => Required<KsonSettings>,
         protected workspaceRoot: string | null = null
     ) {
     }
@@ -58,11 +56,17 @@ export abstract class CommandExecutorBase {
             case CommandType.DELIMITED_FORMAT:
             case CommandType.COMPACT_FORMAT:
             case CommandType.CLASSIC_FORMAT: {
-                const indentType = this.getConfiguration().formatOptions.indentType;
+                const formatArgs = commandArgs as CommandParameters[CommandType.PLAIN_FORMAT];
+
+                // Indentation is injected by the client from the active editor; fall back to
+                // two-space indent when absent so the server stays robust without a client.
+                const indentType = formatArgs.insertSpaces === false
+                    ? IndentType.Tabs
+                    : new IndentType.Spaces(formatArgs.tabSize ?? 2);
 
                 return this.executeFormat(commandArgs.documentUri, document, new FormatOptions(
                     indentType,
-                    (commandArgs as CommandParameters[CommandType.PLAIN_FORMAT]).formattingStyle,
+                    formatArgs.formattingStyle,
                 ));
             }
             case CommandType.ASSOCIATE_SCHEMA: {

--- a/tooling/language-server-protocol/src/core/commands/CommandExecutorFactory.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandExecutorFactory.ts
@@ -1,13 +1,11 @@
 import {Connection} from "vscode-languageserver";
 import {FormattingService} from "../features/FormattingService";
 import {KsonDocumentsManager} from "../document/KsonDocumentsManager";
-import {KsonSettings} from "../KsonSettings";
 import {CommandExecutorBase} from "./CommandExecutor.base";
 
 export type CommandExecutorFactory = (
     connection: Connection,
     documentManager: KsonDocumentsManager,
     formattingService: FormattingService,
-    getConfiguration: () => Required<KsonSettings>,
     workspaceRoot: string | null
 ) => CommandExecutorBase;

--- a/tooling/language-server-protocol/src/core/commands/CommandParameters.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandParameters.ts
@@ -9,18 +9,27 @@ export interface CommandParameters {
     [CommandType.PLAIN_FORMAT ]: {
         documentUri: string;
         formattingStyle: FormattingStyle;
+        // Indentation is injected by the client middleware from the active editor.
+        insertSpaces?: boolean;
+        tabSize?: number;
     };
     [CommandType.COMPACT_FORMAT ]: {
         documentUri: string;
         formattingStyle: FormattingStyle;
+        insertSpaces?: boolean;
+        tabSize?: number;
     };
     [CommandType.DELIMITED_FORMAT]: {
         documentUri: string;
         formattingStyle: FormattingStyle;
+        insertSpaces?: boolean;
+        tabSize?: number;
     };
     [CommandType.CLASSIC_FORMAT]: {
         documentUri: string;
         formattingStyle: FormattingStyle;
+        insertSpaces?: boolean;
+        tabSize?: number;
     };
     [CommandType.ASSOCIATE_SCHEMA]: {
         documentUri: string;

--- a/tooling/language-server-protocol/src/core/commands/CommandParameters.ts
+++ b/tooling/language-server-protocol/src/core/commands/CommandParameters.ts
@@ -1,6 +1,6 @@
 import { CommandType } from './CommandType.js';
 import { Command } from 'vscode-languageserver';
-import { FormattingStyle } from 'kson';
+import { FormattingStyleId } from '../formattingStyle.js';
 
 /**
  * Type-safe mapping of command types to their expected parameter structures
@@ -8,26 +8,27 @@ import { FormattingStyle } from 'kson';
 export interface CommandParameters {
     [CommandType.PLAIN_FORMAT ]: {
         documentUri: string;
-        formattingStyle: FormattingStyle;
+        // Carried as the style id (lowercase enum name); the server maps it via formattingStyleFromId.
+        formattingStyle: FormattingStyleId;
         // Indentation is injected by the client middleware from the active editor.
         insertSpaces?: boolean;
         tabSize?: number;
     };
     [CommandType.COMPACT_FORMAT ]: {
         documentUri: string;
-        formattingStyle: FormattingStyle;
+        formattingStyle: FormattingStyleId;
         insertSpaces?: boolean;
         tabSize?: number;
     };
     [CommandType.DELIMITED_FORMAT]: {
         documentUri: string;
-        formattingStyle: FormattingStyle;
+        formattingStyle: FormattingStyleId;
         insertSpaces?: boolean;
         tabSize?: number;
     };
     [CommandType.CLASSIC_FORMAT]: {
         documentUri: string;
-        formattingStyle: FormattingStyle;
+        formattingStyle: FormattingStyleId;
         insertSpaces?: boolean;
         tabSize?: number;
     };

--- a/tooling/language-server-protocol/src/core/commands/createCommandExecutor.browser.ts
+++ b/tooling/language-server-protocol/src/core/commands/createCommandExecutor.browser.ts
@@ -1,7 +1,6 @@
 import {Connection} from 'vscode-languageserver';
 import {KsonDocumentsManager} from '../document/KsonDocumentsManager.js';
 import {FormattingService} from '../features/FormattingService.js';
-import type {KsonSettings} from '../KsonSettings.js';
 import {CommandExecutor} from './CommandExecutor.browser.js';
 
 /**
@@ -12,14 +11,12 @@ export function createCommandExecutor(
     connection: Connection,
     documentManager: KsonDocumentsManager,
     formattingService: FormattingService,
-    getConfiguration: () => Required<KsonSettings>,
     workspaceRoot: string | null = null
 ): CommandExecutor {
     return new CommandExecutor(
         connection,
         documentManager,
         formattingService,
-        getConfiguration,
         workspaceRoot
     );
 }

--- a/tooling/language-server-protocol/src/core/commands/createCommandExecutor.node.ts
+++ b/tooling/language-server-protocol/src/core/commands/createCommandExecutor.node.ts
@@ -1,7 +1,6 @@
 import {Connection} from 'vscode-languageserver';
 import {KsonDocumentsManager} from '../document/KsonDocumentsManager.js';
 import {FormattingService} from '../features/FormattingService.js';
-import type {KsonSettings} from '../KsonSettings.js';
 import {CommandExecutor} from './CommandExecutor.node.js';
 
 /**
@@ -12,14 +11,12 @@ export function createCommandExecutor(
     connection: Connection,
     documentManager: KsonDocumentsManager,
     formattingService: FormattingService,
-    getConfiguration: () => Required<KsonSettings>,
     workspaceRoot: string | null = null
 ): CommandExecutor {
     return new CommandExecutor(
         connection,
         documentManager,
         formattingService,
-        getConfiguration,
         workspaceRoot
     );
 }

--- a/tooling/language-server-protocol/src/core/features/CodeLensService.ts
+++ b/tooling/language-server-protocol/src/core/features/CodeLensService.ts
@@ -3,6 +3,7 @@ import { KsonDocument } from '../document/KsonDocument.js';
 import { CommandType } from '../commands/CommandType.js';
 import { createTypedCommand } from '../commands/CommandParameters.js';
 import { FormattingStyle } from 'kson';
+import { formattingStyleId } from '../formattingStyle.js';
 
 /**
  * Service responsible for providing code lenses for Kson documents
@@ -13,28 +14,32 @@ export class CodeLensService {
      * Get code lenses for a Kson document.
     */
     getCodeLenses(document: KsonDocument): CodeLens[] {
+        const plainId = formattingStyleId(FormattingStyle.PLAIN);
         const formatCommand = createTypedCommand(
             CommandType.PLAIN_FORMAT,
-            'plain',
-            { documentUri: document.uri, formattingStyle: FormattingStyle.PLAIN}
+            plainId,
+            { documentUri: document.uri, formattingStyle: plainId }
         );
 
+        const delimitedId = formattingStyleId(FormattingStyle.DELIMITED);
         const delimitedFormatCommand = createTypedCommand(
             CommandType.DELIMITED_FORMAT,
-            'delimited',
-            { documentUri: document.uri, formattingStyle: FormattingStyle.DELIMITED }
+            delimitedId,
+            { documentUri: document.uri, formattingStyle: delimitedId }
         );
 
+        const compactId = formattingStyleId(FormattingStyle.COMPACT);
         const compactFormatCommand = createTypedCommand(
             CommandType.COMPACT_FORMAT,
-            'compact',
-            { documentUri: document.uri, formattingStyle: FormattingStyle.COMPACT }
+            compactId,
+            { documentUri: document.uri, formattingStyle: compactId }
         );
 
+        const classicId = formattingStyleId(FormattingStyle.CLASSIC);
         const classicFormatCommand = createTypedCommand(
             CommandType.CLASSIC_FORMAT,
-            'classic',
-            { documentUri: document.uri, formattingStyle: FormattingStyle.CLASSIC }
+            classicId,
+            { documentUri: document.uri, formattingStyle: classicId }
         );
 
         // Place both lenses at the start of the document

--- a/tooling/language-server-protocol/src/core/formattingStyle.ts
+++ b/tooling/language-server-protocol/src/core/formattingStyle.ts
@@ -1,0 +1,32 @@
+import {FormattingStyle} from 'kson';
+
+/**
+ * Wire/display id for a formatting style: the Kotlin enum's stable name lowercased
+ * ("plain", "delimited", ...), rather than its minified internal fields. Derived
+ * directly from {@link FormattingStyle} so it can never drift from the enum's own
+ * set of names, and matches the lowercase values the VS Code config surfaces.
+ */
+export type FormattingStyleId = Lowercase<FormattingStyle['name']>;
+
+/**
+ * The wire/display id for a {@link FormattingStyle} — its lowercased enum name.
+ */
+export function formattingStyleId(style: FormattingStyle): FormattingStyleId {
+    return style.name.toLowerCase() as FormattingStyleId;
+}
+
+/**
+ * Resolve a style id back to the {@link FormattingStyle} enum via its canonical
+ * {@link FormattingStyle.valueOf}. Case-insensitive and defaults to
+ * {@link FormattingStyle.PLAIN} for anything absent or unrecognized.
+ */
+export function formattingStyleFromId(id?: string): FormattingStyle {
+    if (!id) {
+        return FormattingStyle.PLAIN;
+    }
+    try {
+        return FormattingStyle.valueOf(id.toUpperCase());
+    } catch {
+        return FormattingStyle.PLAIN;
+    }
+}

--- a/tooling/language-server-protocol/src/core/services/KsonTextDocumentService.ts
+++ b/tooling/language-server-protocol/src/core/services/KsonTextDocumentService.ts
@@ -43,6 +43,7 @@ import {
     toWireCommandId,
 } from '../commands/CommandType.js';
 import {KsonSettings, ksonSettingsWithDefaults} from '../KsonSettings.js';
+import {FormatOptions, IndentType} from 'kson';
 
 
 /**
@@ -106,7 +107,6 @@ export class KsonTextDocumentService {
             this.connection,
             this.documentManager,
             this.formattingService,
-            () => this.configuration,
             this.workspaceRoot
         );
 
@@ -163,7 +163,12 @@ export class KsonTextDocumentService {
             if (!document) {
                 return [];
             }
-            return this.formattingService.formatDocument(document, this.configuration.formatOptions);
+            // The editor's indentation arrives per-request; it is the source of truth.
+            const indentType = params.options.insertSpaces
+                ? new IndentType.Spaces(params.options.tabSize)
+                : IndentType.Tabs;
+            const formatOptions = new FormatOptions(indentType, this.configuration.formattingStyle);
+            return this.formattingService.formatDocument(document, formatOptions);
         } catch (error) {
             this.connection.console.error(`Error formatting document: ${error}`);
             return [];

--- a/tooling/language-server-protocol/src/test/core/commands/CommandExecutor.test.ts
+++ b/tooling/language-server-protocol/src/test/core/commands/CommandExecutor.test.ts
@@ -13,6 +13,7 @@ import {
 } from "vscode-languageserver";
 import {CommandType, toWireCommandId} from "../../../core/commands/CommandType";
 import {FormattingStyle} from "kson";
+import {FormattingStyleId, formattingStyleId} from "../../../core/formattingStyle";
 import {RemoteWorkspace} from "vscode-languageserver/lib/common/server";
 import {createCommandExecutor} from "../../../core/commands/createCommandExecutor.node.js";
 
@@ -76,7 +77,7 @@ function buildWorkspaceEdit(uri: string, replaceRange: Range, newText: string): 
     };
 }
 
-function buildCommandParams(command: CommandType, uri: string, style: FormattingStyle): ExecuteCommandParams {
+function buildCommandParams(command: CommandType, uri: string, style: FormattingStyleId): ExecuteCommandParams {
     return {
         command: toWireCommandId(command, TEST_DISTRIBUTION_ID),
         arguments: [{ documentUri: uri, formattingStyle: style }]
@@ -125,7 +126,7 @@ describe('KSON Command Executor', () => {
         const expected = buildWorkspaceEdit(TEST_URI,
             Range.create(0, 0, 0, 10)
             , 'x: 1');
-        const commandParams = buildCommandParams(CommandType.PLAIN_FORMAT, TEST_URI, FormattingStyle.PLAIN);
+        const commandParams = buildCommandParams(CommandType.PLAIN_FORMAT, TEST_URI, formattingStyleId(FormattingStyle.PLAIN));
         
         await executeAndAssertCommand(content, expected, commandParams);
     });
@@ -138,7 +139,7 @@ describe('KSON Command Executor', () => {
             '}'
         ].join('\n');
         const expected = buildWorkspaceEdit(TEST_URI, Range.create(0, 0, 0, 10), expectedContent);
-        const commandParams = buildCommandParams(CommandType.DELIMITED_FORMAT, TEST_URI, FormattingStyle.DELIMITED);
+        const commandParams = buildCommandParams(CommandType.DELIMITED_FORMAT, TEST_URI, formattingStyleId(FormattingStyle.DELIMITED));
         
         await executeAndAssertCommand(content, expected, commandParams);
     });
@@ -146,7 +147,7 @@ describe('KSON Command Executor', () => {
     it('should execute compact formatting', async () => {
         const content = '{"x" : 1, "y" : 2}';
         const expected = buildWorkspaceEdit(TEST_URI, Range.create(0, 0, 0, 18), 'x:1 y:2');
-        const commandParams = buildCommandParams(CommandType.COMPACT_FORMAT, TEST_URI, FormattingStyle.COMPACT);
+        const commandParams = buildCommandParams(CommandType.COMPACT_FORMAT, TEST_URI, formattingStyleId(FormattingStyle.COMPACT));
         
         await executeAndAssertCommand(content, expected, commandParams);
     });
@@ -160,7 +161,7 @@ describe('KSON Command Executor', () => {
             '}'
         ].join('\n');
         const expected = buildWorkspaceEdit(TEST_URI, Range.create(0, 0, 0, 18), expectedContent);
-        const commandParams = buildCommandParams(CommandType.CLASSIC_FORMAT, TEST_URI, FormattingStyle.CLASSIC);
+        const commandParams = buildCommandParams(CommandType.CLASSIC_FORMAT, TEST_URI, formattingStyleId(FormattingStyle.CLASSIC));
 
         await executeAndAssertCommand(content, expected, commandParams);
     });

--- a/tooling/language-server-protocol/src/test/core/features/CodeLensService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/CodeLensService.test.ts
@@ -2,7 +2,8 @@ import {CodeLensService} from '../../../core/features/CodeLensService.js';
 import {CommandType} from '../../../core/commands/CommandType.js';
 import {describe, it} from 'mocha';
 import assert from 'assert';
-import {FormattingStyle} from 'kson'
+import {FormattingStyle} from 'kson';
+import {formattingStyleId} from '../../../core/formattingStyle.js';
 import {createKsonDocument, TEST_URI} from '../../TestHelpers.js';
 import {TextDocument} from 'vscode-languageserver-textdocument';
 import {KsonDocument, parseTextDocument} from '../../../core/document/KsonDocument.js';
@@ -44,10 +45,10 @@ describe('CodeLensService', () => {
         const document = createKsonDocument('key: value');
         const lenses = service.getCodeLenses(document);
 
-        assert.strictEqual(lenses[0].command?.arguments?.[0].formattingStyle, FormattingStyle.PLAIN);
-        assert.strictEqual(lenses[1].command?.arguments?.[0].formattingStyle, FormattingStyle.DELIMITED);
-        assert.strictEqual(lenses[2].command?.arguments?.[0].formattingStyle, FormattingStyle.CLASSIC);
-        assert.strictEqual(lenses[3].command?.arguments?.[0].formattingStyle, FormattingStyle.COMPACT);
+        assert.strictEqual(lenses[0].command?.arguments?.[0].formattingStyle, formattingStyleId(FormattingStyle.PLAIN));
+        assert.strictEqual(lenses[1].command?.arguments?.[0].formattingStyle, formattingStyleId(FormattingStyle.DELIMITED));
+        assert.strictEqual(lenses[2].command?.arguments?.[0].formattingStyle, formattingStyleId(FormattingStyle.CLASSIC));
+        assert.strictEqual(lenses[3].command?.arguments?.[0].formattingStyle, formattingStyleId(FormattingStyle.COMPACT));
     });
 
     it('should place all lenses at line 0, character 0', () => {

--- a/tooling/language-server-protocol/src/test/core/features/FormattingService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/FormattingService.test.ts
@@ -4,7 +4,7 @@ import {KsonDocument} from '../../../core/document/KsonDocument.js';
 import {KsonTooling} from 'kson-tooling';
 import {describe, it} from 'mocha';
 import assert from "assert";
-import {ksonSettingsWithDefaults} from "../../../core/KsonSettings";
+import {FormatOptions, FormattingStyle, IndentType} from 'kson';
 
 /**
  * Tests for testing the JSON document formatting functionality.
@@ -22,14 +22,10 @@ describe('KSON Formatter', () => {
             KsonTooling.getInstance().parse(unformatted),
         );
 
-        const ksonSettings = ksonSettingsWithDefaults({
-            format: {
-                insertSpaces: insertSpaces,
-                tabSize: 2
-            }
-        })
+        const indentType = insertSpaces ? new IndentType.Spaces(2) : IndentType.Tabs;
+        const formatOptions = new FormatOptions(indentType, FormattingStyle.PLAIN);
 
-        const edits = formattingService.formatDocument(ksonDocument, ksonSettings.formatOptions);
+        const edits = formattingService.formatDocument(ksonDocument, formatOptions);
         const formatted = applyEdits(document, edits);
 
         assert.strictEqual(formatted, expected, 'should have a matching formatted document');

--- a/tooling/language-server-protocol/src/test/core/services/KsonTextDocumentService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/services/KsonTextDocumentService.test.ts
@@ -45,9 +45,9 @@ describe('KsonTextDocumentService', () => {
     }
 
     describe('Formatting', () => {
-        async function assertFormatting(content: string, expected: string) {
+        async function assertFormatting(content: string, expected: string, tabSize = 2, insertSpaces = true) {
             openDocument(content);
-            const result = await connection.requestFormatting(TEST_URI);
+            const result = await connection.requestFormatting(TEST_URI, tabSize, insertSpaces);
             assert.ok(result, "should not get a null or undefined result");
 
             const textEdits = result as TextEdit[];
@@ -66,6 +66,24 @@ describe('KsonTextDocumentService', () => {
                 '  age: 30'
             ].join('\n');
             await assertFormatting('person:{name:"John",age:30}', expected);
+        });
+
+        it('should indent with tabs when insertSpaces is false', async () => {
+            const expected = [
+                'person:',
+                '\tname: John',
+                '\tage: 30'
+            ].join('\n');
+            await assertFormatting('person:{name:"John",age:30}', expected, 2, false);
+        });
+
+        it('should honor a non-default tabSize', async () => {
+            const expected = [
+                'person:',
+                '    name: John',
+                '    age: 30'
+            ].join('\n');
+            await assertFormatting('person:{name:"John",age:30}', expected, 4, true);
         });
 
         it('should return empty array when document is not found', async () => {

--- a/tooling/lsp-clients/monaco/package.json
+++ b/tooling/lsp-clients/monaco/package.json
@@ -36,7 +36,8 @@
   },
   "files": ["dist", "readme.md"],
   "dependencies": {
-    "@kson/lsp-shared": "file:../shared"
+    "@kson/lsp-shared": "file:../shared",
+    "kson-language-server": "file:../../language-server-protocol"
   },
   "peerDependencies": {
     "monaco-editor": ">=0.50.0",

--- a/tooling/lsp-clients/monaco/src/bridge/KsonLspBridge.test.ts
+++ b/tooling/lsp-clients/monaco/src/bridge/KsonLspBridge.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, beforeEach } from 'vitest';
-import { KsonLspBridge, type KsonLspBridgeOptions } from './KsonLspBridge.js';
+import { KsonLspBridge, type KsonLspBridgeOptions, type ServerCapabilities } from './KsonLspBridge.js';
+import { editor as monacoStubEditor } from '../test/monacoStub.js';
 
 /**
  * Stub worker that captures posted messages and lets tests respond to them.
@@ -19,6 +20,15 @@ class WorkerStub {
         for (const msg of this.posted) {
             if (msg.method === 'initialize' && msg.id !== undefined) {
                 this.onmessage?.({ data: { jsonrpc: '2.0', id: msg.id, result: { capabilities: {} } } } as MessageEvent);
+            }
+        }
+    }
+
+    /** Resolve every posted request for `method` with the given result. */
+    respondTo(method: string, result: unknown = null): void {
+        for (const msg of this.posted) {
+            if (msg.method === method && msg.id !== undefined) {
+                this.onmessage?.({ data: { jsonrpc: '2.0', id: msg.id, result } } as MessageEvent);
             }
         }
     }
@@ -104,5 +114,99 @@ describe('KsonLspBridge.initialize — enableBundledSchemas defaulting', () => {
         // Inference only fires when initializationOptions is provided; treat absent
         // bundledSchemas as "no schemas" → false.
         expect(params.initializationOptions?.enableBundledSchemas).toBe(false);
+    });
+});
+
+describe('KsonLspBridge.registerLspCommands — format indentation injection', () => {
+    const TARGET_URI = 'file:///doc.kson';
+
+    beforeEach(() => {
+        monacoStubEditor.__reset();
+    });
+
+    /**
+     * Attach a bridge to a fake editor so the server's commands get registered,
+     * and register the target model (tabs, size 4) that those commands address.
+     */
+    function registerServerCommands(commands: string[]): { worker: WorkerStub; bridge: KsonLspBridge } {
+        const worker = new WorkerStub();
+        const bridge = new KsonLspBridge(worker as unknown as Worker);
+        const model = {
+            uri: { toString: () => TARGET_URI },
+            getValue: () => '',
+            onDidChangeContent: () => ({ dispose: () => {} }),
+            getOptions: () => ({ insertSpaces: false, tabSize: 4 }),
+        };
+        monacoStubEditor.__setModel(TARGET_URI, model);
+        bridge.attachToEditor(
+            { getModel: () => model } as unknown as Parameters<KsonLspBridge['attachToEditor']>[0],
+            'kson',
+            { executeCommandProvider: { commands } } as ServerCapabilities,
+        );
+        return { worker, bridge };
+    }
+
+    it('injects the target model insertSpaces/tabSize into a format command', async () => {
+        const { worker, bridge } = registerServerCommands(['kson.plainFormat']);
+
+        const handler = monacoStubEditor.__getCommand('kson.plainFormat');
+        expect(handler).toBeDefined();
+        const pending = handler!(null, { documentUri: TARGET_URI, formattingStyle: 'plain' });
+        worker.respondTo('workspace/executeCommand');
+        await pending;
+
+        const exec = worker.posted.find((m) => m.method === 'workspace/executeCommand');
+        expect(exec?.params).toEqual({
+            command: 'kson.plainFormat',
+            arguments: [{
+                documentUri: TARGET_URI,
+                formattingStyle: 'plain',
+                insertSpaces: false,
+                tabSize: 4,
+            }],
+        });
+
+        bridge.dispose();
+    });
+
+    it('falls back to spaces/tabSize 2 when the target model is not resolvable', async () => {
+        const { worker, bridge } = registerServerCommands(['kson.plainFormat']);
+
+        // documentUri addresses a model that was never registered → getModel returns null.
+        const handler = monacoStubEditor.__getCommand('kson.plainFormat');
+        const pending = handler!(null, { documentUri: 'file:///untracked.kson', formattingStyle: 'plain' });
+        worker.respondTo('workspace/executeCommand');
+        await pending;
+
+        const exec = worker.posted.find((m) => m.method === 'workspace/executeCommand');
+        expect(exec?.params).toEqual({
+            command: 'kson.plainFormat',
+            arguments: [{
+                documentUri: 'file:///untracked.kson',
+                formattingStyle: 'plain',
+                insertSpaces: true,
+                tabSize: 2,
+            }],
+        });
+
+        bridge.dispose();
+    });
+
+    it('passes a non-format command through without injecting indentation', async () => {
+        const { worker, bridge } = registerServerCommands(['kson.associateSchema']);
+
+        const handler = monacoStubEditor.__getCommand('kson.associateSchema');
+        expect(handler).toBeDefined();
+        const pending = handler!(null, { documentUri: TARGET_URI, schemaName: 'config' });
+        worker.respondTo('workspace/executeCommand');
+        await pending;
+
+        const exec = worker.posted.find((m) => m.method === 'workspace/executeCommand');
+        expect(exec?.params).toEqual({
+            command: 'kson.associateSchema',
+            arguments: [{ documentUri: TARGET_URI, schemaName: 'config' }],
+        });
+
+        bridge.dispose();
     });
 });

--- a/tooling/lsp-clients/monaco/src/bridge/KsonLspBridge.test.ts
+++ b/tooling/lsp-clients/monaco/src/bridge/KsonLspBridge.test.ts
@@ -197,14 +197,14 @@ describe('KsonLspBridge.registerLspCommands — format indentation injection', (
 
         const handler = monacoStubEditor.__getCommand('kson.associateSchema');
         expect(handler).toBeDefined();
-        const pending = handler!(null, { documentUri: TARGET_URI, schemaName: 'config' });
+        const pending = handler!(null, { documentUri: TARGET_URI, schemaPath: 'config' });
         worker.respondTo('workspace/executeCommand');
         await pending;
 
         const exec = worker.posted.find((m) => m.method === 'workspace/executeCommand');
         expect(exec?.params).toEqual({
             command: 'kson.associateSchema',
-            arguments: [{ documentUri: TARGET_URI, schemaName: 'config' }],
+            arguments: [{ documentUri: TARGET_URI, schemaPath: 'config' }],
         });
 
         bridge.dispose();

--- a/tooling/lsp-clients/monaco/src/bridge/KsonLspBridge.ts
+++ b/tooling/lsp-clients/monaco/src/bridge/KsonLspBridge.ts
@@ -6,6 +6,7 @@
  */
 
 import * as monaco from 'monaco-editor';
+import { CommandType } from 'kson-language-server';
 import { KSON_LANGUAGE_ID } from '../language/ksonLanguage.js';
 import { JsonRpcConnection } from './JsonRpcConnection.js';
 import {
@@ -32,6 +33,19 @@ import {
     type LspSemanticTokensLegend,
     type LspDiagnostic,
 } from './lspToMonaco.js';
+
+/** Wire ids for the four formatting commands are `${distributionId}.${CommandType}`. */
+const FORMAT_COMMAND_TYPES: CommandType[] = [
+    CommandType.PLAIN_FORMAT,
+    CommandType.DELIMITED_FORMAT,
+    CommandType.COMPACT_FORMAT,
+    CommandType.CLASSIC_FORMAT,
+];
+
+/** Match a format command by its wire-id suffix, staying agnostic to the distribution id. */
+function isFormatCommandId(command: string): boolean {
+    return FORMAT_COMMAND_TYPES.some(type => command.endsWith(`.${type}`));
+}
 
 const DIAGNOSTIC_DEBOUNCE_MS = 300;
 
@@ -281,6 +295,20 @@ export class KsonLspBridge {
             this.disposables.push(
                 monaco.editor.registerCommand(commandId, async (_accessor, ...args: unknown[]) => {
                     try {
+                        // The editor's indentation (the Spaces/Tabs toggle) is the source of truth
+                        // for formatting. textDocument/formatting carries it automatically, but the
+                        // CodeLens format buttons run commands with no such params — inject it from
+                        // the target model so the buttons honor the editor setting too.
+                        if (isFormatCommandId(commandId)) {
+                            const first = (args[0] ?? {}) as { documentUri?: string };
+                            const model = first.documentUri
+                                ? monaco.editor.getModel(monaco.Uri.parse(first.documentUri))
+                                : null;
+                            const options = model?.getOptions();
+                            const insertSpaces = options?.insertSpaces ?? true;
+                            const tabSize = options?.tabSize ?? 2;
+                            args = [{ ...first, insertSpaces, tabSize }, ...args.slice(1)];
+                        }
                         await this.connection.sendRequest('workspace/executeCommand', {
                             command: commandId,
                             arguments: args,

--- a/tooling/lsp-clients/monaco/src/test/monacoStub.ts
+++ b/tooling/lsp-clients/monaco/src/test/monacoStub.ts
@@ -20,18 +20,42 @@ export const Uri = {
     parse: (uri: string) => ({ toString: () => uri, scheme: 'file', path: uri }),
 };
 
+// Test seams: the bridge registers server commands and resolves models by uri.
+// These registries let tests invoke a registered command and control the
+// indentation a model reports. The `__` helpers are not part of the real
+// monaco-editor API.
+const registeredCommands = new Map<string, (...args: unknown[]) => unknown>();
+const modelsByUri = new Map<string, unknown>();
+
 export const editor = {
-    registerCommand: () => ({ dispose: () => {} }),
+    registerCommand: (id: string, handler: (...args: unknown[]) => unknown) => {
+        registeredCommands.set(id, handler);
+        return { dispose: () => registeredCommands.delete(id) };
+    },
     registerEditorOpener: () => ({ dispose: () => {} }),
     createModel: () => ({}),
-    getModel: () => null,
+    getModel: (uri?: { toString(): string }) =>
+        uri ? modelsByUri.get(uri.toString()) ?? null : null,
     setModelMarkers: () => {},
+    /** Test-only: retrieve a handler registered via registerCommand. */
+    __getCommand: (id: string) => registeredCommands.get(id),
+    /** Test-only: register a model so getModel(uri) resolves it. */
+    __setModel: (uri: string, model: unknown) => { modelsByUri.set(uri, model); },
+    /** Test-only: clear all registered commands and models. */
+    __reset: () => { registeredCommands.clear(); modelsByUri.clear(); },
 };
 
 export const languages = {
     register: () => {},
     setLanguageConfiguration: () => {},
     setMonarchTokensProvider: () => {},
+    registerCompletionItemProvider: () => ({ dispose: () => {} }),
+    registerHoverProvider: () => ({ dispose: () => {} }),
+    registerDefinitionProvider: () => ({ dispose: () => {} }),
+    registerDocumentSymbolProvider: () => ({ dispose: () => {} }),
+    registerDocumentHighlightProvider: () => ({ dispose: () => {} }),
+    registerDocumentFormattingEditProvider: () => ({ dispose: () => {} }),
+    registerCodeLensProvider: () => ({ dispose: () => {} }),
     CompletionItemKind: {
         Text: 0, Method: 1, Function: 2, Constructor: 3, Field: 4,
         Variable: 5, Class: 6, Interface: 7, Module: 8, Property: 9,

--- a/tooling/lsp-clients/package-lock.json
+++ b/tooling/lsp-clients/package-lock.json
@@ -42,7 +42,8 @@
       "version": "0.3.0-dev.0",
       "license": "ISC",
       "dependencies": {
-        "@kson/lsp-shared": "file:../shared"
+        "@kson/lsp-shared": "file:../shared",
+        "kson-language-server": "file:../../language-server-protocol"
       },
       "devDependencies": {
         "@types/react": "^18.3.0",

--- a/tooling/lsp-clients/vscode/package.json
+++ b/tooling/lsp-clients/vscode/package.json
@@ -87,17 +87,6 @@
           "default": true,
           "description": "Enable bundled schemas for configured KSON languages. When enabled, KSON languages with bundled schemas will automatically provide hover, completions, and validation."
         },
-        "kson.format.tabSize": {
-          "type": "number",
-          "default": 2,
-          "minimum": 1,
-          "description": "Number of spaces for indentation"
-        },
-        "kson.format.insertSpaces": {
-          "type": "boolean",
-          "default": true,
-          "description": "Use spaces instead of tabs for indentation"
-        },
         "kson.format.formattingStyle": {
           "type": "string",
           "enum": [

--- a/tooling/lsp-clients/vscode/src/config/clientOptions.ts
+++ b/tooling/lsp-clients/vscode/src/config/clientOptions.ts
@@ -6,9 +6,22 @@ import {
     DocumentSelector,
 } from 'vscode-languageclient';
 import { getLanguageConfiguration } from './languageConfig';
-import type { KsonInitializationOptions } from 'kson-language-server';
+import { CommandType, type KsonInitializationOptions } from 'kson-language-server';
 
 const MAX_RESTART_COUNT = 3;
+
+/** Wire ids for the four formatting commands are `${distributionId}.${CommandType}`. */
+const FORMAT_COMMAND_TYPES: CommandType[] = [
+    CommandType.PLAIN_FORMAT,
+    CommandType.DELIMITED_FORMAT,
+    CommandType.COMPACT_FORMAT,
+    CommandType.CLASSIC_FORMAT,
+];
+
+/** Match a format command by its wire-id suffix, staying agnostic to the distribution id. */
+function isFormatCommandId(command: string): boolean {
+    return FORMAT_COMMAND_TYPES.some(type => command.endsWith(`.${type}`));
+}
 
 /**
  * Create shared client options.
@@ -41,6 +54,21 @@ export const createClientOptions = (
             fileEvents: vscode.workspace.createFileSystemWatcher(fileWatcherPattern)
         },
         outputChannel,
+        middleware: {
+            // The editor's indentation (the "Spaces/Tabs" status-bar toggle) is the source of
+            // truth for formatting. DocumentFormattingParams carry it automatically, but the
+            // CodeLens format buttons run commands with no such params — inject it here so the
+            // buttons honor the editor setting too.
+            executeCommand: (command, args, next) => {
+                if (isFormatCommandId(command)) {
+                    const options = vscode.window.activeTextEditor?.options;
+                    const insertSpaces = typeof options?.insertSpaces === 'boolean' ? options.insertSpaces : true;
+                    const tabSize = typeof options?.tabSize === 'number' ? options.tabSize : 2;
+                    args = [{ ...(args?.[0] ?? {}), insertSpaces, tabSize }, ...args.slice(1)];
+                }
+                return next(command, args);
+            }
+        },
         errorHandler: {
             error: () => ({action: ErrorAction.Continue}),
             closed: () => {

--- a/tooling/lsp-clients/vscode/test/suite/formatting-settings.test.ts
+++ b/tooling/lsp-clients/vscode/test/suite/formatting-settings.test.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import {createTestFile, cleanUp, pollUntil} from './common';
+import { assert } from './assert';
 
 
 describe('Formatting Settings Test Suite', () => {
@@ -12,6 +13,16 @@ describe('Formatting Settings Test Suite', () => {
         // always fetch from the workspace to ensure we see the latest edits
         return vscode.workspace.openTextDocument(testFileUri!);
     };
+
+    /**
+     * Show the test document and set the editor's indentation (the "Spaces/Tabs"
+     * status-bar toggle), which is the source of truth the formatter reads.
+     */
+    async function showWithIndentation(insertSpaces: boolean, tabSize: number): Promise<vscode.TextEditor> {
+        const editor = await vscode.window.showTextDocument(await document());
+        editor.options = { insertSpaces, tabSize };
+        return editor;
+    }
 
     /**
      * Format the document and poll until the result matches the expected text.
@@ -48,10 +59,9 @@ describe('Formatting Settings Test Suite', () => {
     })
 
     afterEach(async () => {
-        // Reset all kson settings to defaults before cleaning up
+        // Reset kson settings to defaults before cleaning up. Indentation is per-editor
+        // (gone when the editor closes in cleanUp), so only the style needs resetting.
         const config = vscode.workspace.getConfiguration('kson');
-        await config.update('format.insertSpaces', undefined, vscode.ConfigurationTarget.Workspace);
-        await config.update('format.tabSize', undefined, vscode.ConfigurationTarget.Workspace);
         await config.update('format.formattingStyle', undefined, vscode.ConfigurationTarget.Workspace);
 
         if (testFileUri) {
@@ -60,12 +70,8 @@ describe('Formatting Settings Test Suite', () => {
         }
     });
 
-    it('Should format with 8 spaces when insertSpaces is true', async () => {
-        // Update settings to use spaces with 8-space indentation
-        const config = vscode.workspace.getConfiguration('kson');
-        await config.update('format.insertSpaces', true, vscode.ConfigurationTarget.Workspace);
-        await config.update('format.tabSize', 8, vscode.ConfigurationTarget.Workspace);
-        await config.update('format.formattingStyle', 'plain', vscode.ConfigurationTarget.Workspace);
+    it('Should format with 8 spaces when the editor uses 8-wide spaces', async () => {
+        await showWithIndentation(true, 8);
 
         const expectedText = [
             'a: 1',
@@ -76,12 +82,8 @@ describe('Formatting Settings Test Suite', () => {
         await formatAndAwait(expectedText);
     }).timeout(10000);
 
-    it('Should format with tabs when insertSpaces is false', async () => {
-        // Update settings to use tabs
-        const config = vscode.workspace.getConfiguration('kson');
-        await config.update('format.insertSpaces', false, vscode.ConfigurationTarget.Workspace);
-        await config.update('format.tabSize', 4, vscode.ConfigurationTarget.Workspace);
-        await config.update('format.formattingStyle', 'plain', vscode.ConfigurationTarget.Workspace);
+    it('Should format with tabs when the editor uses tabs', async () => {
+        await showWithIndentation(false, 4);
 
         const expectedText = [
             'a: 1',
@@ -93,11 +95,12 @@ describe('Formatting Settings Test Suite', () => {
     }).timeout(10000);
 
     it('Should format delimited when formattingStyle is delimited', async () => {
-        // Update settings to use delimited formatting with spaces
+        // Style has no editor equivalent, so it stays a kson config key.
         const config = vscode.workspace.getConfiguration('kson');
-        await config.update('format.insertSpaces', true, vscode.ConfigurationTarget.Workspace);
-        await config.update('format.tabSize', 2, vscode.ConfigurationTarget.Workspace);
         await config.update('format.formattingStyle', "delimited", vscode.ConfigurationTarget.Workspace);
+
+        // Pin the editor indentation so the delimited output is deterministic.
+        await showWithIndentation(true, 2);
 
         const expectedText = [
             '{',
@@ -111,7 +114,7 @@ describe('Formatting Settings Test Suite', () => {
         await formatAndAwait(expectedText);
     }).timeout(10000);
 
-    it('Should update formatting when settings change dynamically', async () => {
+    it('Should update formatting when the editor indentation changes', async () => {
         const expectedSpacesText = [
             'a: 1',
             'b:',
@@ -123,18 +126,47 @@ describe('Formatting Settings Test Suite', () => {
             '\tc: 2'
         ].join('\n');
 
-        const config = vscode.workspace.getConfiguration('kson');
-
         // First format with spaces
-        await config.update('format.insertSpaces', true, vscode.ConfigurationTarget.Workspace);
-        await config.update('format.tabSize', 2, vscode.ConfigurationTarget.Workspace);
-        await config.update('format.formattingStyle', 'plain', vscode.ConfigurationTarget.Workspace);
-
+        const editor = await showWithIndentation(true, 2);
         await formatAndAwait(expectedSpacesText);
 
-        // Now change to tabs
-        await config.update('format.insertSpaces', false, vscode.ConfigurationTarget.Workspace);
-
+        // Now switch the same editor to tabs
+        editor.options = { insertSpaces: false, tabSize: 2 };
         await formatAndAwait(expectedTabsText);
+    }).timeout(15000);
+
+    it('Should honor the editor indentation when running a CodeLens format command', async () => {
+        // Resolve the real CodeLenses so we invoke the exact wire command + args the buttons use.
+        const lenses = await pollUntil(
+            () => vscode.commands.executeCommand<vscode.CodeLens[]>('vscode.executeCodeLensProvider', testFileUri!),
+            result => !!result && result.length > 0,
+            { timeout: 5000, message: 'No code lenses resolved' }
+        );
+
+        const plainLens = lenses.find(lens => lens.command?.command.endsWith('.plainFormat'));
+        assert.ok(plainLens?.command, 'Expected a plainFormat code lens');
+
+        // Drive the editor to tabs; the client middleware must inject this into the command.
+        await showWithIndentation(false, 4);
+
+        const expectedText = [
+            'a: 1',
+            'b:',
+            '\tc: 2'
+        ].join('\n');
+
+        // Invoking the wire command routes through the LanguageClient executeCommand
+        // middleware, which injects the active editor's indentation into the args.
+        await pollUntil(
+            async () => {
+                await vscode.commands.executeCommand(
+                    plainLens!.command!.command,
+                    ...(plainLens!.command!.arguments ?? [])
+                );
+                return (await document()).getText().replace(/\r\n/g, '\n');
+            },
+            text => text === expectedText,
+            { timeout: 5000, interval: 100, message: `Expected tab-indented formatting:\n${expectedText}` }
+        );
     }).timeout(15000);
 });


### PR DESCRIPTION
Formatting a KSON document ignored the editor's indentation setting — toggling **Spaces: 2** vs **Tabs** (or changing the indent size) in the status bar made no difference to the output.

**Root cause:** the language server's `onDocumentFormatting` (`tooling/language-server-protocol/src/core/services/KsonTextDocumentService.ts`) discarded the per-request `DocumentFormattingParams.options` (the LSP `FormattingOptions` carrying `insertSpaces`/`tabSize` that the editor populates) and instead drove indentation from a separate custom `kson.format.tabSize` / `kson.format.insertSpaces` config namespace. The editor's own setting never reached the formatter.