### PR TITLE
Render Message, Result, and Position instances as readable text

### DIFF
--- a/kson-lib/src/commonMain/kotlin/org/kson/Kson.kt
+++ b/kson-lib/src/commonMain/kotlin/org/kson/Kson.kt
@@ -141,16 +141,26 @@ object Kson {
  * Result of a Kson conversion operation
  */
 sealed class Result {
-    class Success(val output: String) : Result()
-    class Failure(val errors: List<Message>) : Result()
+    class Success(val output: String) : Result() {
+        override fun toString(): String = "Success"
+    }
+
+    class Failure(val errors: List<Message>) : Result() {
+        override fun toString(): String = "Failure: ${errors.size} errors"
+    }
 }
 
 /**
  * A [parseSchema] result
  */
 sealed class SchemaResult {
-    class Success(val schemaValidator: SchemaValidator) : SchemaResult()
-    class Failure(val errors: List<Message>) : SchemaResult()
+    class Success(val schemaValidator: SchemaValidator) : SchemaResult() {
+        override fun toString(): String = "Success"
+    }
+
+    class Failure(val errors: List<Message>) : SchemaResult() {
+        override fun toString(): String = "Failure: ${errors.size} errors"
+    }
 }
 
 /**
@@ -383,7 +393,19 @@ enum class TokenType {
 /**
  * Represents a message logged during Kson processing
  */
-class Message internal constructor(val message: String, val severity: MessageSeverity, val start: Position, val end: Position)
+class Message internal constructor(val message: String, val severity: MessageSeverity, val start: Position, val end: Position) {
+    /**
+     * Render this message as human-readable text. Note that start/end [Position]
+     * are 0-based, while the line and column rendered here are 1-based.
+     */
+    fun render(): String =
+        "[$severity] $message at ${start.render1Based()}"
+
+    /**
+     * Note: delegates to [render] to avoid seeing only an object identity string.
+     */
+    override fun toString(): String = render()
+}
 
 /**
  * Represents the severity of a [Message]
@@ -401,6 +423,17 @@ enum class MessageSeverity{
  */
 class Position internal constructor(val line: Int, val column: Int) {
     internal constructor(coordinates: Coordinates) : this(coordinates.line, coordinates.column)
+
+    /**
+     *  Using 1-based line/column numbers
+     *  following [the gnu standard](https://www.gnu.org/prep/standards/html_node/Errors.html)
+     *  for this sort of output.
+     *
+     *  @see Coordinates.toString
+     */
+    fun render1Based(): String = "${line + 1}:${column + 1}"
+
+    override fun toString(): String = render1Based()
 }
 
 /**

--- a/kson-lib/src/commonTest/kotlin/org/kson/KsonSmokeTest.kt
+++ b/kson-lib/src/commonTest/kotlin/org/kson/KsonSmokeTest.kt
@@ -79,7 +79,26 @@ class KsonSmokeTest {
         assertTrue(error.start.line == 0)
         assertTrue(error.start.column > 0)
     }
-    
+
+    @Test
+    fun testMessage_toString_rendersReadableOneBasedLocation() {
+        val input = """{"invalid": }"""
+        val result = Kson.toJson(input)
+        assertIs<Result.Failure>(result)
+        val error = result.errors.first()
+
+        val rendered = error.render()
+        assertTrue(rendered.contains(error.message))
+        assertTrue(rendered.contains("[${error.severity}]"))
+        // `start` is 0-based, but the rendered location is 1-based
+        assertTrue(rendered.endsWith("at ${error.start.line + 1}:${error.start.column + 1}"))
+
+        // toString() delegates to render(), so logging a Message never yields an
+        // object identity string
+        assertEquals(rendered, error.toString())
+        assertFalse(error.toString().contains("org.kson.Message@"))
+    }
+
     @Test
     fun testToYaml_success() {
         val input = """{"name": "test", "value": 123}"""

--- a/lib-python/src/kson/__init__.py
+++ b/lib-python/src/kson/__init__.py
@@ -420,6 +420,29 @@ class Position(KotlinObjectBase):
 
         return cast(Any, (lambda x0: x0)(result))
 
+    def render1_based(
+        self,
+    ) -> str:
+        """ Using 1-based line/column numbers
+         following [the gnu standard](https://www.gnu.org/prep/standards/html_node/Errors.html)
+         for this sort of output.
+
+         @see Coordinates.toString
+        """
+
+
+        jni_ref = self._jni_ref
+        result = _call_method(
+            b"org/kson/Position",
+            jni_ref,
+            b"render1Based",
+            b"()Ljava/lang/String;",
+            "ObjectMethod",
+            []
+        )
+
+        return cast(Any, (_java_string_to_python_str)(result))
+
 
 class Message(KotlinObjectBase):
     """Represents a message logged during Kson processing"""
@@ -493,6 +516,26 @@ class Message(KotlinObjectBase):
         )
 
         return cast(Any, (lambda x0: _from_kotlin_object(Position, x0))(result))
+
+    def render(
+        self,
+    ) -> str:
+        """Render this message as human-readable text. Note that start/end [Position]
+        are 0-based, while the line and column rendered here are 1-based.
+        """
+
+
+        jni_ref = self._jni_ref
+        result = _call_method(
+            b"org/kson/Message",
+            jni_ref,
+            b"render",
+            b"()Ljava/lang/String;",
+            "ObjectMethod",
+            []
+        )
+
+        return cast(Any, (_java_string_to_python_str)(result))
 
 
 class Token(KotlinObjectBase):

--- a/lib-rust/kson/src/generated/mod.rs
+++ b/lib-rust/kson/src/generated/mod.rs
@@ -241,6 +241,32 @@ impl Position {
 
         result
     }
+
+    /// Using 1-based line/column numbers
+    /// following [the gnu standard](https://www.gnu.org/prep/standards/html_node/Errors.html)
+    /// for this sort of output.
+    ///
+    /// @see Coordinates.toString
+    pub fn render1_based(
+        &self,
+    ) -> String {
+        let self_ptr = self.to_kotlin_object();
+        let self_obj = self_ptr.as_kotlin_object();
+
+
+        let (_, _detach_guard) = util::attach_thread_to_java_vm();
+        let result = call_jvm_function!(
+            util,
+            c"org/kson/Position",
+            c"render1Based",
+            c"()Ljava/lang/String;",
+            CallObjectMethod,
+            self_obj,
+
+        );
+
+        FromKotlinObject::from_kotlin_object(result)
+    }
 }
 
 impl std::fmt::Debug for Position {
@@ -434,6 +460,29 @@ impl Message {
             c"org/kson/Message",
             c"getEnd",
             c"()Lorg/kson/Position;",
+            CallObjectMethod,
+            self_obj,
+
+        );
+
+        FromKotlinObject::from_kotlin_object(result)
+    }
+
+    /// Render this message as human-readable text. Note that start/end [Position]
+    /// are 0-based, while the line and column rendered here are 1-based.
+    pub fn render(
+        &self,
+    ) -> String {
+        let self_ptr = self.to_kotlin_object();
+        let self_obj = self_ptr.as_kotlin_object();
+
+
+        let (_, _detach_guard) = util::attach_thread_to_java_vm();
+        let result = call_jvm_function!(
+            util,
+            c"org/kson/Message",
+            c"render",
+            c"()Ljava/lang/String;",
             CallObjectMethod,
             self_obj,
 


### PR DESCRIPTION
Previously these classes used the default implementation of toString. Whether called directly, in a method like joinToString, or in a debugger these all rendered the object identity (e.g., `org.kson.Message@<hash>`). This change instead makes the toString for Message, Result/SchemaResult (success or failure), and Position render more human-useful text.

Note that positions in this change are all rendered 1-based (i.e., lines and columns start at 1, not 0).

Closes #412 .