### PR TITLE
Make @kson_org/monaco-editor installable from npm

### DIFF
--- a/tooling/lsp-clients/demos/iframe/pnpm-lock.yaml
+++ b/tooling/lsp-clients/demos/iframe/pnpm-lock.yaml
@@ -27,9 +27,6 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@kson/lsp-shared@file:../../shared':
-    resolution: {directory: ../../shared, type: directory}
-
   '@kson_org/monaco-editor@file:../../monaco':
     resolution: {directory: ../../monaco, type: directory}
     peerDependencies:
@@ -152,12 +149,6 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -178,18 +169,6 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  kson-kson-lib@file:../../../../kson-lib/build/dist/js/productionLibrary:
-    resolution: {directory: ../../../../kson-lib/build/dist/js/productionLibrary, type: directory}
-    bundledDependencies: []
-
-  kson-kson-tooling-lib@file:../../../../kson-tooling-lib/build/dist/js/productionLibrary:
-    resolution: {directory: ../../../../kson-tooling-lib/build/dist/js/productionLibrary, type: directory}
-    bundledDependencies: []
-
-  kson-language-server@file:../../../language-server-protocol:
-    resolution: {directory: ../../../language-server-protocol, type: directory}
-    engines: {node: 24.x}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -270,10 +249,6 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
-  minimatch@5.1.9:
-    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
-    engines: {node: '>=10'}
-
   monaco-editor@0.55.1:
     resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
@@ -296,11 +271,6 @@ packages:
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
-    engines: {node: '>=10'}
     hasBin: true
 
   source-map-js@1.2.1:
@@ -357,30 +327,6 @@ packages:
       yaml:
         optional: true
 
-  vscode-jsonrpc@8.2.0:
-    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
-    engines: {node: '>=14.0.0'}
-
-  vscode-languageclient@9.0.1:
-    resolution: {integrity: sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==}
-    engines: {vscode: ^1.82.0}
-
-  vscode-languageserver-protocol@3.17.5:
-    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
-
-  vscode-languageserver-textdocument@1.0.12:
-    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
-
-  vscode-languageserver-types@3.17.5:
-    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
-
-  vscode-languageserver@9.0.1:
-    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
-    hasBin: true
-
-  vscode-uri@3.1.0:
-    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
-
 snapshots:
 
   '@emnapi/core@1.10.0':
@@ -399,15 +345,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@kson/lsp-shared@file:../../shared':
-    dependencies:
-      kson-language-server: file:../../../language-server-protocol
-      vscode-languageclient: 9.0.1
-      vscode-languageserver: 9.0.1
-
   '@kson_org/monaco-editor@file:../../monaco(monaco-editor@0.55.1)':
     dependencies:
-      '@kson/lsp-shared': file:../../shared
       monaco-editor: 0.55.1
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -478,12 +417,6 @@ snapshots:
   '@types/trusted-types@2.0.7':
     optional: true
 
-  balanced-match@1.0.2: {}
-
-  brace-expansion@2.1.1:
-    dependencies:
-      balanced-match: 1.0.2
-
   detect-libc@2.1.2: {}
 
   dompurify@3.2.7:
@@ -496,18 +429,6 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
-
-  kson-kson-lib@file:../../../../kson-lib/build/dist/js/productionLibrary: {}
-
-  kson-kson-tooling-lib@file:../../../../kson-tooling-lib/build/dist/js/productionLibrary: {}
-
-  kson-language-server@file:../../../language-server-protocol:
-    dependencies:
-      kson: kson-kson-lib@file:../../../../kson-lib/build/dist/js/productionLibrary
-      kson-tooling: kson-kson-tooling-lib@file:../../../../kson-tooling-lib/build/dist/js/productionLibrary
-      vscode-languageserver: 9.0.1
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.1.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -560,10 +481,6 @@ snapshots:
 
   marked@14.0.0: {}
 
-  minimatch@5.1.9:
-    dependencies:
-      brace-expansion: 2.1.1
-
   monaco-editor@0.55.1:
     dependencies:
       dompurify: 3.2.7
