### PR TITLE
Narrow unions through $ref and allOf

### DIFF
--- a/src/commonMain/kotlin/org/kson/schema/JsonSchema.kt
+++ b/src/commonMain/kotlin/org/kson/schema/JsonSchema.kt
@@ -110,107 +110,75 @@ class JsonObjectSchema(
   private fun soleRefValidator(): RefValidator? = schemaValidators.singleOrNull() as? RefValidator
 
   /**
-   * For each property this object schema pins to a finite value set — via a sole `const` or `enum`
-   * validator (e.g. `{ "const": "A" }` or `{ "enum": ["A", "B"] }`) — maps the property name to that
-   * set of pinned values.  A property qualifies when its schema's sole validator reports a non-null
-   * [JsonSchemaValidator.pinnedValues].  By default an *empty* pin (`enum: []`) is dropped: it selects
-   * no value, so it carries no discriminating information.  [includeEmptyPins] keeps empty pins for
-   * branch *elimination* — an empty pin definitively rejects whatever value the document supplies.
+   * This schema plus everything it composes with — the target of a lone `$ref` and each `allOf`
+   * member, followed transitively.  Unlike `oneOf`/`anyOf`, these edges compose rather than choose:
+   * every schema reached constrains the same document, so the readers below take their declarations
+   * as one.  Crossing both is what makes `allOf: [{ $ref: Base }, { oneOf: [ … ] }]` — what code
+   * generators emit for a base type refined by variants — readable at all, since its properties live
+   * on `Base` and a union reaches it through a `$ref`.
    *
-   * When this schema declares no properties of its own but is a lone `$ref` — the dominant shape for
-   * `oneOf`/`anyOf` branches (`oneOf: [{ $ref: … }]`) — resolves a single level through the ref to read
-   * the target's own pins, so `$ref`-based discriminated unions are recognized just like inline ones.
-   * A target that is itself only another `$ref` contributes no pins.
-   *
-   * Drives union-error narrowing: discriminator detection reads it in the default mode (branches
-   * keyed by a shared property pinned to pairwise-disjoint sets), while elimination reads it with
-   * [includeEmptyPins] to drop any branch whose pin the document's value contradicts.
+   * A *property*'s schema is never followed, so a self-referential `child: { $ref: node }` is not a
+   * path here; the set bounds the cycles that remain, like an `allOf` that `$ref`s back to its schema.
+   */
+  private fun compositionSources(): Set<JsonObjectSchema> {
+    val sources = mutableSetOf<JsonObjectSchema>()
+    val pending = ArrayDeque<JsonObjectSchema>(listOf(this))
+    while (pending.isNotEmpty()) {
+      val schema = pending.removeFirst()
+      if (!sources.add(schema)) continue
+      (schema.soleRefValidator()?.resolvedSchema() as? JsonObjectSchema)?.let { pending.add(it) }
+      schema.schemaValidators.filterIsInstance<AllOfValidator>()
+        .flatMapTo(pending) { it.allOf.filterIsInstance<JsonObjectSchema>() }
+    }
+    return sources
+  }
+
+  /**
+   * This branch's *pins* (see the glossary in [org.kson.schema.validators.reportUnionMatchFailure]),
+   * read across every [compositionSources] schema.  Empty pins are dropped unless [includeEmptyPins]:
+   * they discriminate nothing, but they do eliminate, since they admit no value at all.
    */
   internal fun pinnedProperties(includeEmptyPins: Boolean = false): Map<String, Set<KsonValue>> {
-    ownPinnedProperties(includeEmptyPins)?.let { return it }
-    // Lone $ref branch: resolve one level to read the target's pins.
-    val refTarget = soleRefValidator()?.resolvedSchema() as? JsonObjectSchema
-    return refTarget?.ownPinnedProperties(includeEmptyPins) ?: emptyMap()
-  }
-
-  /**
-   * The pins declared by this schema's own `properties` (its [PropertiesValidator]), or `null` when it
-   * declares none.  Reads only this schema's own validators — never resolves a `$ref` — so
-   * [pinnedProperties] can unwrap a lone `$ref` exactly one level without chaining through aliases.  A
-   * property contributes when its schema's sole validator reports a non-null [JsonSchemaValidator.pinnedValues];
-   * an *empty* pin (`enum: []`) is kept only when [includeEmptyPins] is set (see [pinnedProperties]).
-   */
-  private fun ownPinnedProperties(includeEmptyPins: Boolean): Map<String, Set<KsonValue>>? {
-    val propertySchemas = schemaValidators
-      .filterIsInstance<PropertiesValidator>()
-      .firstOrNull()
-      ?.propertySchemas ?: return null
-
-    return buildMap {
-      propertySchemas.forEach { (propertyName, propertySchema) ->
-        val pinned = (propertySchema as? JsonObjectSchema)?.schemaValidators?.singleOrNull()?.pinnedValues()
-        // `pinned != null` marks a const/enum-pinned property; an empty pin selects nothing, so it
-        // counts only for elimination ([includeEmptyPins]), never for discriminator detection.
-        if (pinned != null && (includeEmptyPins || pinned.isNotEmpty())) {
-          put(propertyName.value, pinned)
-        }
+    val pins = mutableMapOf<String, Set<KsonValue>>()
+    compositionSources().forEach { source ->
+      source.ownPinnedProperties().forEach { (property, values) ->
+        // all sources constrain the same document, so a property pinned by several of them is pinned
+        // to the intersection — which may be empty, hence the policy above is applied to the result
+        pins[property] = pins[property]?.intersect(values) ?: values
       }
     }
+    return if (includeEmptyPins) pins else pins.filterValues { it.isNotEmpty() }
   }
 
   /**
-   * The property names this schema requires — via its [RequiredValidator] — resolving one level
-   * through a lone `$ref` exactly as [pinnedProperties] does, so a `$ref`-based branch contributes its
-   * target's requirements.  Empty when neither this schema nor its ref target declares `required`.
-   *
-   * Unioned with [declaredPropertyNames] to form a branch's *known* property names for presence-based
-   * union narrowing, when no value-based discriminator applies.
+   * This branch's *known properties* (see the glossary in
+   * [org.kson.schema.validators.reportUnionMatchFailure]), read across every [compositionSources]
+   * schema: what it requires, plus what it merely declares.
    */
-  internal fun requiredProperties(): Set<String> {
-    ownRequiredProperties()?.let { return it }
-    // Lone $ref branch: resolve one level to read the target's requirements.
-    val refTarget = soleRefValidator()?.resolvedSchema() as? JsonObjectSchema
-    return refTarget?.ownRequiredProperties() ?: emptySet()
-  }
+  internal fun knownProperties(): Set<String> =
+    compositionSources().flatMapTo(mutableSetOf()) { source ->
+      source.ownRequiredProperties() + source.ownPropertySchemas().keys.map { it.value }
+    }
 
-  /**
-   * The property names this schema's own [RequiredValidator] declares, or `null` when it declares none —
-   * mirroring [ownPinnedProperties] so [requiredProperties] can unwrap a lone `$ref` exactly one level
-   * without chaining through aliases.
-   */
-  private fun ownRequiredProperties(): Set<String>? =
+  /** The pins declared by this schema's *own* `properties`, empty pins included. */
+  private fun ownPinnedProperties(): Map<String, Set<KsonValue>> =
+    ownPropertySchemas().mapNotNull { (name, propertySchema) ->
+      val pinned = (propertySchema as? JsonObjectSchema)?.schemaValidators?.singleOrNull()?.pinnedValues()
+      pinned?.let { name.value to it }
+    }.toMap()
+
+  /** The property names this schema's *own* `required` lists, empty when it declares none. */
+  private fun ownRequiredProperties(): Set<String> =
     schemaValidators.filterIsInstance<RequiredValidator>()
       .firstOrNull()
       ?.required
-      ?.mapTo(mutableSetOf()) { it.value }
+      ?.mapTo(mutableSetOf()) { it.value } ?: emptySet()
 
-  /**
-   * The property names this schema *declares* — the keys of its `properties` (its [PropertiesValidator]) —
-   * resolving one level through a lone `$ref` exactly as [requiredProperties] does.  Empty when neither
-   * this schema nor its ref target declares any `properties`.
-   *
-   * Unioned with [requiredProperties] to form a branch's *known* property names: a document carrying a
-   * property a branch declares — even as an *optional* property — counts as that branch recognizing it,
-   * so presence-based narrowing matches every branch that knows the property, not only those requiring it.
-   */
-  internal fun declaredPropertyNames(): Set<String> {
-    ownDeclaredPropertyNames()?.let { return it }
-    // Lone $ref branch: resolve one level to read the target's declared properties.
-    val refTarget = soleRefValidator()?.resolvedSchema() as? JsonObjectSchema
-    return refTarget?.ownDeclaredPropertyNames() ?: emptySet()
-  }
-
-  /**
-   * The keys of this schema's own `properties` ([PropertiesValidator]), or `null` when it declares none —
-   * mirroring [ownRequiredProperties] so [declaredPropertyNames] can unwrap a lone `$ref` exactly one
-   * level without chaining through aliases.
-   */
-  private fun ownDeclaredPropertyNames(): Set<String>? =
+  /** This schema's *own* `properties`, empty when it declares none. */
+  private fun ownPropertySchemas(): Map<KsonString, JsonSchema?> =
     schemaValidators.filterIsInstance<PropertiesValidator>()
       .firstOrNull()
-      ?.propertySchemas
-      ?.keys
-      ?.mapTo(mutableSetOf()) { it.value }
+      ?.propertySchemas ?: emptyMap()
 
   /**
    * Validates a [KsonValue] against this schema, logging any validation errors to the [messageSink]

--- a/src/commonMain/kotlin/org/kson/schema/JsonSchemaValidator.kt
+++ b/src/commonMain/kotlin/org/kson/schema/JsonSchemaValidator.kt
@@ -9,6 +9,11 @@ import org.kson.value.*
 interface JsonSchemaValidator: Validator {
     override fun validate(ksonValue: KsonValue, messageSink: MessageSink, sourceContext: SourceContext)
 
+    // schema todo introspection on the execution interface: this asks a validator what it *declares*,
+    //   not whether a document passes.  It exists because a schema keeps only its compiled validators,
+    //   so callers must recover declarations by casting (see JsonObjectSchema.ownPinnedProperties).
+    //   If a third consumer needs that, give JsonObjectSchema a parsed declaration model instead and
+    //   drop this method.
     /** The finite set of values this validator restricts its target to (const/enum), or null if it doesn't pin to a finite set. */
     fun pinnedValues(): Set<KsonValue>? = null
 }

--- a/src/commonMain/kotlin/org/kson/schema/validators/UnionNarrowing.kt
+++ b/src/commonMain/kotlin/org/kson/schema/validators/UnionNarrowing.kt
@@ -10,23 +10,29 @@ import org.kson.schema.JsonSchema
 import org.kson.validation.SourceContext
 
 /**
- * Reports why a document failed to match any branch of a `oneOf` / `anyOf` union, narrowing the
- * reported errors to the branch(es) that actually matter before resorting to a full per-branch dump.
- * The strategies below run in priority order; the first to report wins:
+ * Reporting for a document that matched no branch of a `oneOf` / `anyOf` union: narrow the reported
+ * errors to the branch(es) that actually matter, rather than dumping every branch's complaints.
  *
- *  1. [selectDiscriminatedBranch] — a *value discriminator* (a shared property pinned to
- *     pairwise-disjoint value sets) selects the single branch the document's value picks, or proves
- *     a closed union's value out of range with one [SCHEMA_ENUM_VALUE_NOT_ALLOWED].
- *  2. [narrowByElimination] — drop any branch whose pinned value the document contradicts, then narrow
- *     the survivors by which distinguishing properties the document carries, and dump only what remains.
- *  3. [reportNoSubSchemaMatchErrors] — nothing narrowed the union, so dump every branch.
+ * Vocabulary used here and by the [JsonObjectSchema] accessors this file reads:
+ *  - *pin* — a property fixed to a finite value set by `const` or `enum`.  An *empty* pin (`enum: []`)
+ *    admits nothing, so it discriminates nothing but eliminates anything.
+ *  - *known property* — one a branch declares under `properties` (optional included) or lists in
+ *    `required`, read across everything the branch composes (`$ref`, `allOf`).
+ *  - *discriminator* — a property at least two branches pin to *pairwise-disjoint* sets, so a value
+ *    picks at most one branch.  The union is *closed* when every branch pins it.
+ *  - *distinguishing property* — one known to some branches but not all.
+ */
+
+/**
+ * Narrows and reports, trying each strategy in order until one handles it:
  *
- * Always emits at least one error: each strategy that handles reporting emits ≥1 message, and the final
- * dump is unconditional.  Returns [Unit] rather than a handled/not-handled flag so callers can't
- * accidentally skip the dump — the safety invariant is enforced here, not at the call site.
+ *  1. [selectDiscriminatedBranch] — the document's discriminator value picks a branch (or proves
+ *     itself out of range in a closed union).
+ *  2. [narrowByShape] — drop branches the document contradicts, keep those it looks like.
+ *  3. [reportNoSubSchemaMatchErrors] — nothing narrowed; dump every branch.
  *
- * [sourceContext] is threaded to [selectDiscriminatedBranch]'s deep re-validation so the selected branch is re-checked
- * under the same context that already proved every branch fails (preserving the ≥1-error invariant).
+ * Always emits at least one error: every strategy emits ≥1 message and the final dump is
+ * unconditional.  Returns [Unit] rather than a handled flag so callers can't skip that dump.
  */
 internal fun reportUnionMatchFailure(
     branches: List<JsonSchema>,
@@ -37,25 +43,21 @@ internal fun reportUnionMatchFailure(
     sourceContext: SourceContext
 ) {
     if (!selectDiscriminatedBranch(branches, ksonValue, messageSink, sourceContext) &&
-        !narrowByElimination(branches, ksonValue, messageSink, matchAttemptMessageSinks, noMatchMessage)) {
+        !narrowByShape(branches, ksonValue, messageSink, matchAttemptMessageSinks, noMatchMessage)) {
         reportNoSubSchemaMatchErrors(ksonValue, messageSink, matchAttemptMessageSinks, noMatchMessage)
     }
 }
 
 /**
- * When [branches] form a discriminated union — some shared property is pinned to *pairwise-disjoint*
- * value sets (via `const` or `enum`) by at least two branches — report against the branch the
- * document's discriminator value selects, rather than dumping every branch's errors:
+ * Reports against the branch the document's discriminator selects:
  *
- *  - the value matches one branch's pinned set: report only that branch's errors (the real failure
- *    lives deeper in the document, e.g. a missing required property)
- *  - the value matches no branch, and *every* branch pins the discriminator (a closed union):
- *    report one [SCHEMA_ENUM_VALUE_NOT_ALLOWED] at the value, listing the allowed values
- *  - the value matches no branch, but a wildcard/negative branch leaves the union open: we can't
- *    prove the value invalid, so fall back to the caller's dump
+ *  - value matches one branch's pin: report only that branch's errors — the real failure is deeper
+ *  - value matches none and the union is closed: one [SCHEMA_ENUM_VALUE_NOT_ALLOWED] listing the
+ *    allowed values
+ *  - value matches none but a wildcard branch leaves the union open: we can't call the value wrong,
+ *    so decline
  *
- * Returns `true` when it handled reporting (so the caller skips the generic dump), `false` when
- * [branches] are not a discriminated union or the document lacks the discriminator property.
+ * Returns `true` when it reported, `false` when there is no discriminator or the document lacks it.
  */
 private fun selectDiscriminatedBranch(
     branches: List<JsonSchema>,
@@ -69,46 +71,30 @@ private fun selectDiscriminatedBranch(
 
     val selectedBranch = discriminator.branchByValue[discriminatorValue]
     when {
-        // The document picks exactly one branch; report only that branch's (deeper) errors.
         selectedBranch != null -> selectedBranch.validate(ksonValue, messageSink, sourceContext)
 
-        // No branch matches and every branch pins the discriminator, so the value itself is wrong.
         discriminator.allBranchesPinned -> {
             val allowedValues = discriminator.branchByValue.keys
                 .joinToString(", ") { it.toDisplayString() }
             messageSink.error(discriminatorValue.location, SCHEMA_ENUM_VALUE_NOT_ALLOWED.create(allowedValues))
         }
 
-        // No branch matches but a wildcard/negative branch might legitimately accept this value,
-        // so we can't claim "must be one of …" — fall back to the caller's dump.
+        // a wildcard/negative branch might legitimately accept this value
         else -> return false
     }
     return true
 }
 
 /**
- * Narrows a union with no value discriminator to the branch(es) worth reporting
- * by composing two signals over the already-failed branches.
+ * Narrows a union with no discriminator by combining [survivingBranches] (definitive: the document
+ * contradicts a pin) with [presenceMatchedBranches] (heuristic: the document carries a property the
+ * branch knows and others don't).
  *
- *  - *Elimination* (definitive): a branch is provably dead when it pins a property `p` to a value set
- *    `V` and the document carries `p` with a value ∉ `V`.  No ≥2-branch gate and no disjointness
- *    requirement — a single contradicted pin suffices.  Empty pins (`enum: []`) reject any present
- *    value, so pins are read with [JsonObjectSchema.pinnedProperties] in `includeEmptyPins` mode.
- *  - *Presence* (heuristic): a branch matches when the document carries a *distinguishing* known
- *    property — one declared or required by some but not all branches.  A branch's *known* properties
- *    are those it declares (even as optional) unioned with those it requires.  This is the exact rule
- *    the presence-only strategy used, so a pin-free union degenerates to that behavior.
- *
- * Composition, writing `S` for the surviving (not-eliminated) branches and `M` for the presence-matched:
- * report `S ∩ M` when that is a non-empty *strict* subset of the branches, else `S` when *it* is, else
- * decline (let the caller dump every branch).  Intersecting with `S` keeps presence from resurrecting a
- * branch whose own pin the document contradicts; the non-empty-strict-subset guard keeps us from
- * reporting nothing or everything.  Reports the chosen branches via [reportNoSubSchemaMatchErrors] over
- * their already-collected [matchAttemptMessageSinks] — a single chosen branch collapses to its bare
- * messages (no [noMatchMessage] header), matching that helper's existing behavior.  Only
- * [JsonObjectSchema] branches carry pins or known properties; others neither eliminate nor match.
+ * Reports `S ∩ M` when that is a non-empty *strict* subset of the branches, else `S` when it is, else
+ * declines.  Intersecting keeps presence from resurrecting a branch the document contradicts; the
+ * strict-subset guard keeps us from reporting nothing, or everything by a longer route.
  */
-private fun narrowByElimination(
+private fun narrowByShape(
     branches: List<JsonSchema>,
     ksonValue: KsonValue,
     messageSink: MessageSink,
@@ -117,27 +103,8 @@ private fun narrowByElimination(
 ): Boolean {
     if (ksonValue !is KsonObject) return false
 
-    // Elimination: keep a branch unless the document contradicts one of its pins (a present value
-    // outside the pinned set — which an empty pin can never contain).
-    val survivors = branches.indices.filter { i ->
-        val pins = (branches[i] as? JsonObjectSchema)?.pinnedProperties(includeEmptyPins = true) ?: emptyMap()
-        pins.none { (property, values) ->
-            ksonValue.propertyLookup[property]?.let { it !in values } ?: false
-        }
-    }
-
-    // Presence: a known property of some branch but not all is distinguishing; a branch matches when
-    // the document carries one such property it knows.
-    val knownByBranch = branches.map { branch ->
-        (branch as? JsonObjectSchema)?.let { it.declaredPropertyNames() + it.requiredProperties() } ?: emptySet()
-    }
-    val distinguishing = knownByBranch.flatten().toSet()
-        .filter { property -> knownByBranch.count { property in it } < branches.size }
-        .toSet()
-    val presentProperties = ksonValue.propertyLookup.keys
-    val presenceMatched = knownByBranch.indices.filter { i ->
-        knownByBranch[i].any { it in distinguishing && it in presentProperties }
-    }
+    val survivors = survivingBranches(branches, ksonValue)
+    val presenceMatched = presenceMatchedBranches(branches, ksonValue)
 
     val intersection = survivors.filter { it in presenceMatched }
     val chosen = when {
@@ -155,17 +122,38 @@ private fun narrowByElimination(
     return true
 }
 
+/**
+ * The branches the document does *not* contradict: it carries no property the branch pins to a set
+ * the document's value falls outside of.  Definitive — one contradicted pin is proof, needing neither
+ * a second branch nor disjointness.  Empty pins count, hence [includeEmptyPins].
+ */
+private fun survivingBranches(branches: List<JsonSchema>, ksonValue: KsonObject): List<Int> =
+    branches.indices.filter { i ->
+        val pins = (branches[i] as? JsonObjectSchema)?.pinnedProperties(includeEmptyPins = true) ?: emptyMap()
+        pins.none { (property, values) ->
+            ksonValue.propertyLookup[property]?.let { it !in values } ?: false
+        }
+    }
+
+/**
+ * The branches the document *looks like*: it carries a distinguishing property they know.  A
+ * heuristic — a shared property proves nothing, so only properties some branches know and others
+ * don't are consulted.  Non-[JsonObjectSchema] branches know nothing and so never match.
+ */
+private fun presenceMatchedBranches(branches: List<JsonSchema>, ksonValue: KsonObject): List<Int> {
+    val knownByBranch = branches.map { (it as? JsonObjectSchema)?.knownProperties() ?: emptySet() }
+    val distinguishing = knownByBranch.flatten().toSet()
+        .filterTo(mutableSetOf()) { property -> knownByBranch.count { property in it } < branches.size }
+    val presentProperties = ksonValue.propertyLookup.keys
+    return knownByBranch.indices.filter { i ->
+        knownByBranch[i].any { it in distinguishing && it in presentProperties }
+    }
+}
+
 /** A non-empty proper subset of [branches] — a genuine narrowing, neither empty nor the whole set. */
 private fun List<Int>.isNonEmptyStrictSubsetOf(branches: List<JsonSchema>): Boolean =
     isNotEmpty() && size < branches.size
 
-/**
- * Detects a discriminator: a property pinned to *pairwise-disjoint* value sets by at least two
- * branches.  Branches that don't pin the property (wildcard / negative / non-object branches) are
- * tolerated and simply left out of the value→branch map.  When several properties qualify, the one
- * pinned by the most branches wins (ties broken by declaration order — the first branch that pins it).
- * Returns `null` when no property qualifies.
- */
 private fun detectDiscriminator(branches: List<JsonSchema>): Discriminator? {
     // Per branch, the properties it pins to a finite value set (empty for wildcard / non-object branches).
     val branchPins = branches.map { (it as? JsonObjectSchema)?.pinnedProperties() ?: emptyMap() }

--- a/src/commonTest/kotlin/org/kson/schema/validators/OneOfPresenceUnionTest.kt
+++ b/src/commonTest/kotlin/org/kson/schema/validators/OneOfPresenceUnionTest.kt
@@ -208,8 +208,8 @@ class OneOfPresenceUnionTest : JsonSchemaTest {
 
     /**
      * A `$ref`-based union with no value discriminator (the targets pin nothing) but distinct *required*
-     * properties still narrows by presence: [org.kson.schema.JsonObjectSchema.requiredProperties] resolves
-     * through each branch's `$ref` to read its target's requirements, so the present `needs_a` selects
+     * properties still narrows by presence: [org.kson.schema.JsonObjectSchema.knownProperties] reads
+     * through each branch's `$ref` to its target's requirements, so the present `needs_a` selects
      * branch A and only its deeper `detail_a` failure surfaces, not branch B's.
      */
     @Test

--- a/src/commonTest/kotlin/org/kson/schema/validators/UnionNarrowingThroughAllOfTest.kt
+++ b/src/commonTest/kotlin/org/kson/schema/validators/UnionNarrowingThroughAllOfTest.kt
@@ -1,0 +1,160 @@
+package org.kson.schema.validators
+
+import org.kson.parser.messages.MessageType.*
+import org.kson.schema.JsonSchemaTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+/**
+ * Union narrowing reads a branch's pins and known properties across everything the branch composes,
+ * so a branch shaped `allOf: [{ $ref: Base }, { oneOf: [ … ] }]` — what code generators emit for "a
+ * base type refined by variants" — narrows exactly like one declaring those properties inline.
+ * Reading only a branch's own `properties` made such a branch look empty: nothing to eliminate it,
+ * nothing to presence-match it, so every union containing one dumped all its branches' errors.
+ */
+class UnionNarrowingThroughAllOfTest : JsonSchemaTest {
+    /**
+     * Presence narrowing picks `Item`: the document carries `mode`, declared by `Base` an `allOf` hop
+     * down and unknown to `Group`, so the bad `mode` value surfaces alone rather than alongside
+     * `Group`'s complaints about a shape the document never claimed.
+     */
+    @Test
+    fun testAnyOfPresenceNarrowsThroughAllOfComposedBranch() {
+        val errors = assertKsonSchemaErrors(
+            """
+                mode: "sync"
+                action: "fetch"
+            """.trimIndent(),
+            """
+                {
+                  "anyOf": [
+                    { "${'$'}ref": "#/${'$'}defs/Group" },
+                    { "${'$'}ref": "#/${'$'}defs/Item" }
+                  ],
+                  "${'$'}defs": {
+                    "Group": {
+                      "additionalProperties": false,
+                      "properties": { "name": {}, "members": {} },
+                      "required": ["members"]
+                    },
+                    "Base": {
+                      "properties": { "name": {}, "mode": {}, "action": {} }
+                    },
+                    "Item": {
+                      "allOf": [
+                        { "${'$'}ref": "#/${'$'}defs/Base" },
+                        {
+                          "oneOf": [
+                            { "properties": { "mode": { "const": "read" }, "action": { "const": "fetch" } } },
+                            { "properties": { "mode": { "const": "write" }, "action": { "const": "store" } } }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+            """.trimIndent(),
+            listOf(SCHEMA_ENUM_VALUE_NOT_ALLOWED)
+        )
+
+        // the surviving error is about `mode`, not about Group's unmet shape
+        assertContains(errors[0].message.toString(), "read")
+        assertFalse(errors[0].message.toString().contains("members"))
+    }
+
+    /**
+     * A discriminator pinned inside an `allOf` member discriminates: the document's `kind` selects its
+     * branch, so only that branch's deeper failure is reported.
+     */
+    @Test
+    fun testOneOfDiscriminatorDetectedThroughAllOfComposedBranch() {
+        val errors = assertKsonSchemaErrors(
+            """kind: "a"""",
+            dualBranchAllOfUnion,
+            listOf(SCHEMA_REQUIRED_PROPERTY_MISSING)
+        )
+
+        assertContains(errors[0].message.toString(), "needs_a")
+        assertFalse(errors[0].message.toString().contains("needs_b"))
+    }
+
+    /**
+     * With every branch pinning `kind` through its `allOf`, the union is closed, so a `kind` no branch
+     * claims is reported as one out-of-range value rather than as a dump of both branches.
+     */
+    @Test
+    fun testOneOfClosedUnionThroughAllOfReportsAllowedDiscriminatorValues() {
+        val errors = assertKsonSchemaErrors(
+            """kind: "c"""",
+            dualBranchAllOfUnion,
+            listOf(SCHEMA_ENUM_VALUE_NOT_ALLOWED)
+        )
+
+        assertContains(errors[0].message.toString(), "\"a\", \"b\"")
+    }
+
+    /** Two branches, each pinning `kind` to its own `const` one `allOf` hop down, over a shared base. */
+    private val dualBranchAllOfUnion = """
+        {
+          "oneOf": [
+            {
+              "allOf": [
+                { "${'$'}ref": "#/${'$'}defs/base" },
+                { "properties": { "kind": { "const": "a" } } }
+              ],
+              "required": ["needs_a"]
+            },
+            {
+              "allOf": [
+                { "${'$'}ref": "#/${'$'}defs/base" },
+                { "properties": { "kind": { "const": "b" } } }
+              ],
+              "required": ["needs_b"]
+            }
+          ],
+          "${'$'}defs": {
+            "base": { "properties": { "kind": { "type": "string" } } }
+          }
+        }
+    """.trimIndent()
+
+    /**
+     * Composed sources all constrain the same document, so a property pinned by more than one is
+     * pinned to the *intersection* of their sets: the base admits `"A"` or `"B"`, the refining member
+     * only `"A"`, so `kind: "B"` contradicts the composed branch and eliminates it — where the wider
+     * of the two pins alone would have kept it alive.  Both branches know `kind` and `other` and
+     * neither `needs_*` is present, so this elimination is the only thing that can narrow here.
+     */
+    @Test
+    fun testEliminationIntersectsPinsAcrossComposedSources() {
+        val errors = assertKsonSchemaErrors(
+            """
+                kind: "B"
+                other: "present"
+            """.trimIndent(),
+            """
+                {
+                  "oneOf": [
+                    {
+                      "properties": { "kind": {}, "other": {} },
+                      "allOf": [
+                        { "properties": { "kind": { "const": "A" } } },
+                        { "properties": { "kind": { "enum": ["A", "B"] } } }
+                      ],
+                      "required": ["needs_a"]
+                    },
+                    {
+                      "properties": { "kind": {}, "other": {} },
+                      "required": ["needs_b"]
+                    }
+                  ]
+                }
+            """.trimIndent(),
+            listOf(SCHEMA_REQUIRED_PROPERTY_MISSING)
+        )
+
+        assertContains(errors[0].message.toString(), "needs_b")
+        assertFalse(errors[0].message.toString().contains("needs_a"))
+    }
+}


### PR DESCRIPTION
Union narrowing picks which `oneOf`/`anyOf` branch a failing document meant, so we report that branch's error instead of every branch's. To do that it needs to know what each branch declares, and it could only see declarations written directly on the branch, or one `$ref` away. It could not see declarations reached through an `allOf`, which is where a base type's shared fields normally live:

    allOf: [{$ref: Base}, {oneOf: [...]}]

The properties live on `Base` and the union reaches the branch through a `$ref`, so the branch looks empty. Nothing eliminates it, nothing matches it, and we dump every branch.

**Before** (two-branch union, document with a bad `mode`):

```
Value must match at least one sub-schema
Value matches none of these sub-schemas:
- Group:
    - Additional property 'mode' is not allowed (1:1)
    - Additional property 'action' is not allowed (2:1)
    - Missing required properties: members (1:1)
- Item:
    - Value must be one of: "read", "write" (1:8)
```

**After:**

```
Value must be one of: "read", "write"
```

Now we follow both composing edges, a lone `$ref` and `allOf` membership, transitively with a visited set, and read everything reached as one declaration. They all constrain the same document, so a property pinned by several of them is pinned to the intersection of their sets. Property schemas are still not followed, so `child: {$ref: node}` stays out of the walk.

The rest of the diff is tidy-up with no behaviour change, reviewable separately: the terms this code uses (pin, known property, discriminator) get one glossary at the top of `UnionNarrowing.kt`, and `narrowByElimination`, which also did presence matching, is split in three. Todo left on `pinnedValues`, which only sits on the validator interface because a schema keeps its compiled validators and not the declarations behind them.

Four tests in `UnionNarrowingThroughAllOfTest`. Each fails without the traversal.
