### PR TITLE
Reject unquoted object keys that start with a digit or `-`

### DIFF
--- a/src/commonMain/kotlin/org/kson/parser/Parser.kt
+++ b/src/commonMain/kotlin/org/kson/parser/Parser.kt
@@ -553,6 +553,20 @@ class Parser(private val builder: AstBuilder, private val maxNestingLevel: Int =
             return true
         }
 
+        // helpful error for keys with an illegal start char: the lexer scans tokens that start with a digit or
+        // '-' generously as NUMBER tokens (see Lexer.number), so a NUMBER immediately followed by a COLON is an
+        // attempt to use such a token as a key, which is illegal for unquoted keys
+        val isInvalidStartCharKey = builder.getTokenType() == NUMBER && builder.lookAhead(1) == COLON
+        if (isInvalidStartCharKey) {
+            val invalidKey = builder.getTokenText()
+            builder.advanceLexer()
+            keywordMark.error(OBJECT_KEY_INVALID_START_CHAR.create(invalidKey))
+
+            // advance past the COLON
+            builder.advanceLexer()
+            return true
+        }
+
         // try to parse a keyword in the style of "string followed by :"
         if (string() && builder.getTokenType() == COLON) {
             keywordMark.done(OBJECT_KEY)

--- a/src/commonMain/kotlin/org/kson/parser/messages/Message.kt
+++ b/src/commonMain/kotlin/org/kson/parser/messages/Message.kt
@@ -174,6 +174,16 @@ enum class MessageType(
             return "`$reservedWord` cannot be used as an object key"
         }
     },
+    OBJECT_KEY_INVALID_START_CHAR {
+        override fun expectedArgs(): List<String> {
+            return listOf("Object key")
+        }
+
+        override fun doFormat(parsedArgs: ParsedErrorArgs): String {
+            val objectKey = parsedArgs.getArg("Object key")
+            return "`$objectKey` cannot be used as an object key. Unquoted keys must start with a letter or `_`"
+        }
+    },
     IGNORED_OBJECT_END_DOT {
         override fun expectedArgs(): List<String> {
             return emptyList()

--- a/src/commonTest/kotlin/org/kson/KsonCoreTestObjectError.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestObjectError.kt
@@ -45,6 +45,48 @@ class KsonCoreTestObjectError : KsonCoreTestError {
     }
 
     @Test
+    fun testHelpfulErrorForInvalidKeyStartChars() {
+        // keys that start with a digit or a `-` are lexed as numbers, so they cannot be used as unquoted keys
+        assertParserRejectsSource(
+            """
+               key: value
+               1one: "can't start a key with a digit"
+               99: "can't use a bare number as a key"
+               -one: "can't start a key with a dash"
+               -99: "can't use a negative number as a key"
+            """.trimIndent(),
+            listOf(
+                OBJECT_KEY_INVALID_START_CHAR,
+                OBJECT_KEY_INVALID_START_CHAR,
+                OBJECT_KEY_INVALID_START_CHAR,
+                OBJECT_KEY_INVALID_START_CHAR
+            )
+        )
+
+        // the error still fires with whitespace between the key and its colon
+        assertParserRejectsSource(
+            """
+               key   : value
+               1one   : "can't start a key with a digit"
+               -one   : "can't start a key with a dash"
+            """.trimIndent(),
+            listOf(OBJECT_KEY_INVALID_START_CHAR, OBJECT_KEY_INVALID_START_CHAR)
+        )
+
+        // ...and inside `{}`-delimited objects
+        assertParserRejectsSource(
+            """
+               {
+                 test: true
+                 1haaa: 22
+                 -haaa: 22
+               }
+            """.trimIndent(),
+            listOf(OBJECT_KEY_INVALID_START_CHAR, OBJECT_KEY_INVALID_START_CHAR)
+        )
+    }
+
+    @Test
     fun testIgnoredEndDotError() {
         assertParserRejectsSource("""
             {


### PR DESCRIPTION
The lexer scans any token starting with a digit or `-` generously as a single NUMBER token so `NumberParser` can report a helpful error. That worked for top-level values but not for object keys: a key like `12`, `-33`, or `12a` never reached key handling and fell through to confusing errors that never mentioned the key.

Detect this in `keyword()`: a NUMBER token immediately followed by a COLON is an attempt to use a digit- or `-`-led token as a key. Report the new `OBJECT_KEY_INVALID_START_CHAR` message and keep parsing the rest of the property, so a single clear error is surfaced.

Behavior comparison (top-level `<key>: value` input):

```
`12` / `-33` (bare number keys)
  before: EOF_NOT_REACHED
          "Unexpected trailing content. The previous content parsed
           as a complete Kson document."
  after:  OBJECT_KEY_INVALID_START_CHAR
          "`12` cannot be used as an object key. Unquoted keys must
           start with a letter or `_`"

`12a` (numeric-looking, not a valid number)
  before: INVALID_DIGITS
          "Invalid character `a` found in this number"
          EOF_NOT_REACHED
          "Unexpected trailing content. ..."
  after:  OBJECT_KEY_INVALID_START_CHAR
          "`12a` cannot be used as an object key. Unquoted keys must
           start with a letter or `_`"
```

Keys starting with other special characters are unchanged:

```
`&18` / `&zz`
          ILLEGAL_CHARACTERS   "Kson does not allow "&" here"
          EOF_NOT_REACHED      "Unexpected trailing content. ..."

`$18` / `$zz` / `%18` / `%zz`
          EMBED_BLOCK_NO_CLOSE "Unclosed "$"" / "Unclosed "%""
          (the $/% opens an embed block that consumes the rest of
           the input, so no trailing-content error and no further
           errors are reported)
```