@@ -602,8 +519,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
 
-  semver@7.8.4: {}
-
   source-map-js@1.2.1: {}
 
   tinyglobby@0.2.17:
@@ -623,26 +538,3 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       fsevents: 2.3.3
-
-  vscode-jsonrpc@8.2.0: {}
-
-  vscode-languageclient@9.0.1:
-    dependencies:
-      minimatch: 5.1.9
-      semver: 7.8.4
-      vscode-languageserver-protocol: 3.17.5
-
-  vscode-languageserver-protocol@3.17.5:
-    dependencies:
-      vscode-jsonrpc: 8.2.0
-      vscode-languageserver-types: 3.17.5
-
-  vscode-languageserver-textdocument@1.0.12: {}
-
-  vscode-languageserver-types@3.17.5: {}
-
-  vscode-languageserver@9.0.1:
-    dependencies:
-      vscode-languageserver-protocol: 3.17.5
-
-  vscode-uri@3.1.0: {}

--- a/tooling/lsp-clients/demos/react/pnpm-lock.yaml
+++ b/tooling/lsp-clients/demos/react/pnpm-lock.yaml
@@ -51,9 +51,6 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@kson/lsp-shared@file:../../shared':
-    resolution: {directory: ../../shared, type: directory}
-
   '@kson_org/monaco-editor@file:../../monaco':
     resolution: {directory: ../../monaco, type: directory}
     peerDependencies:
@@ -207,12 +204,6 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
-
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -236,18 +227,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  kson-kson-lib@file:../../../../kson-lib/build/dist/js/productionLibrary:
-    resolution: {directory: ../../../../kson-lib/build/dist/js/productionLibrary, type: directory}
-    bundledDependencies: []
-
-  kson-kson-tooling-lib@file:../../../../kson-tooling-lib/build/dist/js/productionLibrary:
-    resolution: {directory: ../../../../kson-tooling-lib/build/dist/js/productionLibrary, type: directory}
-    bundledDependencies: []
-
-  kson-language-server@file:../../../language-server-protocol:
-    resolution: {directory: ../../../language-server-protocol, type: directory}
-    engines: {node: 24.x}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -327,10 +306,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  minimatch@5.1.9:
-    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
-    engines: {node: '>=10'}
-
   monaco-editor@0.52.2:
     resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
 
@@ -366,11 +341,6 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
-
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -434,30 +404,6 @@ packages:
       yaml:
         optional: true
 
-  vscode-jsonrpc@8.2.0:
-    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
-    engines: {node: '>=14.0.0'}
-
-  vscode-languageclient@9.0.1:
-    resolution: {integrity: sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==}
-    engines: {vscode: ^1.82.0}
-
-  vscode-languageserver-protocol@3.17.5:
-    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
-
-  vscode-languageserver-textdocument@1.0.12:
-    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
-
-  vscode-languageserver-types@3.17.5:
-    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
-
-  vscode-languageserver@9.0.1:
-    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
-    hasBin: true
-
-  vscode-uri@3.1.0:
-    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
-
 snapshots:
 
   '@emnapi/core@1.10.0':
@@ -476,15 +422,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@kson/lsp-shared@file:../../shared':
-    dependencies:
-      kson-language-server: file:../../../language-server-protocol
-      vscode-languageclient: 9.0.1
-      vscode-languageserver: 9.0.1
-
   '@kson_org/monaco-editor@file:../../monaco(monaco-editor@0.52.2)(react@18.3.1)':
     dependencies:
-      '@kson/lsp-shared': file:../../shared
       monaco-editor: 0.52.2
     optionalDependencies:
       react: 18.3.1
@@ -581,12 +520,6 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16
 
-  balanced-match@1.0.2: {}
-
-  brace-expansion@2.1.1:
-    dependencies:
-      balanced-match: 1.0.2
-
   csstype@3.2.3: {}
 
   detect-libc@2.1.2: {}
@@ -599,18 +532,6 @@ snapshots:
     optional: true
 
   js-tokens@4.0.0: {}
