### PR TITLE
Fix CI toolchain caching

### DIFF
--- a/.circleci/config.kson
+++ b/.circleci/config.kson
@@ -46,8 +46,8 @@ commands:
           .
         .
     .
-  'restore-gradle-caches':
-    description: 'Restore Gradle and JDK caches'
+  'restore-build-caches':
+    description: 'Restore Gradle dependency, rattler, and uv caches shared by build and Python jobs'
     parameters:
       platform:
         type: string
@@ -62,21 +62,18 @@ commands:
             =
       - restore_cache:
           keys:
-            - 'v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}'
+            - 'v1-<< parameters.platform >>-rattler-{{ checksum "kson-lib/pixi.lock" }}'
+            - 'v1-<< parameters.platform >>-rattler-'
             =
       - restore_cache:
           keys:
-            - 'v2-<< parameters.platform >>-vscode-tests'
-            =
-      - restore_cache:
-          keys:
-            - 'v1-<< parameters.platform >>-pnpm-store-{{ checksum "tooling/lsp-clients/pnpm-lock.yaml" }}-{{ checksum "tooling/language-server-protocol/pnpm-lock.yaml" }}'
-            - 'v1-<< parameters.platform >>-pnpm-store-'
+            - 'v1-<< parameters.platform >>-uv-{{ checksum "lib-python/uv.lock" }}'
+            - 'v1-<< parameters.platform >>-uv-'
           .
         .
     .
-  'save-gradle-caches':
-    description: 'Save Gradle and JDK caches'
+  'save-build-caches':
+    description: 'Save Gradle dependency, rattler, and uv caches shared by build and Python jobs'
     parameters:
       platform:
         type: string
@@ -91,10 +88,53 @@ commands:
 
       - save_cache:
           paths:
-            - './gradle/jdk'
-            - './buildSrc/gradle/jdk'
-          key: 'v1-<< parameters.platform >>-jdk-{{ checksum "jdk.properties" }}'
+            - '~/.cache/rattler'
+            - '~/Library/Caches/rattler'
+            - '~/AppData/Local/rattler'
+          key: 'v1-<< parameters.platform >>-rattler-{{ checksum "kson-lib/pixi.lock" }}'
 
+      - save_cache:
+          paths:
+            - '~/.cache/uv'
+            - '~/Library/Caches/uv'
+            - '~/AppData/Local/uv'
+          key: 'v1-<< parameters.platform >>-uv-{{ checksum "lib-python/uv.lock" }}'
+          .
+        .
+    .
+  'restore-gradle-caches':
+    description: 'Restore all caches for the full cross-platform build jobs'
+    parameters:
+      platform:
+        type: string
+        description: 'Platform identifier for cache keys'
+        .
+      .
+    steps:
+      - 'restore-build-caches':
+          platform: '<< parameters.platform >>'
+      - restore_cache:
+          keys:
+            - 'v2-<< parameters.platform >>-vscode-tests'
+            =
+      - restore_cache:
+          keys:
+            - 'v1-<< parameters.platform >>-pnpm-store-{{ checksum "tooling/lsp-clients/pnpm-lock.yaml" }}-{{ checksum "tooling/language-server-protocol/pnpm-lock.yaml" }}'
+            - 'v1-<< parameters.platform >>-pnpm-store-'
+          .
+        .
+    .
+  'save-gradle-caches':
+    description: 'Save all caches for the full cross-platform build jobs'
+    parameters:
+      platform:
+        type: string
+        description: 'Platform identifier for cache keys'
+        .
+      .
+    steps:
+      - 'save-build-caches':
+          platform: '<< parameters.platform >>'
       - save_cache:
           paths:
             # Mirror vscodeTestCache.ts OS defaults for the VS Code electron download
@@ -323,6 +363,8 @@ jobs:
       - checkout
       - 'clean-git-config':
           shell: bash
