### PR TITLE
Fix CI toolchain caching: remove dead konan/jdk caches, add rattler/uv, cache Python jobs

### DIFF
--- a/.circleci/config.kson
+++ b/.circleci/config.kson
@@ -66,6 +66,11 @@ commands:
             =
       - restore_cache:
           keys:
+            - 'v1-<< parameters.platform >>-konan-{{ checksum "settings.gradle.kts" }}'
+            - 'v1-<< parameters.platform >>-konan-'
+            =
+      - restore_cache:
+          keys:
             - 'v1-<< parameters.platform >>-vscode-tests'
           .
         .
@@ -89,6 +94,11 @@ commands:
             - './gradle/jdk'
             - './buildSrc/gradle/jdk'
           key: 'v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}'
+
+      - save_cache:
+          paths:
+            - '~/.konan'
+          key: 'v1-<< parameters.platform >>-konan-{{ checksum "settings.gradle.kts" }}'
 
       - save_cache:
           paths:

--- a/.circleci/config.kson
+++ b/.circleci/config.kson
@@ -66,6 +66,11 @@ commands:
             =
       - restore_cache:
           keys:
+            - 'v1-<< parameters.platform >>-konan-{{ checksum "settings.gradle.kts" }}'
+            - 'v1-<< parameters.platform >>-konan-'
+            =
+      - restore_cache:
+          keys:
             - 'v2-<< parameters.platform >>-vscode-tests'
             =
       - restore_cache:
@@ -94,6 +99,11 @@ commands:
             - './gradle/jdk'
             - './buildSrc/gradle/jdk'
           key: 'v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}'
+
+      - save_cache:
+          paths:
+            - '~/.konan'
+          key: 'v1-<< parameters.platform >>-konan-{{ checksum "settings.gradle.kts" }}'
 
       - save_cache:
           paths:

--- a/.circleci/config.kson
+++ b/.circleci/config.kson
@@ -46,8 +46,8 @@ commands:
           .
         .
     .
-  'restore-gradle-caches':
-    description: 'Restore Gradle and JDK caches'
+  'restore-build-caches':
+    description: 'Restore Gradle dependency, rattler, and uv caches shared by build and Python jobs'
     parameters:
       platform:
         type: string
@@ -62,26 +62,18 @@ commands:
             =
       - restore_cache:
           keys:
-            - 'v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}'
+            - 'v1-<< parameters.platform >>-rattler-{{ checksum "kson-lib/pixi.lock" }}'
+            - 'v1-<< parameters.platform >>-rattler-'
             =
       - restore_cache:
           keys:
-            - 'v1-<< parameters.platform >>-konan-{{ checksum "settings.gradle.kts" }}'
-            - 'v1-<< parameters.platform >>-konan-'
-            =
-      - restore_cache:
-          keys:
-            - 'v2-<< parameters.platform >>-vscode-tests'
-            =
-      - restore_cache:
-          keys:
-            - 'v1-<< parameters.platform >>-pnpm-store-{{ checksum "tooling/lsp-clients/pnpm-lock.yaml" }}-{{ checksum "tooling/language-server-protocol/pnpm-lock.yaml" }}'
-            - 'v1-<< parameters.platform >>-pnpm-store-'
+            - 'v1-<< parameters.platform >>-uv-{{ checksum "lib-python/uv.lock" }}'
+            - 'v1-<< parameters.platform >>-uv-'
           .
         .
     .
-  'save-gradle-caches':
-    description: 'Save Gradle and JDK caches'
+  'save-build-caches':
+    description: 'Save Gradle dependency, rattler, and uv caches shared by build and Python jobs'
     parameters:
       platform:
         type: string
@@ -96,15 +88,53 @@ commands:
 
       - save_cache:
           paths:
-            - './gradle/jdk'
-            - './buildSrc/gradle/jdk'
-          key: 'v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}'
+            - '~/.cache/rattler'
+            - '~/Library/Caches/rattler'
+            - '~/AppData/Local/rattler'
+          key: 'v1-<< parameters.platform >>-rattler-{{ checksum "kson-lib/pixi.lock" }}'
 
       - save_cache:
           paths:
-            - '~/.konan'
-          key: 'v1-<< parameters.platform >>-konan-{{ checksum "settings.gradle.kts" }}'
-
+            - '~/.cache/uv'
+            - '~/Library/Caches/uv'
+            - '~/AppData/Local/uv'
+          key: 'v1-<< parameters.platform >>-uv-{{ checksum "lib-python/uv.lock" }}'
+          .
+        .
+    .
+  'restore-gradle-caches':
+    description: 'Restore all caches for the full cross-platform build jobs'
+    parameters:
+      platform:
+        type: string
+        description: 'Platform identifier for cache keys'
+        .
+      .
+    steps:
+      - 'restore-build-caches':
+          platform: '<< parameters.platform >>'
+      - restore_cache:
+          keys:
+            - 'v2-<< parameters.platform >>-vscode-tests'
+            =
+      - restore_cache:
+          keys:
+            - 'v1-<< parameters.platform >>-pnpm-store-{{ checksum "tooling/lsp-clients/pnpm-lock.yaml" }}-{{ checksum "tooling/language-server-protocol/pnpm-lock.yaml" }}'
+            - 'v1-<< parameters.platform >>-pnpm-store-'
+          .
+        .
+    .
+  'save-gradle-caches':
+    description: 'Save all caches for the full cross-platform build jobs'
+    parameters:
+      platform:
+        type: string
+        description: 'Platform identifier for cache keys'
+        .
+      .
+    steps:
+      - 'save-build-caches':
+          platform: '<< parameters.platform >>'
       - save_cache:
           paths:
             # Mirror vscodeTestCache.ts OS defaults for the VS Code electron download
@@ -333,6 +363,8 @@ jobs:
       - checkout
       - 'clean-git-config':
           shell: bash
+      - 'restore-build-caches':
+          platform: 'linux-amd64'
       - run:
           name: 'Build Python source distribution'
           command: './gradlew :lib-python:createSdistBuildEnvironment'
@@ -347,6 +379,8 @@ jobs:
             - 'lib-python/dist/*.tar.gz'
             =
 
+      - 'save-build-caches':
+          platform: 'linux-amd64'
       - store_artifacts:
           path: 'lib-python/dist'
           destination: 'python-sdist'
@@ -361,8 +395,12 @@ jobs:
     steps:
       - 'setup-python-test':
           platform: linux
+      - 'restore-build-caches':
+          platform: 'linux-amd64'
       - setup_remote_docker
       - 'run-python-tests-unix'
+      - 'save-build-caches':
+          platform: 'linux-amd64'
       - store_artifacts:
           path: 'lib-python/dist'
           destination: 'python-linux-amd64'
@@ -377,7 +415,11 @@ jobs:
     steps:
       - 'setup-python-test':
           platform: macos
+      - 'restore-build-caches':
+          platform: 'macos-python'
       - 'run-python-tests-unix'
+      - 'save-build-caches':
+          platform: 'macos-python'
       - store_artifacts:
           path: 'lib-python/dist'
           destination: 'python-macos'
@@ -393,6 +435,8 @@ jobs:
     steps:
       - 'setup-python-test':
           platform: windows
+      - 'restore-build-caches':
+          platform: 'windows-python'
       - run:
           name: 'Check Python version and upgrade if needed'
           command: 'python --version\npython -m pip install --upgrade pip\n'
@@ -414,6 +458,8 @@ jobs:
           name: 'Build platform-specific wheel'
           command: '.\\gradlew.bat :lib-python:buildWheel --no-daemon\n'
 
+      - 'save-build-caches':
+          platform: 'windows-python'
       - store_artifacts:
           path: 'lib-python/dist'
           destination: 'python-windows'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,8 @@ commands:
           destination: "kson-lib-static"
 
 
-  "restore-gradle-caches":
-    description: "Restore Gradle and JDK caches"
+  "restore-build-caches":
+    description: "Restore Gradle dependency, rattler, and uv caches shared by build and Python jobs"
     parameters:
       platform:
         type: string
@@ -63,21 +63,15 @@ commands:
             - "v1-<< parameters.platform >>-dependencies-"
       - restore_cache:
           keys:
-            - "v1-<< parameters.platform >>-jdk-{{ checksum \"jdk.properties\" }}"
+            - "v1-<< parameters.platform >>-rattler-{{ checksum \"kson-lib/pixi.lock\" }}"
+            - "v1-<< parameters.platform >>-rattler-"
       - restore_cache:
           keys:
-            - "v1-<< parameters.platform >>-konan-{{ checksum \"settings.gradle.kts\" }}"
-            - "v1-<< parameters.platform >>-konan-"
-      - restore_cache:
-          keys:
-            - "v2-<< parameters.platform >>-vscode-tests"
-      - restore_cache:
-          keys:
-            - "v1-<< parameters.platform >>-pnpm-store-{{ checksum \"tooling/lsp-clients/pnpm-lock.yaml\" }}-{{ checksum \"tooling/language-server-protocol/pnpm-lock.yaml\" }}"
-            - "v1-<< parameters.platform >>-pnpm-store-"
+            - "v1-<< parameters.platform >>-uv-{{ checksum \"lib-python/uv.lock\" }}"
+            - "v1-<< parameters.platform >>-uv-"
 
-  "save-gradle-caches":
-    description: "Save Gradle and JDK caches"
+  "save-build-caches":
+    description: "Save Gradle dependency, rattler, and uv caches shared by build and Python jobs"
     parameters:
       platform:
         type: string
@@ -91,15 +85,47 @@ commands:
 
       - save_cache:
           paths:
-            - "./gradle/jdk"
-            - "./buildSrc/gradle/jdk"
-          key: "v1-<< parameters.platform >>-jdk-{{ checksum \"jdk.properties\" }}"
+            - "~/.cache/rattler"
+            - "~/Library/Caches/rattler"
+            - "~/AppData/Local/rattler"
+          key: "v1-<< parameters.platform >>-rattler-{{ checksum \"kson-lib/pixi.lock\" }}"
 
       - save_cache:
           paths:
-            - "~/.konan"
-          key: "v1-<< parameters.platform >>-konan-{{ checksum \"settings.gradle.kts\" }}"
+            - "~/.cache/uv"
+            - "~/Library/Caches/uv"
+            - "~/AppData/Local/uv"
+          key: "v1-<< parameters.platform >>-uv-{{ checksum \"lib-python/uv.lock\" }}"
 
+
+  "restore-gradle-caches":
+    description: "Restore all caches for the full cross-platform build jobs"
+    parameters:
+      platform:
+        type: string
+        description: "Platform identifier for cache keys"
+
+    steps:
+      - "restore-build-caches":
+          platform: "<< parameters.platform >>"
+      - restore_cache:
+          keys:
+            - "v2-<< parameters.platform >>-vscode-tests"
+      - restore_cache:
+          keys:
+            - "v1-<< parameters.platform >>-pnpm-store-{{ checksum \"tooling/lsp-clients/pnpm-lock.yaml\" }}-{{ checksum \"tooling/language-server-protocol/pnpm-lock.yaml\" }}"
+            - "v1-<< parameters.platform >>-pnpm-store-"
+
+  "save-gradle-caches":
+    description: "Save all caches for the full cross-platform build jobs"
+    parameters:
+      platform:
+        type: string
+        description: "Platform identifier for cache keys"
+
+    steps:
+      - "save-build-caches":
+          platform: "<< parameters.platform >>"
       - save_cache:
           paths:
             # Mirror vscodeTestCache.ts OS defaults for the VS Code electron download
@@ -300,6 +326,8 @@ jobs:
       - checkout
       - "clean-git-config":
           shell: bash
+      - "restore-build-caches":
+          platform: "linux-amd64"
       - run:
           name: "Build Python source distribution"
           command: "./gradlew :lib-python:createSdistBuildEnvironment"
@@ -313,6 +341,8 @@ jobs:
           paths:
             - "lib-python/dist/*.tar.gz"
 
+      - "save-build-caches":
+          platform: "linux-amd64"
       - store_artifacts:
           path: "lib-python/dist"
           destination: "python-sdist"
@@ -325,8 +355,12 @@ jobs:
     steps:
       - "setup-python-test":
           platform: linux
+      - "restore-build-caches":
+          platform: "linux-amd64"
       - setup_remote_docker
       - "run-python-tests-unix"
+      - "save-build-caches":
+          platform: "linux-amd64"
       - store_artifacts:
           path: "lib-python/dist"
           destination: "python-linux-amd64"