-
-  kson-kson-lib@file:../../../../kson-lib/build/dist/js/productionLibrary: {}
-
-  kson-kson-tooling-lib@file:../../../../kson-tooling-lib/build/dist/js/productionLibrary: {}
-
-  kson-language-server@file:../../../language-server-protocol:
-    dependencies:
-      kson: kson-kson-lib@file:../../../../kson-lib/build/dist/js/productionLibrary
-      kson-tooling: kson-kson-tooling-lib@file:../../../../kson-tooling-lib/build/dist/js/productionLibrary
-      vscode-languageserver: 9.0.1
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.1.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -665,10 +586,6 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  minimatch@5.1.9:
-    dependencies:
-      brace-expansion: 2.1.1
-
   monaco-editor@0.52.2: {}
 
   nanoid@3.3.12: {}
@@ -718,8 +635,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  semver@7.8.4: {}
-
   source-map-js@1.2.1: {}
 
   state-local@1.0.7: {}
@@ -743,26 +658,3 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       fsevents: 2.3.3
-
-  vscode-jsonrpc@8.2.0: {}
-
-  vscode-languageclient@9.0.1:
-    dependencies:
-      minimatch: 5.1.9
-      semver: 7.8.4
-      vscode-languageserver-protocol: 3.17.5
-
-  vscode-languageserver-protocol@3.17.5:
-    dependencies:
-      vscode-jsonrpc: 8.2.0
-      vscode-languageserver-types: 3.17.5
-
-  vscode-languageserver-textdocument@1.0.12: {}
-
-  vscode-languageserver-types@3.17.5: {}
-
-  vscode-languageserver@9.0.1:
-    dependencies:
-      vscode-languageserver-protocol: 3.17.5
-
-  vscode-uri@3.1.0: {}

--- a/tooling/lsp-clients/demos/vanilla/pnpm-lock.yaml
+++ b/tooling/lsp-clients/demos/vanilla/pnpm-lock.yaml
@@ -30,9 +30,6 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@kson/lsp-shared@file:../../shared':
-    resolution: {directory: ../../shared, type: directory}
-
   '@kson_org/monaco-editor@file:../../monaco':
     resolution: {directory: ../../monaco, type: directory}
     peerDependencies:
@@ -152,12 +149,6 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -175,18 +166,6 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  kson-kson-lib@file:../../../../kson-lib/build/dist/js/productionLibrary:
-    resolution: {directory: ../../../../kson-lib/build/dist/js/productionLibrary, type: directory}
-    bundledDependencies: []
-
-  kson-kson-tooling-lib@file:../../../../kson-tooling-lib/build/dist/js/productionLibrary:
-    resolution: {directory: ../../../../kson-tooling-lib/build/dist/js/productionLibrary, type: directory}
-    bundledDependencies: []
-
-  kson-language-server@file:../../../language-server-protocol:
-    resolution: {directory: ../../../language-server-protocol, type: directory}
-    engines: {node: 24.x}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -262,10 +241,6 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  minimatch@5.1.9:
-    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
-    engines: {node: '>=10'}
-
   monaco-editor@0.52.2:
     resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
 
@@ -288,11 +263,6 @@ packages:
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
-    engines: {node: '>=10'}
     hasBin: true
 
   source-map-js@1.2.1:
@@ -349,30 +319,6 @@ packages:
       yaml:
         optional: true
 
-  vscode-jsonrpc@8.2.0:
-    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
-    engines: {node: '>=14.0.0'}
-
-  vscode-languageclient@9.0.1:
-    resolution: {integrity: sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==}
-    engines: {vscode: ^1.82.0}
-
-  vscode-languageserver-protocol@3.17.5:
-    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
-
-  vscode-languageserver-textdocument@1.0.12:
-    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
-
-  vscode-languageserver-types@3.17.5:
-    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
-
-  vscode-languageserver@9.0.1:
-    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
-    hasBin: true
-
-  vscode-uri@3.1.0:
-    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
-
 snapshots:
 
   '@emnapi/core@1.10.0':