+      - 'restore-build-caches':
+          platform: 'linux-amd64'
       - run:
           name: 'Build Python source distribution'
           command: './gradlew :lib-python:createSdistBuildEnvironment'
@@ -337,6 +379,8 @@ jobs:
             - 'lib-python/dist/*.tar.gz'
             =
 
+      - 'save-build-caches':
+          platform: 'linux-amd64'
       - store_artifacts:
           path: 'lib-python/dist'
           destination: 'python-sdist'
@@ -351,8 +395,12 @@ jobs:
     steps:
       - 'setup-python-test':
           platform: linux
+      - 'restore-build-caches':
+          platform: 'linux-amd64'
       - setup_remote_docker
       - 'run-python-tests-unix'
+      - 'save-build-caches':
+          platform: 'linux-amd64'
       - store_artifacts:
           path: 'lib-python/dist'
           destination: 'python-linux-amd64'
@@ -367,7 +415,11 @@ jobs:
     steps:
       - 'setup-python-test':
           platform: macos
+      - 'restore-build-caches':
+          platform: 'macos-python'
       - 'run-python-tests-unix'
+      - 'save-build-caches':
+          platform: 'macos-python'
       - store_artifacts:
           path: 'lib-python/dist'
           destination: 'python-macos'
@@ -383,6 +435,8 @@ jobs:
     steps:
       - 'setup-python-test':
           platform: windows
+      - 'restore-build-caches':
+          platform: 'windows-python'
       - run:
           name: 'Check Python version and upgrade if needed'
           command: 'python --version\npython -m pip install --upgrade pip\n'
@@ -404,6 +458,8 @@ jobs:
           name: 'Build platform-specific wheel'
           command: '.\\gradlew.bat :lib-python:buildWheel --no-daemon\n'
 
+      - 'save-build-caches':
+          platform: 'windows-python'
       - store_artifacts:
           path: 'lib-python/dist'
           destination: 'python-windows'

--- a/.circleci/config.kson
+++ b/.circleci/config.kson
@@ -62,10 +62,6 @@ commands:
             =
       - restore_cache:
           keys:
-            - 'v1-<< parameters.platform >>-gradle-build-cache-'
-            =
-      - restore_cache:
-          keys:
             - 'v1-<< parameters.platform >>-rattler-{{ checksum "kson-lib/pixi.lock" }}'
             - 'v1-<< parameters.platform >>-rattler-'
             =
@@ -92,11 +88,6 @@ commands:
 
       - save_cache:
           paths:
-            - '~/.gradle/caches/build-cache-1'
-          key: 'v1-<< parameters.platform >>-gradle-build-cache-{{ .Revision }}'
-
-      - save_cache:
-          paths:
             - '~/.cache/rattler'
             - '~/Library/Caches/rattler'
             - '~/AppData/Local/rattler'
@@ -108,6 +99,27 @@ commands:
             - '~/Library/Caches/uv'
             - '~/AppData/Local/uv'
           key: 'v1-<< parameters.platform >>-uv-{{ checksum "lib-python/uv.lock" }}'
+          .
+        .
+    .
+  # Gradle build cache, scoped to build-linux-amd64 only (keeps stale cached output out of release artifacts).
+  # Escape hatch: if CI misbehaves inexplicably, bump the v1->v2 prefix on both keys below to bust the cache.
+  'restore-gradle-build-cache':
+    description: 'Restore the Gradle build cache for build-linux-amd64'
+    steps:
+      - restore_cache:
+          keys:
+            - 'v1-linux-amd64-gradle-build-cache-'
+          .
+        .
+    .
+  'save-gradle-build-cache':
+    description: 'Save the Gradle build cache for build-linux-amd64 (see runbook above)'
+    steps:
+      - save_cache:
+          paths:
+            - '~/.gradle/caches/build-cache-1'
+          key: 'v1-linux-amd64-gradle-build-cache-{{ .Revision }}'
           .
         .
     .
@@ -272,7 +284,6 @@ jobs:
       .
     environment:
       JVM_OPTS: '-Xmx3200m'