@@ -339,7 +373,11 @@ jobs:
     steps:
       - "setup-python-test":
           platform: macos
+      - "restore-build-caches":
+          platform: "macos-python"
       - "run-python-tests-unix"
+      - "save-build-caches":
+          platform: "macos-python"
       - store_artifacts:
           path: "lib-python/dist"
           destination: "python-macos"
@@ -354,6 +392,8 @@ jobs:
     steps:
       - "setup-python-test":
           platform: windows
+      - "restore-build-caches":
+          platform: "windows-python"
       - run:
           name: "Check Python version and upgrade if needed"
           command: "python --version\npython -m pip install --upgrade pip\n"
@@ -375,6 +415,8 @@ jobs:
           name: "Build platform-specific wheel"
           command: ".\\gradlew.bat :lib-python:buildWheel --no-daemon\n"
 
+      - "save-build-caches":
+          platform: "windows-python"
       - store_artifacts:
           path: "lib-python/dist"
           destination: "python-windows"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,10 @@ commands:
             - "v1-<< parameters.platform >>-jdk-{{ checksum \"jdk.properties\" }}"
       - restore_cache:
           keys:
+            - "v1-<< parameters.platform >>-konan-{{ checksum \"settings.gradle.kts\" }}"
+            - "v1-<< parameters.platform >>-konan-"
+      - restore_cache:
+          keys:
             - "v1-<< parameters.platform >>-vscode-tests"
 
   "save-gradle-caches":
@@ -86,6 +90,11 @@ commands:
             - "./gradle/jdk"
             - "./buildSrc/gradle/jdk"
           key: "v1-<< parameters.platform >>-jdk-{{ checksum \"jdk.properties\" }}"
+
+      - save_cache:
+          paths:
+            - "~/.konan"
+          key: "v1-<< parameters.platform >>-konan-{{ checksum \"settings.gradle.kts\" }}"
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,10 @@ commands:
             - "v1-<< parameters.platform >>-jdk-{{ checksum \"jdk.properties\" }}"
       - restore_cache:
           keys:
+            - "v1-<< parameters.platform >>-konan-{{ checksum \"settings.gradle.kts\" }}"
+            - "v1-<< parameters.platform >>-konan-"
+      - restore_cache:
+          keys:
             - "v2-<< parameters.platform >>-vscode-tests"
       - restore_cache:
           keys:
@@ -90,6 +94,11 @@ commands:
             - "./gradle/jdk"
             - "./buildSrc/gradle/jdk"
           key: "v1-<< parameters.platform >>-jdk-{{ checksum \"jdk.properties\" }}"
+
+      - save_cache:
+          paths:
+            - "~/.konan"
+          key: "v1-<< parameters.platform >>-konan-{{ checksum \"settings.gradle.kts\" }}"
 
       - save_cache:
           paths:


### PR DESCRIPTION
This PR was repurposed. It originally added a CircleCI cache for `~/.konan`, but this project has no Kotlin/Native targets — the "native" build is GraalVM native-image — so that cache stored a 16 B empty archive on every run (`Warning: could not archive /home/circleci/.konan - Not found`).

What it does now:

- **Remove two dead caches**: the konan cache (never populated, see above) and the jdk cache (`./gradle/jdk`, `./buildSrc/gradle/jdk` no longer exist — the jvm wrapper installs the GraalVM JDK to `~/.gradle/jdks/`, which the existing `~/.gradle` dependencies cache already covers).
- **Add working toolchain caches**: rattler (pixi conda packages) keyed on `kson-lib/pixi.lock`, and uv (Python packages + CPython downloads) keyed on `lib-python/uv.lock`, each with Linux/macOS/Windows cache paths.
- **Cache the Python sdist jobs**, which previously restored nothing despite `pip install` of the sdist running a full bundled-Gradle + GraalVM native-image build, plus uv/cibuildwheel for wheels. They now restore/save gradle deps + rattler + uv via new shared `restore-build-caches`/`save-build-caches` commands; the Linux ones share `linux-amd64` cache keys with the every-commit `build-linux-amd64` job so release runs start warm.

`.circleci/config.yml` is regenerated from `config.kson`. Suggest squash-merging since the branch history adds then removes the konan cache.