@@ -391,15 +337,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@kson/lsp-shared@file:../../shared':
-    dependencies:
-      kson-language-server: file:../../../language-server-protocol
-      vscode-languageclient: 9.0.1
-      vscode-languageserver: 9.0.1
-
   '@kson_org/monaco-editor@file:../../monaco(monaco-editor@0.52.2)':
     dependencies:
-      '@kson/lsp-shared': file:../../shared
       monaco-editor: 0.52.2
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -467,12 +406,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  balanced-match@1.0.2: {}
-
-  brace-expansion@2.1.1:
-    dependencies:
-      balanced-match: 1.0.2
-
   detect-libc@2.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
@@ -481,18 +414,6 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
-
-  kson-kson-lib@file:../../../../kson-lib/build/dist/js/productionLibrary: {}
-
-  kson-kson-tooling-lib@file:../../../../kson-tooling-lib/build/dist/js/productionLibrary: {}
-
-  kson-language-server@file:../../../language-server-protocol:
-    dependencies:
-      kson: kson-kson-lib@file:../../../../kson-lib/build/dist/js/productionLibrary
-      kson-tooling: kson-kson-tooling-lib@file:../../../../kson-tooling-lib/build/dist/js/productionLibrary
-      vscode-languageserver: 9.0.1
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.1.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -543,10 +464,6 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  minimatch@5.1.9:
-    dependencies:
-      brace-expansion: 2.1.1
-
   monaco-editor@0.52.2: {}
 
   nanoid@3.3.12: {}
@@ -582,8 +499,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
 
-  semver@7.8.4: {}
-
   source-map-js@1.2.1: {}
 
   tinyglobby@0.2.17:
@@ -603,26 +518,3 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       fsevents: 2.3.3
-
-  vscode-jsonrpc@8.2.0: {}
-
-  vscode-languageclient@9.0.1:
-    dependencies:
-      minimatch: 5.1.9
-      semver: 7.8.4
-      vscode-languageserver-protocol: 3.17.5
-
-  vscode-languageserver-protocol@3.17.5:
-    dependencies:
-      vscode-jsonrpc: 8.2.0
-      vscode-languageserver-types: 3.17.5
-
-  vscode-languageserver-textdocument@1.0.12: {}
-
-  vscode-languageserver-types@3.17.5: {}
-
-  vscode-languageserver@9.0.1:
-    dependencies:
-      vscode-languageserver-protocol: 3.17.5
-
-  vscode-uri@3.1.0: {}

--- a/tooling/lsp-clients/monaco/package.json
+++ b/tooling/lsp-clients/monaco/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kson_org/monaco-editor",
   "//": "[[kson-version-num]]",
-  "version": "0.3.0-dev.0",
+  "version": "0.3.0-dev.1",
   "description": "Monaco editor with KSON language support and LSP integration",
   "type": "module",
   "scripts": {
@@ -35,10 +35,6 @@
     "./react": { "import": "./dist/react/index.js", "types": "./dist/react/index.d.ts" }
   },
   "files": ["dist", "dist-iframe", "readme.md"],