-      GRADLE_OPTS: '-Dorg.gradle.caching=true'
       .
     steps:
       - checkout
@@ -326,12 +337,14 @@ jobs:
 
       - 'restore-gradle-caches':
           platform: 'linux-amd64'
+      - 'restore-gradle-build-cache'
 
       - 'clean-git-config':
           shell: bash
       # Cross-platform Gradle tasks
       - 'gradle-core-tasks'
       - 'store-native-artifacts'
+      - 'save-gradle-build-cache'
       - 'save-gradle-caches':
           platform: 'linux-amd64'
           .
@@ -343,9 +356,6 @@ jobs:
       .
     resource_class: 'm4pro.medium'
     working_directory: '~/repo'
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.caching=true'
-      .
     steps:
       - run:
           name: 'Install Chrome'
@@ -373,9 +383,6 @@ jobs:
       - image: 'cimg/python:3.11'
         .
     working_directory: '~/repo'
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.caching=true'
-      .
     steps:
       - checkout
       - 'clean-git-config':
@@ -409,9 +416,6 @@ jobs:
       - image: 'cimg/python:3.11'
         .
     working_directory: '~/repo'
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.caching=true'
-      .
     steps:
       - 'setup-python-test':
           platform: linux
@@ -432,9 +436,6 @@ jobs:
       xcode: '14.2.0'
       .
     working_directory: '~/repo'
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.caching=true'
-      .
     steps:
       - 'setup-python-test':
           platform: macos
@@ -455,9 +456,6 @@ jobs:
       size: medium
       .
     working_directory: '~/repo'
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.caching=true'
-      .
     steps:
       - 'setup-python-test':
           platform: windows

--- a/.circleci/config.kson
+++ b/.circleci/config.kson
@@ -62,6 +62,10 @@ commands:
             =
       - restore_cache:
           keys:
+            - 'v1-<< parameters.platform >>-gradle-build-cache-'
+            =
+      - restore_cache:
+          keys:
             - 'v1-<< parameters.platform >>-rattler-{{ checksum "kson-lib/pixi.lock" }}'
             - 'v1-<< parameters.platform >>-rattler-'
             =
@@ -85,6 +89,11 @@ commands:
           paths:
             - '~/.gradle'
           key: 'v1-<< parameters.platform >>-dependencies-{{ checksum "build.gradle.kts" }}'
+
+      - save_cache:
+          paths:
+            - '~/.gradle/caches/build-cache-1'
+          key: 'v1-<< parameters.platform >>-gradle-build-cache-{{ .Revision }}'
 
       - save_cache:
           paths:
@@ -263,6 +272,7 @@ jobs:
       .
     environment:
       JVM_OPTS: '-Xmx3200m'
+      GRADLE_OPTS: '-Dorg.gradle.caching=true'
       .
     steps:
       - checkout
@@ -297,6 +307,7 @@ jobs:
     working_directory: '~/repo'
     environment:
       JVM_OPTS: '-Xmx3200m'
+      GRADLE_OPTS: '-Dorg.gradle.caching=true'
       TERM: dumb
       DISPLAY: ':99'
       .
@@ -332,6 +343,9 @@ jobs:
       .
     resource_class: 'm4pro.medium'
     working_directory: '~/repo'
+    environment:
+      GRADLE_OPTS: '-Dorg.gradle.caching=true'
+      .
     steps:
       - run:
           name: 'Install Chrome'
@@ -359,6 +373,9 @@ jobs:
       - image: 'cimg/python:3.11'
         .
     working_directory: '~/repo'
+    environment:
+      GRADLE_OPTS: '-Dorg.gradle.caching=true'
+      .
     steps:
       - checkout
       - 'clean-git-config':
@@ -392,6 +409,9 @@ jobs:
       - image: 'cimg/python:3.11'
         .
     working_directory: '~/repo'
