### PR TITLE
Fix incorrect command in CLI readme

### DIFF
--- a/tooling/cli/readme.md
+++ b/tooling/cli/readme.md
@@ -17,7 +17,7 @@ The native binary will be generated in `tooling/cli/build/native/nativeCompile/`
 The CLI provides several commands for working with KSON files:
 
 - `format` - Format KSON files
-- `analyze` - Analyze KSON files for issues
+- `validate` - Validate KSON files for issues
 - `json` or `yaml` - Convert KSON files to other formats
 
 Run the CLI with `--help` for more information on available commands and options.


### PR DESCRIPTION
The CLI offers `validate`, not `analyze`