-  "dependencies": {
-    "@kson/lsp-shared": "file:../shared",
-    "kson-language-server": "file:../../language-server-protocol"
-  },
   "peerDependencies": {
     "monaco-editor": ">=0.50.0",
     "react": ">=18.0.0"
@@ -47,8 +43,10 @@
     "react": { "optional": true }
   },
   "devDependencies": {
+    "@kson/lsp-shared": "file:../shared",
     "@types/react": "^18.3.0",
     "happy-dom": "^20.8.4",
+    "kson-language-server": "file:../../language-server-protocol",
     "monaco-editor": "^0.52.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/tooling/lsp-clients/monaco/src/packaging.test.ts
+++ b/tooling/lsp-clients/monaco/src/packaging.test.ts
@@ -1,0 +1,54 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// The bundler inlines `@kson/lsp-shared` and `kson-language-server`, so they are
+// build-time only; shipping them as runtime deps hands consumers a monorepo-relative
+// `file:` path that resolves on no registry. The demos miss this — a directory `file:`
+// install resolves the nested `file:` against the source tree — so only a packed
+// tarball is a faithful check.
+const LOCAL_ONLY_PROTOCOLS = ['file:', 'link:', 'workspace:'];
+
+const packageRoot = resolve(__dirname, '..');
+
+let packedManifest: {
+    dependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+};
+let packDir: string;
+
+// 60s timeout: packing reads the whole ~8MB dist tree, which is slow on a cold CI disk.
+beforeAll(() => {
+    packDir = mkdtempSync(join(tmpdir(), 'kson-monaco-pack-'));
+    execFileSync('pnpm', ['pack', '--pack-destination', packDir], {
+        cwd: packageRoot,
+        stdio: 'pipe',
+    });
+
+    const tarball = readdirSync(packDir).find((f) => f.endsWith('.tgz'));
+    if (!tarball) throw new Error(`pnpm pack produced no tarball in ${packDir}`);
+
+    const manifest = execFileSync('tar', ['-xzOf', join(packDir, tarball), 'package/package.json'], {
+        encoding: 'utf8',
+    });
+    packedManifest = JSON.parse(manifest);
+}, 60_000);
+
+afterAll(() => {
+    if (packDir) rmSync(packDir, { recursive: true, force: true });
+});
+
+describe('packed tarball manifest', () => {
+    it.each(['dependencies', 'peerDependencies'] as const)(
+        'declares no local-only specifiers in %s',
+        (field) => {
+            const offenders = Object.entries(packedManifest[field] ?? {}).filter(([, spec]) =>
+                LOCAL_ONLY_PROTOCOLS.some((protocol) => spec.startsWith(protocol)),
+            );
+
+            expect(offenders).toEqual([]);
+        },
+    );
+});

--- a/tooling/lsp-clients/pnpm-lock.yaml
+++ b/tooling/lsp-clients/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@kson/lsp-shared':
         specifier: file:../shared
         version: link:../shared
-      kson-language-server:
-        specifier: file:../../language-server-protocol
-        version: file:../language-server-protocol
     devDependencies:
       '@types/react':
         specifier: ^18.3.0
@@ -27,6 +24,9 @@ importers:
       happy-dom:
         specifier: ^20.8.4
         version: 20.9.0
+      kson-language-server:
+        specifier: file:../../language-server-protocol
+        version: file:../language-server-protocol
       monaco-editor:
         specifier: ^0.52.0
         version: 0.52.2
@@ -41,7 +41,7 @@ importers:
         version: 8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.0(esbuild@0.27.7)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 5.0.0(esbuild@0.27.7)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0))
       vitest:
         specifier: ^4.1.0
         version: 4.1.5(@types/node@24.12.3)(happy-dom@20.9.0)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0))
@@ -97,13 +97,13 @@ importers:
         version: 1.99.0
       '@vscode/test-electron':
         specifier: ^2.5.2
-        version: 2.5.2
+        version: 2.5.2(supports-color@8.1.1)
       '@vscode/test-web':
         specifier: ^0.0.71
-        version: 0.0.71
+        version: 0.0.71(supports-color@8.1.1)
       '@vscode/vsce':
         specifier: ^3.6.0
-        version: 3.9.1
+        version: 3.9.1(supports-color@8.1.1)
       esbuild:
         specifier: ^0.25.5
         version: 0.25.12
@@ -3193,7 +3193,7 @@ snapshots:
     dependencies:
       vary: 1.1.2
 
-  '@koa/router@13.1.1':
+  '@koa/router@13.1.1(supports-color@8.1.1)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
@@ -3441,8 +3441,8 @@ snapshots:
 
   '@typespec/ts-http-runtime@0.3.5':
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -3500,28 +3500,28 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vscode/test-electron@2.5.2':
+  '@vscode/test-electron@2.5.2(supports-color@8.1.1)':
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       jszip: 3.10.1
       ora: 8.2.0
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
-  '@vscode/test-web@0.0.71':
+  '@vscode/test-web@0.0.71(supports-color@8.1.1)':
     dependencies:
       '@koa/cors': 5.0.0