+    environment:
+      GRADLE_OPTS: '-Dorg.gradle.caching=true'
+      .
     steps:
       - 'setup-python-test':
           platform: linux
@@ -412,6 +432,9 @@ jobs:
       xcode: '14.2.0'
       .
     working_directory: '~/repo'
+    environment:
+      GRADLE_OPTS: '-Dorg.gradle.caching=true'
+      .
     steps:
       - 'setup-python-test':
           platform: macos
@@ -432,6 +455,9 @@ jobs:
       size: medium
       .
     working_directory: '~/repo'
+    environment:
+      GRADLE_OPTS: '-Dorg.gradle.caching=true'
+      .
     steps:
       - 'setup-python-test':
           platform: windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,8 @@ commands:
           destination: "kson-lib-static"
 
 
-  "restore-gradle-caches":
-    description: "Restore Gradle and JDK caches"
+  "restore-build-caches":
+    description: "Restore Gradle dependency, rattler, and uv caches shared by build and Python jobs"
     parameters:
       platform:
         type: string
@@ -63,17 +63,15 @@ commands:
             - "v1-<< parameters.platform >>-dependencies-"
       - restore_cache:
           keys:
-            - "v1-<< parameters.platform >>-jdk-{{ checksum \"jdk.properties\" }}"
+            - "v1-<< parameters.platform >>-rattler-{{ checksum \"kson-lib/pixi.lock\" }}"
+            - "v1-<< parameters.platform >>-rattler-"
       - restore_cache:
           keys:
-            - "v2-<< parameters.platform >>-vscode-tests"
-      - restore_cache:
-          keys:
-            - "v1-<< parameters.platform >>-pnpm-store-{{ checksum \"tooling/lsp-clients/pnpm-lock.yaml\" }}-{{ checksum \"tooling/language-server-protocol/pnpm-lock.yaml\" }}"
-            - "v1-<< parameters.platform >>-pnpm-store-"
+            - "v1-<< parameters.platform >>-uv-{{ checksum \"lib-python/uv.lock\" }}"
+            - "v1-<< parameters.platform >>-uv-"
 
-  "save-gradle-caches":
-    description: "Save Gradle and JDK caches"
+  "save-build-caches":
+    description: "Save Gradle dependency, rattler, and uv caches shared by build and Python jobs"
     parameters:
       platform:
         type: string
@@ -87,10 +85,47 @@ commands:
 
       - save_cache:
           paths:
-            - "./gradle/jdk"
-            - "./buildSrc/gradle/jdk"
-          key: "v1-<< parameters.platform >>-jdk-{{ checksum \"jdk.properties\" }}"
+            - "~/.cache/rattler"
+            - "~/Library/Caches/rattler"
+            - "~/AppData/Local/rattler"
+          key: "v1-<< parameters.platform >>-rattler-{{ checksum \"kson-lib/pixi.lock\" }}"
 
+      - save_cache:
+          paths:
+            - "~/.cache/uv"
+            - "~/Library/Caches/uv"
+            - "~/AppData/Local/uv"
+          key: "v1-<< parameters.platform >>-uv-{{ checksum \"lib-python/uv.lock\" }}"
+
+
+  "restore-gradle-caches":
+    description: "Restore all caches for the full cross-platform build jobs"
+    parameters:
+      platform:
+        type: string
+        description: "Platform identifier for cache keys"
+
+    steps:
+      - "restore-build-caches":
+          platform: "<< parameters.platform >>"
+      - restore_cache:
+          keys:
+            - "v2-<< parameters.platform >>-vscode-tests"
+      - restore_cache:
+          keys:
+            - "v1-<< parameters.platform >>-pnpm-store-{{ checksum \"tooling/lsp-clients/pnpm-lock.yaml\" }}-{{ checksum \"tooling/language-server-protocol/pnpm-lock.yaml\" }}"
+            - "v1-<< parameters.platform >>-pnpm-store-"
+
+  "save-gradle-caches":
+    description: "Save all caches for the full cross-platform build jobs"
+    parameters:
+      platform:
+        type: string
+        description: "Platform identifier for cache keys"
+
+    steps:
+      - "save-build-caches":
+          platform: "<< parameters.platform >>"
       - save_cache:
           paths:
             # Mirror vscodeTestCache.ts OS defaults for the VS Code electron download
