### PR TITLE
Use ./vscode path filter in lsp-clients build scripts

### DIFF
--- a/tooling/lsp-clients/package.json
+++ b/tooling/lsp-clients/package.json
@@ -6,13 +6,13 @@
   "description": "KSON Language Server Protocol Extensions",
   "scripts": {
     "buildMonaco": "pnpm run compile && pnpm --filter @kson_org/monaco-editor run build",
-    "buildVSCode": "pnpm run compile && pnpm --filter kson run packagePlugin",
+    "buildVSCode": "pnpm run compile && pnpm --filter ./vscode run packagePlugin",
     "buildMonacoIframe": "pnpm run compile && pnpm --filter @kson_org/monaco-editor run build:iframe",
     "buildPlugins": "pnpm run buildMonaco && pnpm run buildVSCode",
-    "compile": "pnpm --filter @kson/lsp-shared run compile && pnpm --filter kson run compile",
+    "compile": "pnpm --filter @kson/lsp-shared run compile && pnpm --filter ./vscode run compile",
     "clean": "pnpm -r run clean",
     "test": "pnpm run compile && pnpm -r run test",
-    "vscode": "pnpm run compile && pnpm --filter kson run vscode"
+    "vscode": "pnpm run compile && pnpm --filter ./vscode run vscode"
   },
   "devDependencies": {
     "typescript": "^5.0.0"


### PR DESCRIPTION
The `buildVSCode`, `compile`, and vscode scripts filtered the vscode workspace member by its package name (`--filter kson`). Switching to the `./vscode` path filter makes them consistent with `pnpm-workspace.yaml`, which already declares members by directory.