-      '@koa/router': 13.1.1
+      '@koa/router': 13.1.1(supports-color@8.1.1)
       '@playwright/browser-chromium': 1.59.1
       gunzip-maybe: 1.4.2
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       koa: 3.2.0
       koa-morgan: 1.0.1
-      koa-mount: 4.2.0
-      koa-static: 5.0.0
+      koa-mount: 4.2.0(supports-color@8.1.1)
+      koa-static: 5.0.0(supports-color@8.1.1)
       minimist: 1.2.8
       playwright: 1.59.1
       tar-fs: 3.1.2
@@ -3572,7 +3572,7 @@ snapshots:
       '@vscode/vsce-sign-win32-arm64': 2.0.6
       '@vscode/vsce-sign-win32-x64': 2.0.6
 
-  '@vscode/vsce@3.9.1':
+  '@vscode/vsce@3.9.1(supports-color@8.1.1)':
     dependencies:
       '@azure/identity': 4.13.1
       '@secretlint/node': 10.2.2
@@ -3595,7 +3595,7 @@ snapshots:
       minimatch: 3.1.5
       parse-semver: 1.1.1
       read: 1.0.7
-      secretlint: 10.2.2
+      secretlint: 10.2.2(supports-color@8.1.1)
       semver: 7.7.4
       tmp: 0.2.5
       typed-rest-client: 1.8.11
@@ -4296,14 +4296,14 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -4453,14 +4453,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  koa-mount@4.2.0:
+  koa-mount@4.2.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       koa-compose: 4.1.0
     transitivePeerDependencies:
       - supports-color
 
-  koa-send@5.0.1:
+  koa-send@5.0.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       http-errors: 1.8.1
@@ -4468,10 +4468,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  koa-static@5.0.0:
+  koa-static@5.0.0(supports-color@8.1.1):
     dependencies:
       debug: 3.2.7
-      koa-send: 5.0.1
+      koa-send: 5.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5086,7 +5086,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  secretlint@10.2.2:
+  secretlint@10.2.2(supports-color@8.1.1):
     dependencies:
       '@secretlint/config-creator': 10.2.2
       '@secretlint/formatter': 10.2.2
@@ -5412,7 +5412,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unplugin-dts@1.0.0(esbuild@0.27.7)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0)):
+  unplugin-dts@1.0.0(esbuild@0.27.7)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
       '@rollup/pluginutils': 5.3.0
       '@volar/typescript': 2.4.28
@@ -5451,9 +5451,9 @@ snapshots:
 
   version-range@4.15.0: {}
 
-  vite-plugin-dts@5.0.0(esbuild@0.27.7)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0)):
+  vite-plugin-dts@5.0.0(esbuild@0.27.7)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
-      unplugin-dts: 1.0.0(esbuild@0.27.7)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0))
+      unplugin-dts: 1.0.0(esbuild@0.27.7)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0))
     optionalDependencies:
       vite: 8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0)
     transitivePeerDependencies:

--- a/tooling/lsp-clients/pnpm-lock.yaml
+++ b/tooling/lsp-clients/pnpm-lock.yaml
@@ -13,11 +13,10 @@ importers:
         version: 5.9.3
 
   monaco:
-    dependencies:
+    devDependencies:
       '@kson/lsp-shared':
         specifier: file:../shared
         version: link:../shared
-    devDependencies:
       '@types/react':
         specifier: ^18.3.0
         version: 18.3.28


### PR DESCRIPTION
`@kson/lsp-shared` and `kson-language-server` were declared as runtime `dependencies` via monorepo-relative `file:` paths, but neither package is published and neither path exists outside this repo. The bundler inlines both, so they are build-time only: move them to `devDependencies`, which is what the relationship actually is. Consumers of the published tarball hit this hard — pnpm fails outright with `ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND`, while npm silently plants a dangling symlink and a damaged lockfile that breaks the next install. 

The demo installs never caught it because a directory `file:` install resolves the nested `file:` against the real source tree, so only a packed tarball is a faithful proxy for what consumers receive; the new test packs the package and asserts the shipped manifest declares no local-only specifiers.