@@ -291,6 +326,8 @@ jobs:
       - checkout
       - "clean-git-config":
           shell: bash
+      - "restore-build-caches":
+          platform: "linux-amd64"
       - run:
           name: "Build Python source distribution"
           command: "./gradlew :lib-python:createSdistBuildEnvironment"
@@ -304,6 +341,8 @@ jobs:
           paths:
             - "lib-python/dist/*.tar.gz"
 
+      - "save-build-caches":
+          platform: "linux-amd64"
       - store_artifacts:
           path: "lib-python/dist"
           destination: "python-sdist"
@@ -316,8 +355,12 @@ jobs:
     steps:
       - "setup-python-test":
           platform: linux
+      - "restore-build-caches":
+          platform: "linux-amd64"
       - setup_remote_docker
       - "run-python-tests-unix"
+      - "save-build-caches":
+          platform: "linux-amd64"
       - store_artifacts:
           path: "lib-python/dist"
           destination: "python-linux-amd64"
@@ -330,7 +373,11 @@ jobs:
     steps:
       - "setup-python-test":
           platform: macos
+      - "restore-build-caches":
+          platform: "macos-python"
       - "run-python-tests-unix"
+      - "save-build-caches":
+          platform: "macos-python"
       - store_artifacts:
           path: "lib-python/dist"
           destination: "python-macos"
@@ -345,6 +392,8 @@ jobs:
     steps:
       - "setup-python-test":
           platform: windows
+      - "restore-build-caches":
+          platform: "windows-python"
       - run:
           name: "Check Python version and upgrade if needed"
           command: "python --version\npython -m pip install --upgrade pip\n"
@@ -366,6 +415,8 @@ jobs:
           name: "Build platform-specific wheel"
           command: ".\\gradlew.bat :lib-python:buildWheel --no-daemon\n"
 
+      - "save-build-caches":
+          platform: "windows-python"
       - store_artifacts:
           path: "lib-python/dist"
           destination: "python-windows"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,6 @@ commands:
             - "v1-<< parameters.platform >>-dependencies-"
       - restore_cache:
           keys:
-            - "v1-<< parameters.platform >>-gradle-build-cache-"
-      - restore_cache:
-          keys:
             - "v1-<< parameters.platform >>-rattler-{{ checksum \"kson-lib/pixi.lock\" }}"
             - "v1-<< parameters.platform >>-rattler-"
       - restore_cache:
@@ -88,11 +85,6 @@ commands:
 
       - save_cache:
           paths:
-            - "~/.gradle/caches/build-cache-1"
-          key: "v1-<< parameters.platform >>-gradle-build-cache-{{ .Revision }}"
-
-      - save_cache:
-          paths:
             - "~/.cache/rattler"
             - "~/Library/Caches/rattler"
             - "~/AppData/Local/rattler"
@@ -104,6 +96,24 @@ commands:
             - "~/Library/Caches/uv"
             - "~/AppData/Local/uv"
           key: "v1-<< parameters.platform >>-uv-{{ checksum \"lib-python/uv.lock\" }}"
+
+
+  # Gradle build cache, scoped to build-linux-amd64 only (keeps stale cached output out of release artifacts).
+  # Escape hatch: if CI misbehaves inexplicably, bump the v1->v2 prefix on both keys below to bust the cache.
+  "restore-gradle-build-cache":
+    description: "Restore the Gradle build cache for build-linux-amd64"
+    steps:
+      - restore_cache:
+          keys:
+            - "v1-linux-amd64-gradle-build-cache-"
+
+  "save-gradle-build-cache":
+    description: "Save the Gradle build cache for build-linux-amd64 (see runbook above)"
+    steps:
+      - save_cache:
+          paths:
+            - "~/.gradle/caches/build-cache-1"
+          key: "v1-linux-amd64-gradle-build-cache-{{ .Revision }}"
 
 
   "restore-gradle-caches":
