### PR TITLE
Keep parse warnings when a schema is attached

### DIFF
--- a/kson-lib/src/commonMain/kotlin/org/kson/Kson.kt
+++ b/kson-lib/src/commonMain/kotlin/org/kson/Kson.kt
@@ -162,7 +162,9 @@ class SchemaValidator internal constructor(private val schema: JsonSchema) {
      * @param kson The Kson source to validate
      * @param filepath Optional filepath of the document being validated, used by validators to determine which rules to apply
      *
-     * @return A list of validation error messages, or empty list if valid
+     * @return The [Message]'s from parsing [kson] followed by any schema violations, or an empty list if [kson] parses
+     *   cleanly and satisfies the schema. [Message]'s with [MessageSeverity.ERROR] short-circuit schema validation: an
+     *   unparseable document cannot be checked against a schema, so only its parse messages come back.
      */
     fun validate(kson: String, filepath: String? = null): List<Message> {
         val astParseResult = KsonCore.parseToAst(
@@ -179,7 +181,7 @@ class SchemaValidator internal constructor(private val schema: JsonSchema) {
             schema.validate(ksonValue, messageSink, SourceContext(filepath))
         }
 
-        return publishMessages(messageSink.loggedMessages())
+        return publishMessages(astParseResult.messages + messageSink.loggedMessages())
     }
 }
 

--- a/kson-lib/src/commonTest/kotlin/org/kson/KsonSmokeTest.kt
+++ b/kson-lib/src/commonTest/kotlin/org/kson/KsonSmokeTest.kt
@@ -293,6 +293,22 @@ class KsonSmokeTest {
     }
 
     @Test
+    fun testSchemaValidator_validateReportsParseWarnings() {
+        val schemaKson = """{"type": "object"}"""
+        val schemaResult = Kson.parseSchema(schemaKson)
+        assertIs<SchemaResult.Success>(schemaResult)
+
+        val validator = schemaResult.schemaValidator
+        val duplicateKeyKson = """{"name": "a", "name": "b"}"""
+        val messages = validator.validate(duplicateKeyKson)
+        assertEquals(1, messages.size,
+            "the parse-phase duplicate key warning must survive schema validation, got: " +
+                    messages.map { it.message })
+        assertEquals(MessageSeverity.WARNING, messages[0].severity)
+        assertTrue(messages[0].message.contains("Duplicate key"), messages[0].message)
+    }
+
+    @Test
     fun testPropertyKeys_basicAccess() {
         val input = """
             name: John

--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/DiagnosticBuilder.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/DiagnosticBuilder.kt
@@ -9,8 +9,9 @@ import org.kson.validation.SourceContext
 /**
  * Validates a KSON document and returns [DiagnosticMessage]s.
  *
- * If a schema is provided and valid, validation includes both parse errors and schema violations.
- * If no schema is provided or the schema fails to parse, only document parse errors are returned.
+ * If a schema is provided and valid, validation includes both the document's parse diagnostics
+ * (errors and warnings) and the schema violations.
+ * If no schema is provided or the schema fails to parse, only document parse diagnostics are returned.
  */
 internal object DiagnosticBuilder {
 

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/DiagnosticTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/DiagnosticTest.kt
@@ -114,6 +114,38 @@ class DiagnosticTest {
     }
 
     @Test
+    fun testSchemaValidationKeepsParseWarnings() {
+        val schema = """
+            {
+                type: object
+                properties: {
+                    name: { type: string }
+                }
+            }
+        """.trimIndent()
+        val diagnostics = validateDocument("{ name: \"Alice\", name: \"Bob\" }", schema)
+        assertEquals(1, diagnostics.size, "duplicate key warning should be reported alongside schema checks")
+        assertEquals(DiagnosticSeverity.WARNING, diagnostics[0].severity)
+        assertTrue(diagnostics[0].message.contains("Duplicate key"), diagnostics[0].message)
+    }
+
+    @Test
+    fun testSchemaValidationDoesNotDuplicateParseErrors() {
+        val schema = """
+            {
+                type: object
+                properties: {
+                    name: { type: string }
+                }
+            }
+        """.trimIndent()
+        val diagnostics = validateDocument("key: \"value\" extra", schema)
+        assertEquals(1, diagnostics.size,
+            "the parse error must be reported once, not once per validation pass: $diagnostics")
+        assertEquals(DiagnosticSeverity.ERROR, diagnostics[0].severity)
+    }
+
+    @Test
     fun testValidDocumentMatchingSchema() {
         val schema = """
             {

--- a/lib-python/src/kson/__init__.py
+++ b/lib-python/src/kson/__init__.py
@@ -976,7 +976,9 @@ class SchemaValidator(KotlinObjectBase):
         @param kson The Kson source to validate
         @param filepath Optional filepath of the document being validated, used by validators to determine which rules to apply
 
-        @return A list of validation error messages, or empty list if valid
+        @return The [Message]'s from parsing [kson] followed by any schema violations, or an empty list if [kson] parses
+          cleanly and satisfies the schema. [Message]'s with [MessageSeverity.ERROR] short-circuit schema validation: an
+          unparseable document cannot be checked against a schema, so only its parse messages come back.
         """
 
         if kson is None:

--- a/lib-rust/kson/src/generated/mod.rs
+++ b/lib-rust/kson/src/generated/mod.rs
@@ -2130,7 +2130,9 @@ impl SchemaValidator {
     /// @param kson The Kson source to validate
     /// @param filepath Optional filepath of the document being validated, used by validators to determine which rules to apply
     ///
-    /// @return A list of validation error messages, or empty list if valid
+    /// @return The [Message]'s from parsing [kson] followed by any schema violations, or an empty list if [kson] parses
+    /// cleanly and satisfies the schema. [Message]'s with [MessageSeverity.ERROR] short-circuit schema validation: an
+    /// unparseable document cannot be checked against a schema, so only its parse messages come back.
     pub fn validate(
         &self,
         kson: &str,

--- a/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/BaseKsonCommand.kt
+++ b/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/BaseKsonCommand.kt
@@ -3,13 +3,15 @@ package org.kson.tooling.cli.commands
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.parameters.types.outputStream
 import org.kson.Kson
 import org.kson.Message
+import org.kson.MessageSeverity
 import org.kson.SchemaResult
-import java.io.File
+import org.kson.SchemaValidator
 
 abstract class BaseKsonCommand(
     name: String? = null
@@ -29,6 +31,16 @@ abstract class BaseKsonCommand(
     }
 
     protected fun getFilePath(): String? = inputFile?.path
+
+    /**
+     * The `--strict` flag, for commands that do more than check the document. [ValidateCommand] does
+     * not offer it: checking is its only work, so it is always strict.
+     */
+    protected fun strictOption() = option(
+        "--strict",
+        help = "Fail (exit 1) on any diagnostic, including warnings, instead of reporting them and " +
+                "continuing"
+    ).flag()
 
     /**
      * Checks if we should show help instead of processing.
@@ -59,26 +71,62 @@ abstract class BaseKsonCommand(
         output.bufferedWriter().use { it.write(content) }
     }
 
-    protected fun validateWithSchema(ksonContent: String) {
-        val schemaFile = schema ?: return
+    /**
+     * Checks [ksonContent] before the command does its own work, reporting findings on stderr:
+     *
+     * - with `--schema`: reports the parse messages and schema violations, stopping the command on a
+     *   [MessageSeverity.ERROR], or on any diagnostic when [strict]. Warnings alone do not stop it —
+     *   schema violations are all [MessageSeverity.WARNING], so they cannot be told apart from parse
+     *   warnings here.
+     * - without `--schema`: checks nothing unless [strict], which stops the command on any parse
+     *   diagnostic. Otherwise each command handles unparseable input itself: formatting is error
+     *   tolerant by design, and transpiling reports the errors that stopped it.
+     *
+     * [ValidateCommand] instead takes the messages from [validateAgainstSchema] and prints them in the
+     * single report it produces.
+     */
+    protected fun checkDocument(ksonContent: String, strict: Boolean) {
+        val schemaValidator = parseSchemaOrExit()
 
-        val schemaContent = schemaFile.readText()
-
-        when (val schemaResult = Kson.parseSchema(schemaContent)) {
-            is SchemaResult.Success -> {
-                val validationErrors = schemaResult.schemaValidator.validate(ksonContent, getFilePath())
-
-                if (validationErrors.isEmpty()) {
-                    echo("✓ Document is valid according to the schema")
-                } else {
-                    echo("Validation errors:", err = true)
-                    validationErrors.forEach { error ->
-                        echo("  ${errorFormat(error)}", err = true)
-                    }
-                    throw ProgramResult(1)
+        if (schemaValidator == null) {
+            if (strict) {
+                val parseMessages = Kson.analyze(ksonContent, getFilePath()).errors
+                if (parseMessages.isNotEmpty()) {
+                    reportMessages(parseMessages, fatal = true)
                 }
             }
+            return
+        }
 
+        val messages = schemaValidator.validate(ksonContent, getFilePath())
+        if (messages.isEmpty()) {
+            echo("✓ Document is valid according to the schema")
+            return
+        }
+
+        reportMessages(messages, fatal = strict || messages.any { it.severity == MessageSeverity.ERROR })
+    }
+
+    /**
+     * [ksonContent]'s parse messages followed by any `--schema` violations, or null when no schema was
+     * given. Returns them rather than reporting them, for [ValidateCommand]'s single report; every
+     * other command wants [checkDocument].
+     */
+    protected fun validateAgainstSchema(ksonContent: String): List<Message>? {
+        val schemaValidator = parseSchemaOrExit() ?: return null
+
+        return schemaValidator.validate(ksonContent, getFilePath())
+    }
+
+    /**
+     * The `--schema` file parsed into a validator, or null when no schema was given. A schema that
+     * does not itself parse stops the command.
+     */
+    private fun parseSchemaOrExit(): SchemaValidator? {
+        val schemaContent = (schema ?: return null).readText()
+
+        return when (val schemaResult = Kson.parseSchema(schemaContent)) {
+            is SchemaResult.Success -> schemaResult.schemaValidator
             is SchemaResult.Failure -> {
                 echo("Failed to parse schema:", err = true)
                 schemaResult.errors.forEach { error ->
@@ -86,6 +134,21 @@ abstract class BaseKsonCommand(
                 }
                 throw ProgramResult(1)
             }
+        }
+    }
+
+    /**
+     * Prints [messages] on stderr under an "errors" or "warnings" heading, and stops the command when
+     * [fatal].
+     */
+    private fun reportMessages(messages: List<Message>, fatal: Boolean) {
+        echo(if (fatal) "Validation errors:" else "Validation warnings:", err = true)
+        messages.forEach { message ->
+            echo("  ${errorFormat(message)}", err = true)
+        }
+
+        if (fatal) {
+            throw ProgramResult(1)
         }
     }
 }

--- a/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/KsonFormatCommand.kt
+++ b/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/KsonFormatCommand.kt
@@ -48,6 +48,8 @@ class KsonFormatCommand : BaseKsonCommand(name = "format") {
         .choice("plain", "delimited", "compact", "classic")
         .default("plain")
 
+    private val strict by strictOption()
+
     override fun run() {
         super.run()  // Check for help display
 
@@ -63,8 +65,8 @@ class KsonFormatCommand : BaseKsonCommand(name = "format") {
             throw ProgramResult(1)
         }
 
-        // Validate against schema if provided
-        validateWithSchema(ksonContent)
+        // Check the document before formatting it
+        checkDocument(ksonContent, strict)
 
         val indentType = this.indentType
 

--- a/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/TranspileCommand.kt
+++ b/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/TranspileCommand.kt
@@ -41,6 +41,8 @@ abstract class TranspileCommand(
     private val retainEmbedTags by option("--retain-tags", help = "Retain the embed tags of embed blocks")
             .flag()
 
+    private val strict by strictOption()
+
     override fun run() {
         super.run()  // Check for help display
 
@@ -56,8 +58,8 @@ abstract class TranspileCommand(
             throw ProgramResult(1)
         }
 
-        // Validate against schema if provided
-        validateWithSchema(ksonContent)
+        // Check the document before converting it
+        checkDocument(ksonContent, strict)
 
         val options = optionsFactory(retainEmbedTags)
         when (val result = converter(ksonContent, options)) {

--- a/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/ValidateCommand.kt
+++ b/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/ValidateCommand.kt
@@ -30,8 +30,8 @@ class ValidateCommand : BaseKsonCommand() {
         |${"\u0085"}  $CLI_NAME validate -i file.$FILE_EXTENSION -s schema.$FILE_EXTENSION
         |
         |Exit codes:
-        |${"\u0085"}  0 - No errors found
-        |${"\u0085"}  1 - Errors detected (warnings don't affect exit code)
+        |${"\u0085"}  0 - No errors or warnings found
+        |${"\u0085"}  1 - Errors or warnings detected
     """.trimMargin()
 
     private val showTokens by option("--show-tokens", help = "Display lexical tokens (for debugging)")
@@ -53,16 +53,22 @@ class ValidateCommand : BaseKsonCommand() {
             throw ProgramResult(1)
         }
 
-        // Validate against schema if provided
-        validateWithSchema(ksonContent)
+        // A schema's findings already include the document's parse messages, so they stand in for the
+        // analysis diagnostics rather than being reported next to them.
+        val schemaMessages = validateAgainstSchema(ksonContent)
+        if (schemaMessages != null && schemaMessages.isEmpty()) {
+            echo("✓ Document is valid according to the schema")
+        }
 
         // Perform analysis
         val analysis = Kson.analyze(ksonContent, getFilePath())
+        val messages = schemaMessages ?: analysis.errors
+
         var outputString = ""
-        if (analysis.errors.isEmpty()) {
+        if (messages.isEmpty()) {
             outputString += "✓ No errors or warnings found"
         } else {
-            analysis.errors.forEach { outputString += errorFormat(it) }
+            messages.forEach { outputString += errorFormat(it) }
         }
 
         if (showTokens) {
@@ -72,7 +78,7 @@ class ValidateCommand : BaseKsonCommand() {
             }
         }
 
-        if (analysis.errors.isEmpty()) {
+        if (messages.isEmpty()) {
             writeOutput(outputString)
         } else {
             echo(outputString.trimEnd(), err = true)

--- a/tooling/cli/src/test/kotlin/org/kson/tooling/cli/DocumentCheckTest.kt
+++ b/tooling/cli/src/test/kotlin/org/kson/tooling/cli/DocumentCheckTest.kt
@@ -1,0 +1,285 @@
+package org.kson.tooling.cli
+
+import com.github.ajalt.clikt.testing.test
+import org.junit.Test
+import org.kson.tooling.cli.commands.BaseKsonCommand
+import org.kson.tooling.cli.commands.JsonCommand
+import org.kson.tooling.cli.commands.KsonFormatCommand
+import org.kson.tooling.cli.commands.ValidateCommand
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers the checks the commands run over their input, and how `--schema` and `--strict` shape them.
+ *
+ * The check is only as wide as the caller asked for: `--schema` checks against that schema, `--strict`
+ * checks where there would otherwise be no check, and with neither flag `format` and the transpile
+ * commands handle a broken document themselves. `validate` always checks, and folds the schema's
+ * findings into the single report it prints.
+ */
+class DocumentCheckTest {
+
+    private val duplicateKeyDocument = """{ name: "Alice", name: "Bob" }"""
+    private val unparseableDocument = """key: "value" extra"""
+    private val cleanDocument = """{ name: "Alice" }"""
+    private val permissiveSchema = """{"type": "object"}"""
+    private val stringNameSchema = """{"type": "object", "properties": {"name": {"type": "string"}}}"""
+    private val unparseableSchema = """{"type": ]}"""
+
+    private val duplicateKeyWarning = """[WARNING] Duplicate key "name" in object at 0:17"""
+    private val trailingContentError =
+        "[ERROR] Unexpected trailing content. The previous content parsed as a complete Kson document. " +
+                "at 0:13"
+
+    /**
+     * Runs [command] over [document], returning its exit code, both streams, and whatever it wrote to
+     * `-o` (empty when it wrote nothing).
+     */
+    private fun runCommand(
+        command: BaseKsonCommand,
+        document: String,
+        schema: String? = null,
+        vararg extraArgs: String
+    ): CommandRun {
+        val inputFile = writeTempFile("input", ".kson", document)
+        val schemaFile = schema?.let { writeTempFile("schema", ".kson", it) }
+        val outputFile = File.createTempFile("output", ".kson")
+        outputFile.deleteOnExit()
+
+        try {
+            val args = listOf("-i", inputFile.absolutePath, "-o", outputFile.absolutePath) +
+                    (schemaFile?.let { listOf("-s", it.absolutePath) } ?: emptyList()) +
+                    extraArgs
+
+            val result = command.test(args)
+            return CommandRun(result.statusCode, result.stdout, result.stderr, outputFile.readText())
+        } finally {
+            inputFile.delete()
+            schemaFile?.delete()
+            outputFile.delete()
+        }
+    }
+
+    private data class CommandRun(
+        val statusCode: Int,
+        val stdout: String,
+        val stderr: String,
+        val output: String
+    )
+
+    private fun writeTempFile(prefix: String, suffix: String, content: String): File {
+        val file = File.createTempFile(prefix, suffix)
+        file.deleteOnExit()
+        file.writeText(content)
+        return file
+    }
+
+    /**
+     * No check was asked for, so none runs: `format` formats the document and reports nothing.
+     */
+    @Test
+    fun testFormatWithoutSchemaFormatsDespiteParseWarning() {
+        val run = runCommand(KsonFormatCommand(), duplicateKeyDocument)
+
+        assertEquals(0, run.statusCode, "expected exit 0, stderr: ${run.stderr}")
+        assertEquals(
+            """
+            name: Alice
+            name: Bob
+            """.trimIndent(),
+            run.output
+        )
+        assertEquals("", run.stderr, "stderr should be empty without a schema")
+    }
+
+    /**
+     * The formatter is error tolerant by design, so an unrequested check must not reject input it cannot
+     * parse. What it produces for broken input is covered by `FormatterTest`; here it only needs to
+     * exit 0 and write output.
+     */
+    @Test
+    fun testFormatWithoutSchemaFormatsUnparseableDocument() {
+        val run = runCommand(KsonFormatCommand(), unparseableDocument)
+
+        assertEquals(0, run.statusCode, "expected exit 0, stderr: ${run.stderr}")
+        assertEquals("", run.stderr, "stderr should be empty without a schema")
+        assertTrue(run.output.isNotEmpty(), "expected formatted output, got nothing")
+    }
+
+    /**
+     * Converting needs a parseable document, and reports the failure itself rather than being
+     * pre-empted by an unrequested check.
+     */
+    @Test
+    fun testJsonWithoutSchemaReportsItsOwnConversionFailure() {
+        val run = runCommand(JsonCommand(), unparseableDocument)
+
+        assertEquals(1, run.statusCode, "expected exit 1")
+        assertEquals("", run.output, "output should be empty when the conversion fails")
+        assertEquals("Conversion failed with errors:\n  $trailingContentError\n\n", run.stderr)
+    }
+
+    @Test
+    fun testFormatWithStrictFlagFailsOnParseWarning() {
+        val run = runCommand(KsonFormatCommand(), duplicateKeyDocument, schema = null, "--strict")
+
+        assertEquals(1, run.statusCode, "expected exit 1")
+        assertEquals("", run.output, "output should be empty when the check fails")
+        assertEquals("Validation errors:\n  $duplicateKeyWarning\n\n", run.stderr)
+    }
+
+    /**
+     * Without a schema there is no check to report passing, so a clean document produces no stderr.
+     */
+    @Test
+    fun testJsonWithStrictFlagSucceedsOnCleanDocument() {
+        val run = runCommand(JsonCommand(), cleanDocument, schema = null, "--strict")
+
+        assertEquals(0, run.statusCode, "expected exit 0, stderr: ${run.stderr}")
+        assertEquals(
+            """
+            {
+              "name": "Alice"
+            }
+            """.trimIndent(),
+            run.output
+        )
+        assertEquals("", run.stderr, "stderr should be empty without a schema")
+    }
+
+    /**
+     * `-s` reports every diagnostic it finds: a parse warning and a schema violation are both
+     * [org.kson.MessageSeverity.WARNING], so the command cannot tell them apart. Neither stops it.
+     */
+    @Test
+    fun testFormatWithSchemaReportsParseWarningAndContinues() {
+        val run = runCommand(KsonFormatCommand(), duplicateKeyDocument, permissiveSchema)
+
+        assertEquals(0, run.statusCode, "expected exit 0, stderr: ${run.stderr}")
+        assertEquals(
+            """
+            name: Alice
+            name: Bob
+            """.trimIndent(),
+            run.output
+        )
+        assertEquals("Validation warnings:\n  $duplicateKeyWarning\n\n", run.stderr)
+    }
+
+    @Test
+    fun testFormatWithSchemaReportsViolationAndContinues() {
+        val run = runCommand(KsonFormatCommand(), "{ name: 42 }", stringNameSchema)
+
+        assertEquals(0, run.statusCode, "expected exit 0, stderr: ${run.stderr}")
+        assertEquals("name: 42", run.output)
+        assertEquals(
+            "Validation warnings:\n" +
+                    "  [WARNING] Property 'name': Expected one of: string, but got: integer at 0:8\n\n",
+            run.stderr
+        )
+    }
+
+    @Test
+    fun testFormatWithSchemaAndStrictFlagFailsOnWarning() {
+        val run = runCommand(KsonFormatCommand(), duplicateKeyDocument, permissiveSchema, "--strict")
+
+        assertEquals(1, run.statusCode, "expected exit 1, stderr: ${run.stderr}")
+        assertEquals("", run.output, "output should be empty when the check fails")
+        assertEquals("Validation errors:\n  $duplicateKeyWarning\n\n", run.stderr)
+    }
+
+    /**
+     * A document that does not parse cannot be checked against a schema, so the parse error stops the
+     * command with or without `--strict`.
+     */
+    @Test
+    fun testJsonWithSchemaFailsOnParseError() {
+        val run = runCommand(JsonCommand(), unparseableDocument, permissiveSchema)
+
+        assertEquals(1, run.statusCode, "expected exit 1, stderr: ${run.stderr}")
+        assertEquals("", run.output, "output should be empty when the check fails")
+        assertEquals("Validation errors:\n  $trailingContentError\n\n", run.stderr)
+    }
+
+    /**
+     * When the document is clean, the check reports only that the schema is satisfied.
+     */
+    @Test
+    fun testFormatWithSchemaReportsPassingIt() {
+        val run = runCommand(KsonFormatCommand(), cleanDocument, stringNameSchema)
+
+        assertEquals(0, run.statusCode, "expected exit 0, stderr: ${run.stderr}")
+        assertEquals("name: Alice", run.output)
+        assertEquals("✓ Document is valid according to the schema\n", run.stdout)
+        assertEquals("", run.stderr)
+    }
+
+    /**
+     * Checking is all `validate` does, so it is always strict: any diagnostic fails it. The schema's
+     * findings already include the parse messages, so they are reported once, in `validate`'s format.
+     */
+    @Test
+    fun testValidateWithSchemaFailsOnParseWarning() {
+        val run = runCommand(ValidateCommand(), duplicateKeyDocument, permissiveSchema)
+
+        assertEquals(1, run.statusCode, "expected exit 1, stderr: ${run.stderr}")
+        assertEquals("$duplicateKeyWarning\n", run.stderr)
+        assertEquals("", run.stdout, "stdout should be empty when a diagnostic was found")
+    }
+
+    @Test
+    fun testValidateWithSchemaFailsOnSchemaViolation() {
+        val run = runCommand(ValidateCommand(), "{ name: 42 }", stringNameSchema)
+
+        assertEquals(1, run.statusCode, "expected exit 1, stderr: ${run.stderr}")
+        assertEquals(
+            "[WARNING] Property 'name': Expected one of: string, but got: integer at 0:8\n",
+            run.stderr
+        )
+    }
+
+    /**
+     * `--show-tokens` still works with a schema: the report and the token dump both land in the single
+     * report `validate` prints to stderr.
+     */
+    @Test
+    fun testValidateWithSchemaShowsTokensBesideTheWarning() {
+        val run = runCommand(ValidateCommand(), duplicateKeyDocument, permissiveSchema, "--show-tokens")
+
+        assertEquals(1, run.statusCode, "expected exit 1, stderr: ${run.stderr}")
+        val reportAndTokens = run.stderr.split("\n\n\nTokens:\n")
+        assertEquals(2, reportAndTokens.size, "expected a report and a token dump, stderr: ${run.stderr}")
+        assertEquals(duplicateKeyWarning, reportAndTokens[0], "the report should hold the warning exactly once")
+        assertTrue(
+            reportAndTokens[1].contains("UNQUOTED_STRING: 'name' at 0:17-0:21"),
+            "expected the duplicate key's tokens, got: ${reportAndTokens[1]}"
+        )
+    }
+
+    /**
+     * A schema that does not itself parse stops the command rather than being skipped. The message text
+     * is the schema parser's; the heading and formatting are the command's.
+     */
+    @Test
+    fun testValidateWithUnparseableSchemaFails() {
+        val run = runCommand(ValidateCommand(), cleanDocument, unparseableSchema)
+
+        assertEquals(1, run.statusCode, "expected exit 1 for an unparseable schema")
+        assertTrue(run.stderr.startsWith("Failed to parse schema:\n  [ERROR] "), run.stderr)
+    }
+
+    /**
+     * Two verdicts from two places: the schema is satisfied (stdout, from the check) and the document
+     * is clean (the output file, from `validate`).
+     */
+    @Test
+    fun testValidateWithSchemaReportsPassingItAndTheDocument() {
+        val run = runCommand(ValidateCommand(), cleanDocument, stringNameSchema)
+
+        assertEquals(0, run.statusCode, "expected exit 0, stderr: ${run.stderr}")
+        assertEquals("✓ Document is valid according to the schema\n", run.stdout)
+        assertEquals("✓ No errors or warnings found", run.output)
+        assertEquals("", run.stderr)
+    }
+}

--- a/tooling/lsp-clients/vscode/test/suite/schema-loading.test.ts
+++ b/tooling/lsp-clients/vscode/test/suite/schema-loading.test.ts
@@ -297,6 +297,43 @@ describeNode('Schema Loading Tests', () => {
         }
     }).timeout(10000);
 
+    it('Should report parse warnings alongside schema violations', async () => {
+        // The duplicated `appName` is a parse-phase warning; the missing `version` is a
+        // schema violation. Asserting both in one document is what pins the regression:
+        // the schema violation can only come from the schema, so a passing test proves the
+        // schema really was attached, and the warning proves the schema-backed path no
+        // longer discards parse diagnostics.
+        const content = [
+            'appName: "TestApp"',
+            'appName: "OtherApp"'
+        ].join('\n');
+
+        // A fresh filename: SCHEMA_FILENAME is shared by the tests above, and diagnostics
+        // left over from their content would be picked up before this document is analysed.
+        const [testFileUri, document] = await createTestFile(content, `${uuid()}.config.kson`);
+
+        try {
+            const diagnostics = await waitForDiagnostics(document.uri, 2);
+            const messages = diagnostics.map(d => d.message);
+
+            assert.ok(
+                messages.some(m => m.toLowerCase().includes('duplicate')),
+                `Expected a duplicate-key parse warning. Got: ${messages.join(', ')}`
+            );
+            assert.ok(
+                messages.some(m => m.toLowerCase().includes('version')),
+                `Expected a schema violation for the missing 'version' property, which is what
+                 proves the schema was attached. Got: ${messages.join(', ')}`
+            );
+            for (const diagnostic of diagnostics) {
+                assert.strictEqual(diagnostic.severity, vscode.DiagnosticSeverity.Warning,
+                    `Both diagnostics are warnings. Got: ${diagnostic.message}`);
+            }
+        } finally {
+            await cleanUp(testFileUri);
+        }
+    }).timeout(10000);
+
     it('Should report errors for valid Kson file that does not follow schema', async () => {
         // Create a test file that matches the pattern but doesn't follow the schema
         // (missing required properties: appName and version)


### PR DESCRIPTION
Keep parse warnings when a schema is attached

`SchemaValidator.validate` discarded parse-phase warnings, such as duplicate keys, whenever the document had no hard errors: it returned the parse messages only on the error path, and otherwise built a fresh sink holding schema violations alone.

Every consumer was affected: the LSP, the CLI's `--schema` check, and the Python, Rust, JS and Java bindings. It showed most in the editor, which relies solely on `validate` when a schema is attached, so schema-backed documents reported no warnings at all.

## The fix

`validate` now returns the parse messages followed by the schema violations. Parse errors still short-circuit, because an unparseable document cannot be checked against a schema.

## CLI behaviour

Every schema violation is a warning, so a CLI caller cannot tell one from a parse warning. The check is generalised rather than filtered:

- `format`, `json` and `yaml` with `--schema` report every diagnostic on stderr and still produce output, failing only on parse errors or, with the new `--strict` flag, on any diagnostic.
- Without `--schema` nothing changes unless `--strict` is given.
- `validate` keeps failing on any message.

## Tests

Covered at the lib, LSP tooling and CLI layers. The VS Code test gives one document both a duplicate key and a missing required property, so a pass proves the schema was attached rather than the document having silently fallen back to the schema-less path, where parse warnings were never dropped.