### PR TITLE
Allow dashes and combining marks in unquoted strings

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -58,13 +58,13 @@ Here is a KSON [list](#lists) demonstrating a variety of supported numbers:
 
 Strings in KSON are identical to [strings in JSON](https://datatracker.ietf.org/doc/html/rfc8259#section-7), except:
 
-- KSON strings may be unquoted if they are 'simple', i.e. they only contain letters (from any alphabet), numbers or underscores, and they do not start with a number
+- KSON strings may be unquoted if they are 'simple', i.e. they only contain letters (from any alphabet), numbers, underscores, or dashes. They do not start with a number or a dash.
 
 ```kson
 an_unqu0t3d_striπg
 ```
 
-One consequence of unquoted strings: a bare `true`, `false` or `null` is always its literal value, exactly as in JSON&mdash;quote it (`'true'`) when the string is intended. Likewise, since spaces, dashes and dots are not simple-string characters, strings like `The Great Gatsby`, `2020-01-01` or `kebab-case` must be quoted&mdash;unlike in YAML, `title: The Great Gatsby` is not a single string.
+One consequence of unquoted strings: a bare `true`, `false` or `null` is always its literal value, exactly as in JSON&mdash;quote it (`'true'`) when the string is intended. Likewise, a string that is not 'simple' must be quoted: `The Great Gatsby` (spaces), `v1.2` (a dot) and `2020-01-01` (a leading number) all require quotes&mdash;unlike in YAML, `title: The Great Gatsby` is not valid.
 
 - KSON strings may be quoted using a single quote rather than a double quote. Here is a [list](#lists) of strings demonstrating the difference:
 

--- a/src/commonMain/kotlin/org/kson/parser/behavior/StringUnquoted.kt
+++ b/src/commonMain/kotlin/org/kson/parser/behavior/StringUnquoted.kt
@@ -30,9 +30,12 @@ object StringUnquoted {
 
     /**
      * Returns true if [ch] is a legal [Char] for the body of an unquoted Kson string
+     *
+     * Note that `-` is legal in the body but not as a start [Char], where it would
+     * clash with list dashes and negative numbers
      */
     fun isUnquotedBodyChar(ch: Char?): Boolean {
         ch ?: return false
-        return isUnquotedStartChar(ch) || ch.isDigit()
+        return isUnquotedStartChar(ch) || ch.isDigit() || ch == '-'
     }
 }

--- a/src/commonMain/kotlin/org/kson/parser/behavior/StringUnquoted.kt
+++ b/src/commonMain/kotlin/org/kson/parser/behavior/StringUnquoted.kt
@@ -37,5 +37,25 @@ object StringUnquoted {
     fun isUnquotedBodyChar(ch: Char?): Boolean {
         ch ?: return false
         return isUnquotedStartChar(ch) || ch.isDigit() || ch == '-'
+                // combining marks are body-only characters since they attach to the character before them and
+                // cannot meaningfully start a string
+                || isCombiningMark(ch)
+    }
+
+    /**
+     * Returns true if [ch] is a combining mark used to spell words: a character that renders
+     * attached to the character before it, such as the vowel signs and virama of Devanagari or
+     * Arabic diacritics. We support these in unquoted strings as part of trying to holistically
+     * support non-ASCII alphabets, similar to the rationale for allowed
+     * variable names in Python (see https://peps.python.org/pep-3131)
+     *
+     * We admit the nonspacing (Mn) and spacing (Mc) mark categories, matching Unicode's
+     * identifier rules (UAX #31 ID_Continue, https://www.unicode.org/reports/tr31/).
+     * Enclosing marks (Me) are deliberately excluded, also per UAX #31: they decorate
+     * symbols rather than spell words.
+     */
+    private fun isCombiningMark(ch: Char): Boolean {
+        val category = ch.category
+        return category == CharCategory.NON_SPACING_MARK || category == CharCategory.COMBINING_SPACING_MARK
     }
 }

--- a/src/commonTest/kotlin/org/kson/KsonCoreTestString.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestString.kt
@@ -294,6 +294,59 @@ class KsonCoreTestString : KsonCoreTest {
     }
 
     @Test
+    fun testUnquotedStringWithCombiningMarks() {
+        // हिन्दी spells with Devanagari vowel signs and a virama, which are combining marks rather than letters
+        assertParsesTo(
+            """
+                हिन्दी
+            """.trimIndent(),
+            """
+                हिन्दी
+            """.trimIndent(),
+            """
+                हिन्दी
+            """.trimIndent(),
+            """
+                "हिन्दी"
+            """.trimIndent()
+        )
+
+        // a quoted string spelled with combining marks formats to unquoted
+        assertParsesTo(
+            """
+                'भाषा': 'हिन्दी'
+            """.trimIndent(),
+            """
+                भाषा: हिन्दी
+            """.trimIndent(),
+            """
+                भाषा: हिन्दी
+            """.trimIndent(),
+            """
+                {
+                  "भाषा": "हिन्दी"
+                }
+            """.trimIndent()
+        )
+
+        // a leading combining mark is not a simple-string character, so this string stays quoted
+        assertParsesTo(
+            """
+                'िa'
+            """.trimIndent(),
+            """
+                'िa'
+            """.trimIndent(),
+            """
+                "िa"
+            """.trimIndent(),
+            """
+                "िa"
+            """.trimIndent()
+        )
+    }
+
+    @Test
     fun testReservedKeywordStringsAreQuoted() {
         // Test that strings with reserved keyword content are properly quoted
         assertParsesTo(

--- a/src/commonTest/kotlin/org/kson/KsonCoreTestString.kt
+++ b/src/commonTest/kotlin/org/kson/KsonCoreTestString.kt
@@ -220,6 +220,80 @@ class KsonCoreTestString : KsonCoreTest {
     }
 
     @Test
+    fun testUnquotedStringWithDashes() {
+        assertParsesTo(
+            """
+                kebab-case
+            """.trimIndent(),
+            """
+                kebab-case
+            """.trimIndent(),
+            """
+                kebab-case
+            """.trimIndent(),
+            """
+                "kebab-case"
+            """.trimIndent()
+        )
+
+        // quoted simple strings containing dashes format to unquoted
+        assertParsesTo(
+            """
+                'kebab-case': 'v1-2-3'
+            """.trimIndent(),
+            """
+                kebab-case: v1-2-3
+            """.trimIndent(),
+            """
+                kebab-case: v1-2-3
+            """.trimIndent(),
+            """
+                {
+                  "kebab-case": "v1-2-3"
+                }
+            """.trimIndent()
+        )
+
+        // a trailing dash is part of the string, and does not disturb dash list parsing
+        assertParsesTo(
+            """
+                - kebab-case
+                - trailing-
+            """.trimIndent(),
+            """
+                - kebab-case
+                - trailing-
+            """.trimIndent(),
+            """
+                - kebab-case
+                - trailing-
+            """.trimIndent(),
+            """
+                [
+                  "kebab-case",
+                  "trailing-"
+                ]
+            """.trimIndent()
+        )
+
+        // a leading dash is not a simple-string character, so this string stays quoted
+        assertParsesTo(
+            """
+                '-leading'
+            """.trimIndent(),
+            """
+                '-leading'
+            """.trimIndent(),
+            """
+                "-leading"
+            """.trimIndent(),
+            """
+                "-leading"
+            """.trimIndent()
+        )
+    }
+
+    @Test
     fun testReservedKeywordStringsAreQuoted() {
         // Test that strings with reserved keyword content are properly quoted
         assertParsesTo(

--- a/src/commonTest/kotlin/org/kson/parser/LexerTest.kt
+++ b/src/commonTest/kotlin/org/kson/parser/LexerTest.kt
@@ -610,6 +610,54 @@ class LexerTest {
     }
 
     @Test
+    fun testUnquotedStringWithDashes() {
+        val kebabTokens = assertTokenizesTo(
+            "kebab-case",
+            listOf(UNQUOTED_STRING)
+        )
+        assertEquals("kebab-case", kebabTokens[0].lexeme.text)
+
+        val digitTokens = assertTokenizesTo(
+            "a-1",
+            listOf(UNQUOTED_STRING),
+            "should allow digits after a dash"
+        )
+        assertEquals("a-1", digitTokens[0].lexeme.text)
+
+        val trailingDashTokens = assertTokenizesTo(
+            "trailing-",
+            listOf(UNQUOTED_STRING),
+            "should allow a trailing dash"
+        )
+        assertEquals("trailing-", trailingDashTokens[0].lexeme.text)
+
+        assertTokenizesTo(
+            "a- b",
+            listOf(UNQUOTED_STRING, UNQUOTED_STRING),
+            "a dash glued to the end of an unquoted string belongs to the string, and is not a LIST_DASH"
+        )
+
+        assertTokenizesTo(
+            "- kebab-case",
+            listOf(LIST_DASH, UNQUOTED_STRING),
+            "a whitespace-delimited dash is still a LIST_DASH"
+        )
+
+        assertTokenizesTo(
+            "-foo",
+            listOf(NUMBER),
+            "a leading dash never starts an unquoted string: it is lexed as a (possibly malformed) number"
+        )
+
+        val keywordPrefixTokens = assertTokenizesTo(
+            "true-ish",
+            listOf(UNQUOTED_STRING),
+            "a reserved keyword followed by a dash is an ordinary unquoted string"
+        )
+        assertEquals("true-ish", keywordPrefixTokens[0].lexeme.text)
+    }
+
+    @Test
     fun testTokenLocations() {
         assertTokenizesTo(
             """

--- a/src/commonTest/kotlin/org/kson/parser/LexerTest.kt
+++ b/src/commonTest/kotlin/org/kson/parser/LexerTest.kt
@@ -658,6 +658,29 @@ class LexerTest {
     }
 
     @Test
+    fun testUnquotedStringWithCombiningMarks() {
+        // हिन्दी spells with Devanagari vowel signs and a virama, which are combining marks rather than letters
+        val devanagariTokens = assertTokenizesTo(
+            "हिन्दी",
+            listOf(UNQUOTED_STRING)
+        )
+        assertEquals("हिन्दी", devanagariTokens[0].lexeme.text)
+
+        assertTokenizesTo(
+            // DEVANAGARI VOWEL SIGN I with no character to attach to
+            "िa",
+            listOf(ILLEGAL_CHAR, UNQUOTED_STRING),
+            "a combining mark cannot start an unquoted string"
+        )
+
+        assertTokenizesTo(
+            "5ि",
+            listOf(NUMBER),
+            "a digit-led lexeme containing a mark is generously lexed as one malformed NUMBER, for a clear error"
+        )
+    }
+
+    @Test
     fun testTokenLocations() {
         assertTokenizesTo(
             """


### PR DESCRIPTION
Two small expansions to the range of strings we allow to go unquoted in KSON. This is likely the full extent of what we will allow in unquoted strings, with a good balance between reading ergonomics and conceptual/parsing complexity.

### [Allow dashes in unquoted strings](https://github.com/kson-org/kson/commit/a7b8497edb15300f0634e869a9f23ebcca430154)

Extend the "simple" string rules for unquoted strings to include `-`. This allows a broader range of strings that are commonly used as keys to be unquoted, without broadening the range so far as to cause confusion either for the user or our parsing code.

With this in place, our unquoted strings now strongly resemble the range of allowed "bare" keys in TOML (with KSON allowing letters from any alphabet, rather than TOML's ASCII-only restriction), and of legal CSS class names, so there is precedent for this range. In contrast with both of those, we do not allow unquoted strings to start with `-` (this is by design to minimize conflict/confusion with negative numbers and dash lists).

### [Allow combining marks in unquoted strings](https://github.com/kson-org/kson/commit/693740f1d75b3f15383dfd710a3e93309165930b)

Scripts like Devanagari spell words with combining marks: हिन्दी contains vowel signs and a virama, i.e. marks (Unicode Mn/Mc) that are part of letters while not strictly speaking being letters themselves.

Update our unquoted string parsing to allow these as part of our desire to allow letters from any alphabet. See [PEP 3131](https://peps.python.org/pep-3131) for some related prior art.