@@ -245,8 +255,6 @@ jobs:
 
     environment:
       JVM_OPTS: "-Xmx3200m"
-      GRADLE_OPTS: "-Dorg.gradle.caching=true"
-
     steps:
       - checkout
       - "clean-git-config":
@@ -296,11 +304,13 @@ jobs:
 
       - "restore-gradle-caches":
           platform: "linux-amd64"
+      - "restore-gradle-build-cache"
       - "clean-git-config":
           shell: bash
       # Cross-platform Gradle tasks
       - "gradle-core-tasks"
       - "store-native-artifacts"
+      - "save-gradle-build-cache"
       - "save-gradle-caches":
           platform: "linux-amd64"
 
@@ -309,8 +319,6 @@ jobs:
       xcode: "16.4.0"
     resource_class: "m4pro.medium"
     working_directory: "~/repo"
-    environment:
-      GRADLE_OPTS: "-Dorg.gradle.caching=true"
     steps:
       - run:
           name: "Install Chrome"
@@ -335,8 +343,6 @@ jobs:
     docker:
       - image: "cimg/python:3.11"
     working_directory: "~/repo"
-    environment:
-      GRADLE_OPTS: "-Dorg.gradle.caching=true"
     steps:
       - checkout
       - "clean-git-config":
@@ -367,8 +373,6 @@ jobs:
     docker:
       - image: "cimg/python:3.11"
     working_directory: "~/repo"
-    environment:
-      GRADLE_OPTS: "-Dorg.gradle.caching=true"
     steps:
       - "setup-python-test":
           platform: linux
@@ -387,8 +391,6 @@ jobs:
     macos:
       xcode: "14.2.0"
     working_directory: "~/repo"
-    environment:
-      GRADLE_OPTS: "-Dorg.gradle.caching=true"
     steps:
       - "setup-python-test":
           platform: macos
@@ -408,8 +410,6 @@ jobs:
       size: medium
 
     working_directory: "~/repo"
-    environment:
-      GRADLE_OPTS: "-Dorg.gradle.caching=true"
     steps:
       - "setup-python-test":
           platform: windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,9 @@ commands:
             - "v1-<< parameters.platform >>-dependencies-"
       - restore_cache:
           keys:
+            - "v1-<< parameters.platform >>-gradle-build-cache-"
+      - restore_cache:
+          keys:
             - "v1-<< parameters.platform >>-rattler-{{ checksum \"kson-lib/pixi.lock\" }}"
             - "v1-<< parameters.platform >>-rattler-"
       - restore_cache:
@@ -82,6 +85,11 @@ commands:
           paths:
             - "~/.gradle"
           key: "v1-<< parameters.platform >>-dependencies-{{ checksum \"build.gradle.kts\" }}"
+
+      - save_cache:
+          paths:
+            - "~/.gradle/caches/build-cache-1"
+          key: "v1-<< parameters.platform >>-gradle-build-cache-{{ .Revision }}"
 
       - save_cache:
           paths:
@@ -237,6 +245,8 @@ jobs:
 
     environment:
       JVM_OPTS: "-Xmx3200m"
+      GRADLE_OPTS: "-Dorg.gradle.caching=true"
+
     steps:
       - checkout
       - "clean-git-config":
@@ -267,6 +277,7 @@ jobs:
     working_directory: "~/repo"
     environment:
       JVM_OPTS: "-Xmx3200m"
+      GRADLE_OPTS: "-Dorg.gradle.caching=true"
       TERM: dumb
       DISPLAY: ":99"
 
@@ -298,6 +309,8 @@ jobs:
       xcode: "16.4.0"
     resource_class: "m4pro.medium"
     working_directory: "~/repo"
+    environment:
+      GRADLE_OPTS: "-Dorg.gradle.caching=true"
     steps:
       - run:
           name: "Install Chrome"
@@ -322,6 +335,8 @@ jobs:
     docker:
       - image: "cimg/python:3.11"
     working_directory: "~/repo"
+    environment:
+      GRADLE_OPTS: "-Dorg.gradle.caching=true"
     steps:
       - checkout
       - "clean-git-config":
@@ -352,6 +367,8 @@ jobs:
     docker:
       - image: "cimg/python:3.11"
     working_directory: "~/repo"
+    environment:
+      GRADLE_OPTS: "-Dorg.gradle.caching=true"
     steps:
       - "setup-python-test":
           platform: linux
@@ -370,6 +387,8 @@ jobs:
     macos:
       xcode: "14.2.0"
     working_directory: "~/repo"
+    environment:
+      GRADLE_OPTS: "-Dorg.gradle.caching=true"
     steps:
       - "setup-python-test":
           platform: macos
@@ -389,6 +408,8 @@ jobs:
       size: medium
 
     working_directory: "~/repo"
+    environment:
+      GRADLE_OPTS: "-Dorg.gradle.caching=true"
     steps:
       - "setup-python-test":
           platform: windows

--- a/kson-lib/build.gradle.kts
+++ b/kson-lib/build.gradle.kts
@@ -75,7 +75,7 @@ krossover {
     }
 }
 
-// krossover's KSP processor writes api.json here as an undeclared side effect; declare it as an output so the build cache restores it on a cache hit (upstream plugin bug)
+// krossover's KSP processor writes api.json here as an undeclared side effect; declare it as an output so the build cache restores it.
 afterEvaluate {
     tasks.named("kspKotlinJvm") {
         outputs.file(layout.buildDirectory.file("kotlin/krossover/metadata/api.json"))

--- a/kson-lib/build.gradle.kts
+++ b/kson-lib/build.gradle.kts
@@ -75,6 +75,13 @@ krossover {
     }
 }
 
+// krossover's KSP processor writes api.json here as an undeclared side effect; declare it as an output so the build cache restores it on a cache hit (upstream plugin bug)
+afterEvaluate {
+    tasks.named("kspKotlinJvm") {
+        outputs.file(layout.buildDirectory.file("kotlin/krossover/metadata/api.json"))
+    }
+}
+
 // Task to copy browser distribution after building
 tasks.register("copyBrowserDistribution") {
     description = "Copy browser JS distribution to js-package/browser"


### PR DESCRIPTION
Two of the CI cache entries never stored anything, and the jobs with the biggest downloads had no caching at all. This PR fixes both:

- **Remove the dead jdk cache**: `./gradle/jdk` and `./buildSrc/gradle/jdk` no longer exist — the jvm wrapper installs the GraalVM JDK to `~/.gradle/jdks/`, which the existing `~/.gradle` dependencies cache already covers — so this entry saved an empty archive on every run.
- **Add working toolchain caches**: rattler (pixi conda packages) keyed on `kson-lib/pixi.lock`, and uv (Python packages + CPython downloads) keyed on `lib-python/uv.lock`, each with Linux/macOS/Windows cache paths, following the multi-path pattern of the existing vscode cache.
- **Cache the Python sdist jobs**, which previously restored nothing despite `pip install` of the sdist running a full bundled-Gradle + GraalVM native-image build, plus uv/cibuildwheel for wheels. They now restore/save gradle deps + rattler + uv through new shared `restore-build-caches`/`save-build-caches` commands; the existing gradle-caches commands layer vscode/pnpm on top of the same trio. The Linux Python jobs share `linux-amd64` cache keys with the every-commit `build-linux-amd64` job, so release runs start with warm caches.

`.circleci/config.yml` is regenerated from `config.kson` via the gradle transpile task.

Supersedes #400.
