### PR TITLE
Fix a trio of schema validation bugs

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -9,40 +9,6 @@
     <ID>CyclomaticComplexMethod:Lexer.kt$Lexer$private fun scan()</ID>
     <ID>CyclomaticComplexMethod:TreeNavigation.kt$TreeNavigator$private fun processSingleToken( currentNodes: List&lt;N>, token: PointerParser.Tokens ): List&lt;N></ID>
     <ID>CyclomaticComplexMethod:TypeValidator.kt$TypeValidator$fun validate(ksonValue: KsonValue, messageSink: MessageSink): Boolean</ID>
-    <ID>LargeClass:FormatterTest.kt$FormatterTest</ID>
-    <ID>LargeClass:JsonSchemaTestBundledRemotes.kt$JsonSchemaTestBundledRemotes : JsonSchemaTest</ID>
-    <ID>LargeClass:JsonSuiteTest.kt$JsonSuiteTest</ID>
-    <ID>LargeClass:KsonCoreTestComment.kt$KsonCoreTestComment : KsonCoreTest</ID>
-    <ID>LargeClass:KsonCoreTestEmbedBlock.kt$KsonCoreTestEmbedBlock : KsonCoreTest</ID>
-    <ID>LargeClass:LexerTest.kt$LexerTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_allOf.kt$SchemaDraft2020_12SuiteTest_allOf : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_const.kt$SchemaDraft2020_12SuiteTest_const : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_dynamicRef.kt$SchemaDraft2020_12SuiteTest_dynamicRef : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_enum.kt$SchemaDraft2020_12SuiteTest_enum : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_format.kt$SchemaDraft2020_12SuiteTest_format : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_items.kt$SchemaDraft2020_12SuiteTest_items : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_not.kt$SchemaDraft2020_12SuiteTest_not : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_oneOf.kt$SchemaDraft2020_12SuiteTest_oneOf : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_properties.kt$SchemaDraft2020_12SuiteTest_properties : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_ref.kt$SchemaDraft2020_12SuiteTest_ref : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_refRemote.kt$SchemaDraft2020_12SuiteTest_refRemote : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_type.kt$SchemaDraft2020_12SuiteTest_type : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_unevaluatedItems.kt$SchemaDraft2020_12SuiteTest_unevaluatedItems : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_unevaluatedProperties.kt$SchemaDraft2020_12SuiteTest_unevaluatedProperties : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft2020_12SuiteTest_uniqueItems.kt$SchemaDraft2020_12SuiteTest_uniqueItems : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft7SuiteTest_allOf.kt$SchemaDraft7SuiteTest_allOf : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft7SuiteTest_const.kt$SchemaDraft7SuiteTest_const : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft7SuiteTest_dependencies.kt$SchemaDraft7SuiteTest_dependencies : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft7SuiteTest_enum.kt$SchemaDraft7SuiteTest_enum : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft7SuiteTest_format.kt$SchemaDraft7SuiteTest_format : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft7SuiteTest_items.kt$SchemaDraft7SuiteTest_items : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft7SuiteTest_not.kt$SchemaDraft7SuiteTest_not : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft7SuiteTest_oneOf.kt$SchemaDraft7SuiteTest_oneOf : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft7SuiteTest_properties.kt$SchemaDraft7SuiteTest_properties : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft7SuiteTest_ref.kt$SchemaDraft7SuiteTest_ref : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft7SuiteTest_type.kt$SchemaDraft7SuiteTest_type : JsonSchemaTest</ID>
-    <ID>LargeClass:SchemaDraft7SuiteTest_uniqueItems.kt$SchemaDraft7SuiteTest_uniqueItems : JsonSchemaTest</ID>
-    <ID>LargeClass:TreeNavigationTest.kt$TreeNavigationTest</ID>
     <ID>LongMethod:Formatter.kt$IndentFormatter$@Deprecated( "This formatter is no long a good general purpose formatter. " + "See the TODO in this class's doc for details" ) @Suppress("NestedBlockDepth") private fun indent(source: String, snippetNestingLevel: Int? = null): String</ID>
     <ID>LongMethod:FormatterTest.kt$FormatterTest$@Test fun testCompactFormattingStyleNestedStructures()</ID>
     <ID>LongMethod:FormatterTest.kt$FormatterTest$@Test fun testMultipleTrailingContent()</ID>

--- a/detekt.kson
+++ b/detekt.kson
@@ -6,6 +6,21 @@ build:
 # See https://detekt.dev/docs/rules/overview for all available rules.
 
 complexity:
+  LargeClass:
+    active: true
+    excludes:
+      # Exclude test classes from this lint since tests are a collection of individual little "apps" that
+      # verify the class the test is linked to by name, so a large test class never implies an incoherent
+      # or sprawling class interface, rather it means good coverage for some other hopefully coherent class
+      - '**/test/**'
+      - '**/androidTest/**'
+      - '**/commonTest/**'
+      - '**/jvmTest/**'
+      - '**/androidUnitTest/**'
+      - '**/androidInstrumentedTest/**'
+      - '**/jsTest/**'
+      - '**/iosTest/**'
+    .
   LongMethod:
     active: true
     threshold: 80
@@ -59,5 +74,3 @@ naming:
 exceptions:
   TooGenericExceptionCaught:
     active: false
-    .
-  .

--- a/kson-lib/src/commonMain/kotlin/org/kson/Kson.kt
+++ b/kson-lib/src/commonMain/kotlin/org/kson/Kson.kt
@@ -84,12 +84,17 @@ object Kson {
      * Statically analyze the given Kson and return an [Analysis] object containing any messages generated along with a
      * tokenized version of the source.  Useful for tooling/editor support.
      * @param kson The Kson source to analyze
-     * @param filepath Filepath of the document being analyzed
+     * @param filepath (Optional) Filepath of the document being analyzed
+     * @param schemaValidator (Optional) A schema to validate [kson] against, provided [kson] is error-free and hence
+     *          able to be validated against a schema
      */
-    fun analyze(kson: String, filepath: String? = null) : Analysis {
+    fun analyze(kson: String, filepath: String? = null, schemaValidator: SchemaValidator? = null) : Analysis {
         val parseResult = KsonCore.parseToAst(
             kson,
-            CoreCompileConfig(sourceContext = SourceContext(filepath))
+            CoreCompileConfig(
+                schemaJson = schemaValidator?.schema,
+                sourceContext = SourceContext(filepath)
+            )
         )
         val tokens = convertTokens(parseResult.lexedTokens)
         val messages = publishMessages(parseResult.messages)
@@ -166,29 +171,31 @@ sealed class SchemaResult {
 /**
  * A validator that can check if Kson source conforms to a schema.
  */
-class SchemaValidator internal constructor(private val schema: JsonSchema) {
+class SchemaValidator internal constructor(internal val schema: JsonSchema) {
     /**
-     * Validates the given Kson source against this validator's schema.
-     * @param kson The Kson source to validate
-     * @param filepath Optional filepath of the document being validated, used by validators to determine which rules to apply
+     * Validates the given KSON source against this validator's schema.
      *
-     * @return A list of validation error messages, or empty list if valid
+     * NOTE: this must parse [kson] in order to validate it, but does not report that parse's own messages: a
+     * document may satisfy a schema and still carry warnings of its own.  Pass this validator to [Kson.analyze]
+     * to see both.  The exception is [kson] which fails to parse at all: it _cannot_ be validated against this
+     * [schema], and so those parse errors are returned instead.
+     *
+     * @param kson The KSON source to validate
+     * @param filepath (Optional) filepath of the document being validated, used by validators to determine
+     *                 which rules to apply
+     *
+     * @return A list of schema validation [Message]s, or empty list if [kson] is valid under this [schema]
      */
     fun validate(kson: String, filepath: String? = null): List<Message> {
         val astParseResult = KsonCore.parseToAst(
             kson,
             CoreCompileConfig(sourceContext = SourceContext(filepath))
         )
-        if (astParseResult.hasErrors()) {
-            return publishMessages(astParseResult.messages)
-        }
+        val ksonValue = astParseResult.ksonValue
+            ?: return publishMessages(astParseResult.messages)
 
         val messageSink = MessageSink()
-        val ksonValue = astParseResult.ksonValue
-        if (ksonValue != null) {
-            schema.validate(ksonValue, messageSink, SourceContext(filepath))
-        }
-
+        schema.validate(ksonValue, messageSink, SourceContext(filepath))
         return publishMessages(messageSink.loggedMessages())
     }
 }

--- a/kson-lib/src/commonTest/kotlin/org/kson/KsonSmokeTest.kt
+++ b/kson-lib/src/commonTest/kotlin/org/kson/KsonSmokeTest.kt
@@ -313,6 +313,50 @@ class KsonSmokeTest {
         assertTrue(errors.isNotEmpty())
     }
 
+    /**
+     * [SchemaValidator.validate] only returns message from validating against its schema
+     */
+    @Test
+    fun testSchemaValidator_reportsOnlySchemaViolations() {
+        val schemaKson = """{"type": "object", "properties": {"name": {"type": "string"}}}"""
+        val schemaResult = Kson.parseSchema(schemaKson)
+        assertIs<SchemaResult.Success>(schemaResult)
+
+        // a duplicate key is a warning this document carries, but breaks no rule in the schema above
+        val conformingKsonWithAWarning = """{"name": "John", "name": "Bob"}"""
+        assertTrue(
+            Kson.analyze(conformingKsonWithAWarning).errors.isNotEmpty(),
+            "this document must carry a warning of its own for this test to mean anything"
+        )
+
+        assertEquals(
+            emptyList(),
+            schemaResult.schemaValidator.validate(conformingKsonWithAWarning),
+            "validate must report the schema's findings alone"
+        )
+    }
+
+    /**
+     * The companion to [testSchemaValidator_reportsOnlySchemaViolations]: handing a validator to
+     * [Kson.analyze] is how a caller asks for a document's own diagnostics *and* its schema's.
+     */
+    @Test
+    fun testAnalyzeWithSchemaReportsBothKindsOfMessage() {
+        val schemaKson = """{"type": "object", "required": ["age"]}"""
+        val schemaResult = Kson.parseSchema(schemaKson)
+        assertIs<SchemaResult.Success>(schemaResult)
+
+        val messages = Kson.analyze(
+            """{"name": "John", "name": "Bob"}""",
+            filepath = null,
+            schemaValidator = schemaResult.schemaValidator
+        ).errors.map { it.message }
+
+        assertEquals(2, messages.size, "expected the duplicate key and the missing property, got: $messages")
+        assertTrue(messages[0].contains("Duplicate key"), messages[0])
+        assertTrue(messages[1].contains("age"), messages[1])
+    }
+
     @Test
     fun testPropertyKeys_basicAccess() {
         val input = """

--- a/kson-lib/src/commonTest/kotlin/org/kson/KsonSmokeTest.kt
+++ b/kson-lib/src/commonTest/kotlin/org/kson/KsonSmokeTest.kt
@@ -259,9 +259,11 @@ class KsonSmokeTest {
         val invalidSchema = """{"type": }"""
         val result = Kson.parseSchema(invalidSchema)
         assertIs<SchemaResult.Failure>(result)
-        assertTrue(result.errors.isNotEmpty())
+        assertEquals(1, result.errors.size)
+        assertEquals(MessageSeverity.ERROR, result.errors[0].severity)
+        assertEquals("1:2", result.errors[0].start.render1Based(), "the error should point at the empty value")
     }
-    
+
     @Test
     fun testSchemaValidator_validInput() {
         val schemaKson = """{

--- a/kson-tooling-lib/detekt-baseline.xml
+++ b/kson-tooling-lib/detekt-baseline.xml
@@ -4,8 +4,6 @@
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:SchemaInformation.kt$fun InternalKsonValue.extractSchemaInfo(): String?</ID>
     <ID>CyclomaticComplexMethod:SemanticTokenBuilder.kt$SemanticTokenBuilder$private fun collectKeyTokens(node: AstNode, keyTokens: MutableSet&lt;Token>)</ID>
-    <ID>LargeClass:SchemaCompletionLocationTest.kt$SchemaCompletionLocationTest</ID>
-    <ID>LargeClass:SchemaNavigationTest.kt$SchemaNavigationTest</ID>
     <ID>LongMethod:SchemaCompletionLocationTest.kt$SchemaCompletionLocationTest$@Test fun testCompletionsAtValuePositionWithRefToAnyOfWithDescription()</ID>
     <ID>LongMethod:SchemaCompletionLocationTest.kt$SchemaCompletionLocationTest$@Test fun testOneOfCompletionsFilteredByExistingProperties()</ID>
     <ID>LoopWithTooManyJumpStatements:SchemaDefinitionLocationTest.kt$SchemaDefinitionLocationTest$while</ID>

--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/DiagnosticBuilder.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/DiagnosticBuilder.kt
@@ -4,37 +4,54 @@ import org.kson.Kson
 import org.kson.Message
 import org.kson.MessageSeverity
 import org.kson.SchemaResult
+import org.kson.parser.messages.MessageType
+import org.kson.parser.messages.MessageSeverity as InternalMessageSeverity
 import org.kson.validation.SourceContext
 
 /**
  * Validates a KSON document and returns [DiagnosticMessage]s.
  *
- * If a schema is provided and valid, validation includes both parse errors and schema violations.
- * If no schema is provided or the schema fails to parse, only document parse errors are returned.
+ * If a schema is provided and parses, validation includes both parse errors and schema violations.
+ * If the schema has problems of its own, it cannot validate anything: a [MessageType.SCHEMA_UNUSABLE]
+ * is reported on the document.
  */
 internal object DiagnosticBuilder {
 
     fun build(content: String, schemaContent: String?, sourceContext: SourceContext): List<DiagnosticMessage> {
         if (schemaContent == null) {
-            return Kson.analyze(content, sourceContext.filepath).errors.map { toDiagnosticMessage(it) }
+            return documentDiagnostics(content, sourceContext)
         }
 
-        val diagnosticMessages = when (val result = Kson.parseSchema(schemaContent)) {
-            is SchemaResult.Success -> result.schemaValidator.validate(content, filepath = sourceContext.filepath)
-            is SchemaResult.Failure -> Kson.analyze(content, sourceContext.filepath).errors
+        return when (val result = Kson.parseSchema(schemaContent)) {
+            is SchemaResult.Success -> result.schemaValidator
+                .validate(content, filepath = sourceContext.filepath)
+                .map { toDiagnosticMessage(it) }
+            is SchemaResult.Failure ->
+                listOf(schemaUnusableDiagnostic(result.errors)) + documentDiagnostics(content, sourceContext)
         }
+    }
 
-        return diagnosticMessages.map { toDiagnosticMessage(it) }
+    private fun documentDiagnostics(content: String, sourceContext: SourceContext): List<DiagnosticMessage> =
+        Kson.analyze(content, sourceContext.filepath).errors.map { toDiagnosticMessage(it) }
+
+    private fun schemaUnusableDiagnostic(schemaProblems: List<Message>): DiagnosticMessage {
+        val firstProblem = schemaProblems.first()
+        val message = MessageType.SCHEMA_UNUSABLE.create(
+            firstProblem.start.render1Based(),
+            firstProblem.message
+        )
+        return DiagnosticMessage(
+            message = message.toString(),
+            severity = toDiagnosticSeverity(MessageType.SCHEMA_UNUSABLE.severity),
+            // anchor the external schema problem to the beginning of this document
+            range = Range(0, 0, 0, 0)
+        )
     }
 
     private fun toDiagnosticMessage(logged: Message): DiagnosticMessage {
-        val severity = when (logged.severity) {
-            MessageSeverity.ERROR -> DiagnosticSeverity.ERROR
-            MessageSeverity.WARNING -> DiagnosticSeverity.WARNING
-        }
         return DiagnosticMessage(
             message = logged.message,
-            severity = severity,
+            severity = toDiagnosticSeverity(logged.severity),
             range = Range(
                 logged.start.line,
                 logged.start.column,
@@ -42,5 +59,19 @@ internal object DiagnosticBuilder {
                 logged.end.column
             )
         )
+    }
+
+    private fun toDiagnosticSeverity(severity: MessageSeverity): DiagnosticSeverity {
+        return when (severity) {
+            MessageSeverity.ERROR -> DiagnosticSeverity.ERROR
+            MessageSeverity.WARNING -> DiagnosticSeverity.WARNING
+        }
+    }
+
+    private fun toDiagnosticSeverity(severity: InternalMessageSeverity): DiagnosticSeverity {
+        return when (severity) {
+            InternalMessageSeverity.ERROR -> DiagnosticSeverity.ERROR
+            InternalMessageSeverity.WARNING -> DiagnosticSeverity.WARNING
+        }
     }
 }

--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/DiagnosticBuilder.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/DiagnosticBuilder.kt
@@ -4,6 +4,7 @@ import org.kson.Kson
 import org.kson.Message
 import org.kson.MessageSeverity
 import org.kson.SchemaResult
+import org.kson.SchemaValidator
 import org.kson.parser.messages.MessageType
 import org.kson.parser.messages.MessageSeverity as InternalMessageSeverity
 import org.kson.validation.SourceContext
@@ -11,8 +12,8 @@ import org.kson.validation.SourceContext
 /**
  * Validates a KSON document and returns [DiagnosticMessage]s.
  *
- * If a schema is provided and parses, validation includes both parse errors and schema violations.
- * If the schema has problems of its own, it cannot validate anything: a [MessageType.SCHEMA_UNUSABLE]
+ * If a schema is provided and parses, validation includes any schema violations in addition to the document's own
+ * diagnostics. If the schema has problems of its own, it cannot validate anything: a [MessageType.SCHEMA_UNUSABLE]
  * is reported on the document.
  */
 internal object DiagnosticBuilder {
@@ -23,16 +24,19 @@ internal object DiagnosticBuilder {
         }
 
         return when (val result = Kson.parseSchema(schemaContent)) {
-            is SchemaResult.Success -> result.schemaValidator
-                .validate(content, filepath = sourceContext.filepath)
-                .map { toDiagnosticMessage(it) }
+            is SchemaResult.Success ->
+                documentDiagnostics(content, sourceContext, result.schemaValidator)
             is SchemaResult.Failure ->
                 listOf(schemaUnusableDiagnostic(result.errors)) + documentDiagnostics(content, sourceContext)
         }
     }
 
-    private fun documentDiagnostics(content: String, sourceContext: SourceContext): List<DiagnosticMessage> =
-        Kson.analyze(content, sourceContext.filepath).errors.map { toDiagnosticMessage(it) }
+    private fun documentDiagnostics(
+        content: String,
+        sourceContext: SourceContext,
+        schemaValidator: SchemaValidator? = null
+    ): List<DiagnosticMessage> =
+        Kson.analyze(content, sourceContext.filepath, schemaValidator).errors.map { toDiagnosticMessage(it) }
 
     private fun schemaUnusableDiagnostic(schemaProblems: List<Message>): DiagnosticMessage {
         val firstProblem = schemaProblems.first()

--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/KsonTooling.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/KsonTooling.kt
@@ -276,9 +276,9 @@ object KsonTooling {
      * [SourceContext][SourceContext] are used for the
      * strict parse, so validators receive the document's filepath.
      *
-     * If a [schema] is provided, the document is validated against it.
-     * Schema validation includes both parse errors and schema violations.
-     * If no schema is provided, only parse errors are returned.
+     * If a [schema] is provided, the document is validated against it,
+     * and any schema validation messages are added to the document's
+     * parse messages
      *
      * @param document The pre-parsed document to validate
      * @param schema Optional pre-parsed schema document

--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/KsonTooling.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/KsonTooling.kt
@@ -278,7 +278,7 @@ object KsonTooling {
      *
      * If a [schema] is provided, the document is validated against it.
      * Schema validation includes both parse errors and schema violations.
-     * If no schema is provided (or it fails to parse), only parse errors are returned.
+     * If no schema is provided, only parse errors are returned.
      *
      * @param document The pre-parsed document to validate
      * @param schema Optional pre-parsed schema document

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/DiagnosticTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/DiagnosticTest.kt
@@ -139,6 +139,37 @@ class DiagnosticTest {
         assertEquals(0, diagnostics.size)
     }
 
+    /**
+     * Regression test for an issue where warnings were not included in diagnostics when schema validation was
+     * requested
+     */
+    @Test
+    fun testSchemaViolationsFollowTheDocumentsOwnMessages() {
+        val schema = """
+            {
+                type: object
+                properties: { name: { type: string } }
+                required: ["age"]
+            }
+        """.trimIndent()
+        val diagnostics = validateDocument("{ name: \"Alice\", name: \"Bob\" }", schema)
+        assertEquals(2, diagnostics.size, "expected the duplicate key and the schema violation, got: $diagnostics")
+        assertTrue(diagnostics[0].message.contains("Duplicate key"), diagnostics[0].message)
+        assertTrue(diagnostics[1].message.contains("age"), diagnostics[1].message)
+    }
+
+    /**
+     * Regression test for an issue seen in development where attempting to validate a document
+     * with errors against a schema resulted in the document's parse error messages being duplicated
+     */
+    @Test
+    fun testUnparseableDocumentMessagesNotAffectedBySchemaCheck() {
+        val schema = "{ type: object }"
+        val diagnostics = validateDocument("key: \"value\" extra", schema)
+        assertEquals(1, diagnostics.size, "the parse error must be reported once, got: $diagnostics")
+        assertEquals(DiagnosticSeverity.ERROR, diagnostics[0].severity)
+    }
+
     @Test
     fun testUnusableSchemaIsReportedAlongsideDocumentParseErrors() {
         val ksonDocWithError = "key: \"value\" extra"

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/DiagnosticTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/DiagnosticTest.kt
@@ -183,6 +183,24 @@ class DiagnosticTest {
     }
 
     /**
+     * A schema with KSON warnings that describes a legal schema may be used
+     *
+     * The document breaks the schema twice on purpose: an unusable schema is reported once
+     * ([testSchemaWithSeveralProblemsIsReportedOnce]), so a second violation can only come from a
+     * schema that ran.
+     */
+    @Test
+    fun testSchemaWithWarningsInItsSourceIsStillUsed() {
+        val schemaWithDuplicateKey =
+            "{ type: object, type: object, properties: { a: { type: number }, b: { type: number } } }"
+        val diagnostics = validateDocument("""{ a: "x", b: "y" }""", schemaWithDuplicateKey)
+        assertEquals(
+            2, diagnostics.size,
+            "expected the document's schema violations to be reported, got: $diagnostics"
+        )
+    }
+
+    /**
      * An empty schema file is a routine state on the way to writing one, and every document it governs
      * is unvalidated until it says something.
      */

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/DiagnosticTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/DiagnosticTest.kt
@@ -3,9 +3,20 @@ package org.kson
 import org.kson.tooling.DiagnosticMessage
 import org.kson.tooling.DiagnosticSeverity
 import org.kson.tooling.KsonTooling
+import org.kson.tooling.Range
 import kotlin.test.*
 
 class DiagnosticTest {
+
+    /** An unparseable schema: it has an unclosed object */
+    private val schemaWithError = """
+        {
+          type: object
+          properties: { age: { type: number } }
+    """.trimIndent()
+
+    /** A schema that parses as Kson, but describes no schema: `type` must name a type */
+    private val schemaWithBadType = "{ type: 5 }"
 
     private fun validateDocument(content: String, schemaContent: String? = null): List<DiagnosticMessage> {
         val document = KsonTooling.parse(content)
@@ -129,18 +140,69 @@ class DiagnosticTest {
     }
 
     @Test
-    fun testInvalidSchemaStillReturnsParseErrors() {
-        val invalidSchema = "{ this is not valid : : : }}}"
-        val diagnostics = validateDocument("key: \"value\" extra", invalidSchema)
+    fun testUnusableSchemaIsReportedAlongsideDocumentParseErrors() {
+        val ksonDocWithError = "key: \"value\" extra"
+        val diagnostics = validateDocument(ksonDocWithError)
         assertEquals(1, diagnostics.size)
-        assertEquals(DiagnosticSeverity.ERROR, diagnostics[0].severity)
+        assertEquals(DiagnosticSeverity.ERROR, diagnostics[0].severity, "should be the Kson doc's parse error")
+
+        val diagnosticsWithBrokenSchema = validateDocument(ksonDocWithError, schemaWithError)
+        assertEquals(2, diagnosticsWithBrokenSchema.size)
+        assertEquals(DiagnosticSeverity.WARNING, diagnosticsWithBrokenSchema[0].severity, "the unusable schema")
+        assertEquals(
+            diagnostics,
+            diagnosticsWithBrokenSchema.drop(1),
+            "the Kson doc's own diagnostics should be untouched by the schema report"
+        )
     }
 
     @Test
-    fun testValidDocumentWithBrokenSchemaReturnsNoDiagnostics() {
-        val invalidSchema = "{ broken schema {{{{"
-        val diagnostics = validateDocument("key: \"value\"", invalidSchema)
-        assertEquals(0, diagnostics.size)
+    fun testValidDocumentWithUnusableSchemaReportsTheSchemaProblem() {
+        val validKsonDoc = "key: \"value\""
+        assertEquals(0, validateDocument(validKsonDoc).size, "this doc has nothing to report on its own")
+
+        val diagnostics = validateDocument(validKsonDoc, schemaWithError)
+        assertEquals(1, diagnostics.size)
+        assertEquals(DiagnosticSeverity.WARNING, diagnostics[0].severity)
+        assertEquals(
+            Range(0, 0, 0, 0),
+            diagnostics[0].range,
+            "The problem is in the schema, so this diagnostic is anchored at the start of the document"
+        )
+    }
+
+    /**
+     * A schema can parse perfectly well and still describe no schema, which leaves the document just
+     * as unvalidated as an unparseable schema does.
+     */
+    @Test
+    fun testSchemaThatParsesButDescribesNoSchemaIsReported() {
+        val diagnostics = validateDocument("key: \"value\"", schemaWithBadType)
+        assertEquals(1, diagnostics.size)
+        assertEquals(DiagnosticSeverity.WARNING, diagnostics[0].severity)
+    }
+
+    /**
+     * An empty schema file is a routine state on the way to writing one, and every document it governs
+     * is unvalidated until it says something.
+     */
+    @Test
+    fun testEmptySchemaIsReported() {
+        val diagnostics = validateDocument("key: \"value\"", "")
+        assertEquals(1, diagnostics.size)
+        assertEquals(DiagnosticSeverity.WARNING, diagnostics[0].severity)
+    }
+
+    /**
+     * However many problems a schema has, the document it governs gets a single report of it: the rest
+     * are the schema author's business, and belong to the schema document rather than this one.
+     */
+    @Test
+    fun testSchemaWithSeveralProblemsIsReportedOnce() {
+        val schemaWithThreeProblems = "{ type: 5, minLength: \"nope\", required: 7 }"
+        val diagnostics = validateDocument("key: \"value\"", schemaWithThreeProblems)
+        assertEquals(1, diagnostics.size)
+        assertEquals(DiagnosticSeverity.WARNING, diagnostics[0].severity)
     }
 
     @Test

--- a/lib-python/readme.md
+++ b/lib-python/readme.md
@@ -115,7 +115,7 @@ Use `Kson.analyze()` to parse KSON into tokens and a structured value tree:
 ```python
 from kson import Kson, KsonValue
 
-analysis = Kson.analyze("name: Alice\nscores: [95, 87, 92]", None)
+analysis = Kson.analyze("name: Alice\nscores: [95, 87, 92]", None, None)
 
 # Check for parse errors
 for error in analysis.errors():
@@ -159,7 +159,7 @@ Every value also has `.start()` and `.end()` returning a `Position` with `.line(
 ```python
 from kson import Kson
 
-analysis = Kson.analyze("key: value", None)
+analysis = Kson.analyze("key: value", None, None)
 for token in analysis.tokens():
     print(f"{token.token_type().name}: {repr(token.text())}")
 ```
@@ -199,7 +199,7 @@ KSON supports [embed blocks](https://github.com/kson-org/kson) for embedding raw
 ```python
 from kson import Kson, KsonValue
 
-analysis = Kson.analyze("query: $sql\nSELECT * FROM users\n$$", None)
+analysis = Kson.analyze("query: $sql\nSELECT * FROM users\n$$", None, None)
 value = analysis.kson_value()
 
 if isinstance(value, KsonValue.KsonObject):

--- a/lib-python/src/kson/__init__.py
+++ b/lib-python/src/kson/__init__.py
@@ -1015,11 +1015,18 @@ class SchemaValidator(KotlinObjectBase):
         filepath: Optional[str],
 
     ) -> List[Message]:
-        """Validates the given Kson source against this validator's schema.
-        @param kson The Kson source to validate
-        @param filepath Optional filepath of the document being validated, used by validators to determine which rules to apply
+        """Validates the given KSON source against this validator's schema.
 
-        @return A list of validation error messages, or empty list if valid
+        NOTE: this must parse [kson] in order to validate it, but does not report that parse's own messages: a
+        document may satisfy a schema and still carry warnings of its own.  Pass this validator to [Kson.analyze]
+        to see both.  The exception is [kson] which fails to parse at all: it _cannot_ be validated against this
+        [schema], and so those parse errors are returned instead.
+
+        @param kson The KSON source to validate
+        @param filepath (Optional) filepath of the document being validated, used by validators to determine
+                        which rules to apply
+
+        @return A list of schema validation [Message]s, or empty list if [kson] is valid under this [schema]
         """
 
         if kson is None:
@@ -1554,12 +1561,15 @@ class Kson(KotlinObjectBase):
     def analyze(
         kson: str,
         filepath: Optional[str],
+        schema_validator: Optional[SchemaValidator],
 
     ) -> Analysis:
         """Statically analyze the given Kson and return an [Analysis] object containing any messages generated along with a
         tokenized version of the source.  Useful for tooling/editor support.
         @param kson The Kson source to analyze
-        @param filepath Filepath of the document being analyzed
+        @param filepath (Optional) Filepath of the document being analyzed
+        @param schemaValidator (Optional) A schema to validate [kson] against, provided [kson] is error-free and hence
+                 able to be validated against a schema
         """
 
         if kson is None:
@@ -1569,12 +1579,13 @@ class Kson(KotlinObjectBase):
             b"org/kson/Kson",
             jni_ref,
             b"analyze",
-            b"(Ljava/lang/String;Ljava/lang/String;)Lorg/kson/Analysis;",
+            b"(Ljava/lang/String;Ljava/lang/String;Lorg/kson/SchemaValidator;)Lorg/kson/Analysis;",
             "ObjectMethod",
             [
 
                 _python_str_to_java_string(kson),
                 _python_str_to_java_string(filepath) if filepath is not None else ffi.NULL,
+                schema_validator._jni_ref if schema_validator is not None else ffi.NULL,
             ]
         )
 

--- a/lib-python/tests/smoke_test.py
+++ b/lib-python/tests/smoke_test.py
@@ -207,7 +207,7 @@ def test_kson_to_yaml_failure():
 
 
 def test_kson_analysis():
-    analysis = Kson.analyze("key: [1, 2, 3, 4]", None)
+    analysis = Kson.analyze("key: [1, 2, 3, 4]", None, None)
     assert analysis.errors() == []
 
     # Transform tokens to strings, so we can snapshot them
@@ -245,7 +245,7 @@ list:
   - 3E5
 embed:%tag
 %%"""
-    analysis = Kson.analyze(input, None)
+    analysis = Kson.analyze(input, None, None)
     value = analysis.kson_value()
     assert value is not None
     assert isinstance(value, KsonValue.KsonObject)
@@ -318,7 +318,7 @@ def test_property_keys_basic_access():
     input = """name: John
 age: 30
 city: 'New York'"""
-    analysis = Kson.analyze(input, None)
+    analysis = Kson.analyze(input, None, None)
     value = analysis.kson_value()
     assert value is not None
     assert isinstance(value, KsonValue.KsonObject)
@@ -343,7 +343,7 @@ city: 'New York'"""
 def test_property_keys_with_position_information():
     input = """name: John
 age: 30"""
-    analysis = Kson.analyze(input, None)
+    analysis = Kson.analyze(input, None, None)
     value = analysis.kson_value()
     assert value is not None
     assert isinstance(value, KsonValue.KsonObject)
@@ -365,7 +365,7 @@ age: 30"""
 
 def test_property_keys_empty_object():
     input = "{}"
-    analysis = Kson.analyze(input, None)
+    analysis = Kson.analyze(input, None, None)
     value = analysis.kson_value()
     assert value is not None
     assert isinstance(value, KsonValue.KsonObject)
@@ -379,7 +379,7 @@ def test_kson_value_boolean_and_null():
     input = """flag: true
 other: false
 nothing: null"""
-    analysis = Kson.analyze(input, None)
+    analysis = Kson.analyze(input, None, None)
     value = analysis.kson_value()
     assert isinstance(value, KsonValue.KsonObject)
 
@@ -405,7 +405,7 @@ num: 42
 dec: 3.14
 list: [1]
 obj: {a: b}"""
-    analysis = Kson.analyze(input, None)
+    analysis = Kson.analyze(input, None, None)
     value = analysis.kson_value()
     assert isinstance(value, KsonValue.KsonObject)
     props = value.properties()
@@ -422,7 +422,7 @@ def test_kson_value_embed_type():
     input = """key: $embed
 content here
 embed$$"""
-    analysis = Kson.analyze(input, None)
+    analysis = Kson.analyze(input, None, None)
     value = analysis.kson_value()
     assert isinstance(value, KsonValue.KsonObject)
     props = value.properties()
@@ -501,6 +501,19 @@ properties:
     # Validate a valid document
     errors = validator.validate("name: hello", None)
     assert errors == []
+
+
+def test_analyze_against_a_schema():
+    result = Kson.parse_schema("""type: object
+required: [age]""")
+    assert isinstance(result, SchemaResult.Success)
+
+    # a duplicate key is a warning this document carries; the missing `age` is what the schema objects to
+    analysis = Kson.analyze('{ name: "Alice", name: "Bob" }', None, result.schema_validator())
+    messages = [error.message() for error in analysis.errors()]
+    assert len(messages) == 2, messages
+    assert "Duplicate key" in messages[0]
+    assert "age" in messages[1]
 
 
 def test_parse_schema_validation_errors():
@@ -591,7 +604,7 @@ def test_kson_to_yaml_none_checks():
 
 def test_kson_analyze_none_check():
     with pytest.raises(ValueError):
-        Kson.analyze(NoneAny, NoneAny)
+        Kson.analyze(NoneAny, NoneAny, None)
 
 
 def test_kson_parse_schema_none_check():
@@ -631,7 +644,7 @@ def test_formatting_style_from_kotlin_enum():
 
 def test_number_internal_start_end():
     input = "val: 42"
-    analysis = Kson.analyze(input, None)
+    analysis = Kson.analyze(input, None, None)
     value = analysis.kson_value()
     assert isinstance(value, KsonValue.KsonObject)
     props = value.properties()

--- a/lib-rust/kson/src/generated/mod.rs
+++ b/lib-rust/kson/src/generated/mod.rs
@@ -2175,11 +2175,18 @@ impl SchemaValidator {
 
 impl SchemaValidator {
 
-    /// Validates the given Kson source against this validator's schema.
-    /// @param kson The Kson source to validate
-    /// @param filepath Optional filepath of the document being validated, used by validators to determine which rules to apply
+    /// Validates the given KSON source against this validator's schema.
     ///
-    /// @return A list of validation error messages, or empty list if valid
+    /// NOTE: this must parse [kson] in order to validate it, but does not report that parse's own messages: a
+    /// document may satisfy a schema and still carry warnings of its own.  Pass this validator to [Kson.analyze]
+    /// to see both.  The exception is [kson] which fails to parse at all: it _cannot_ be validated against this
+    /// [schema], and so those parse errors are returned instead.
+    ///
+    /// @param kson The KSON source to validate
+    /// @param filepath (Optional) filepath of the document being validated, used by validators to determine
+    /// which rules to apply
+    ///
+    /// @return A list of schema validation [Message]s, or empty list if [kson] is valid under this [schema]
     pub fn validate(
         &self,
         kson: &str,
@@ -3513,10 +3520,13 @@ impl Kson {
     /// Statically analyze the given Kson and return an [Analysis] object containing any messages generated along with a
     /// tokenized version of the source.  Useful for tooling/editor support.
     /// @param kson The Kson source to analyze
-    /// @param filepath Filepath of the document being analyzed
+    /// @param filepath (Optional) Filepath of the document being analyzed
+    /// @param schemaValidator (Optional) A schema to validate [kson] against, provided [kson] is error-free and hence
+    /// able to be validated against a schema
     pub fn analyze(
         kson: &str,
         filepath: Option<&str>,
+        schema_validator: Option<SchemaValidator>,
     ) -> Analysis {
         let self_ptr = util::access_static_field(c"org/kson/Kson", c"INSTANCE", c"Lorg/kson/Kson;");
         let self_obj = self_ptr.as_kotlin_object();
@@ -3524,17 +3534,20 @@ impl Kson {
         let kson = kson_ptr.as_kotlin_object();
         let filepath_ptr = filepath.to_kotlin_object();
         let filepath = filepath_ptr.as_kotlin_object();
+        let schema_validator_ptr = schema_validator.to_kotlin_object();
+        let schema_validator = schema_validator_ptr.as_kotlin_object();
 
         let (_, _detach_guard) = util::attach_thread_to_java_vm();
         let result = call_jvm_function!(
             util,
             c"org/kson/Kson",
             c"analyze",
-            c"(Ljava/lang/String;Ljava/lang/String;)Lorg/kson/Analysis;",
+            c"(Ljava/lang/String;Ljava/lang/String;Lorg/kson/SchemaValidator;)Lorg/kson/Analysis;",
             CallObjectMethod,
             self_obj,
             kson,
             filepath,
+            schema_validator,
         );
 
         FromKotlinObject::from_kotlin_object(result)

--- a/lib-rust/kson/src/test.rs
+++ b/lib-rust/kson/src/test.rs
@@ -169,7 +169,7 @@ fn test_kson_to_yaml_failure() {
 
 #[test]
 fn test_kson_analysis() {
-    let analysis = Kson::analyze("key: [1, 2, 3, 4]", None);
+    let analysis = Kson::analyze("key: [1, 2, 3, 4]", None, None);
     assert!(analysis.errors().is_empty());
 
     // Transform tokens to strings, so we can snapshot them
@@ -223,6 +223,31 @@ fn test_kson_validate_schema() {
     insta::assert_snapshot!(output, @"0,0 to 0,2 - Expected one of: string, but got: integer");
 }
 
+#[test]
+fn test_kson_analyze_against_a_schema() {
+    let result = Kson::parse_schema(r#"{ "type": "object", "required": ["age"] }"#);
+    let Ok(success) = result else {
+        panic!("expected success, found failure")
+    };
+
+    // a duplicate key is a warning this document carries; the missing `age` is what the schema objects to
+    let analysis = Kson::analyze(
+        r#"{ name: "Alice", name: "Bob" }"#,
+        None,
+        Some(success.schema_validator()),
+    );
+
+    let errors = analysis.errors();
+    assert_eq!(
+        2,
+        errors.len(),
+        "expected the duplicate key and the missing property, got: {}",
+        messages_to_string(&errors)
+    );
+    assert!(errors[0].message().contains("Duplicate key"));
+    assert!(errors[1].message().contains("age"));
+}
+
 /// Transform messages to strings, so we can snapshot them
 fn messages_to_string(msgs: &[Message]) -> String {
     let mut output = String::new();
@@ -255,7 +280,7 @@ list:
   - 3E5
 embed:%tag
 %%"#;
-    let analysis = Kson::analyze(input, None);
+    let analysis = Kson::analyze(input, None, None);
     let kson_value = analysis.kson_value();
     assert!(kson_value.is_some());
 
@@ -343,7 +368,7 @@ fn test_property_keys_basic_access() {
     let input = r#"name: John
 age: 30
 city: 'New York'"#;
-    let analysis = Kson::analyze(input, None);
+    let analysis = Kson::analyze(input, None, None);
     let value = analysis.kson_value().unwrap();
     let KsonValue::KsonObject(obj) = value else {
         panic!("expected object");
@@ -368,7 +393,7 @@ city: 'New York'"#;
 fn test_property_keys_with_position_information() {
     let input = r#"name: John
 age: 30"#;
-    let analysis = Kson::analyze(input, None);
+    let analysis = Kson::analyze(input, None, None);
     let value = analysis.kson_value().unwrap();
     let KsonValue::KsonObject(obj) = value else {
         panic!("expected object");
@@ -392,7 +417,7 @@ age: 30"#;
 #[test]
 fn test_property_keys_empty_object() {
     let input = "{}";
-    let analysis = Kson::analyze(input, None);
+    let analysis = Kson::analyze(input, None, None);
     let value = analysis.kson_value().unwrap();
     let KsonValue::KsonObject(obj) = value else {
         panic!("expected object");

--- a/src/commonMain/kotlin/org/kson/KsonCore.kt
+++ b/src/commonMain/kotlin/org/kson/KsonCore.kt
@@ -6,7 +6,6 @@ import org.kson.ast.*
 import org.kson.parser.*
 import org.kson.parser.messages.MessageType
 import org.kson.parser.messages.MessageType.SCHEMA_EMPTY_SCHEMA
-import org.kson.schema.JsonBooleanSchema
 import org.kson.schema.JsonSchema
 import org.kson.schema.SchemaParser
 import org.kson.stdlibx.exceptions.FatalParseException
@@ -347,9 +346,9 @@ class Json(
  */
 data class CoreCompileConfig(
     /**
-     * The [JSON Schema](https://json-schema.org/) to enforce in this compilation
+     * The [JSON Schema](https://json-schema.org/) to enforce in this compilation, or null to enforce no schema
      */
-    val schemaJson: JsonSchema = NO_SCHEMA,
+    val schemaJson: JsonSchema? = null,
     /**
      * Whether we do the extra work to build an AST patched with [AstNodeError]'s. This could be set to false when
      * formatting for example, since we're only interested in collecting the error nodes and running validators.
@@ -363,17 +362,10 @@ data class CoreCompileConfig(
     /**
      * List of validators that are run on a complete KsonValue
      */
-    val validators: List<Validator> = listOf(schemaJson),
+    val validators: List<Validator> = listOfNotNull(schemaJson),
 
     /**
      * Context information for the source
      */
     val sourceContext: SourceContext = SourceContext()
 )
-
-/**
- * A [JsonBooleanSchema] specifying just `true` is the "trivial" schema that matches everything,
- * and so is equivalent to not having a schema.  See https://json-schema.org/draft/2020-12/json-schema-core#section-4.3.2
- * for more detail
- */
-private val NO_SCHEMA = JsonBooleanSchema(true)

--- a/src/commonMain/kotlin/org/kson/KsonCore.kt
+++ b/src/commonMain/kotlin/org/kson/KsonCore.kt
@@ -54,7 +54,7 @@ object KsonCore {
         }
         if (tokens[initialTokenIndex].tokenType == TokenType.EOF) {
             messageSink.error(tokens[0].lexeme.location, MessageType.BLANK_SOURCE.create())
-            return AstParseResult(KsonRootError(tokens), tokens, messageSink)
+            return AstParseResult(KsonRootError(tokens), tokens, messageSink, coreCompileConfig.ignoreErrors)
         }
 
         val builder = KsonBuilder(tokens, coreCompileConfig.ignoreErrors)
@@ -71,7 +71,7 @@ object KsonCore {
 
         } catch (ex: FatalParseException) {
             messageSink.error(tokens[0].lexeme.location, MessageType.FATAL_PARSE_ERROR.create(ex.message ?: "Unknown error"))
-            return AstParseResult(KsonRootError(tokens), tokens, messageSink)
+            return AstParseResult(KsonRootError(tokens), tokens, messageSink, coreCompileConfig.ignoreErrors)
         }
 
         // If we are not interested in errors we don't have to run extra validations.
@@ -87,7 +87,7 @@ object KsonCore {
                 it.validate(ast.toKsonValue(), messageSink, coreCompileConfig.sourceContext)
             }
         }
-        return AstParseResult(ast, tokens, messageSink)
+        return AstParseResult(ast, tokens, messageSink, coreCompileConfig.ignoreErrors)
     }
 
     /**
@@ -106,9 +106,7 @@ object KsonCore {
             )
         }
         val ksonValue = astParseResult.ksonValue
-        if (ksonValue == null || astParseResult.hasErrors()) {
-            return SchemaParseResult(null, astParseResult.messages)
-        }
+            ?: return SchemaParseResult(null, astParseResult.messages)
 
         val messageSink = MessageSink()
         val jsonSchema = SchemaParser.parseSchemaRoot(ksonValue, messageSink)
@@ -184,23 +182,32 @@ interface ParseResult {
 data class AstParseResult(
     override val ast: KsonRoot,
     override val lexedTokens: List<Token>,
-    private val messageSink: MessageSink
+    private val messageSink: MessageSink,
+    /**
+     * True when this parse was performed with [CoreCompileConfig.ignoreErrors]
+     */
+    private val ignoreErrors: Boolean
 ) : ParseResult {
     override val messages = messageSink.loggedMessages()
 
     /**
-     * A [KsonValue] on the AST constructed here, or null if there were errors trying to parse
-     * (consult [messageSink] for information on any errors).
+     * A [KsonValue] on the AST constructed here, or null if this source could not be parsed into one.
      *
-     * When parsed with [CoreCompileConfig.ignoreErrors], the AST may contain
-     * [org.kson.ast.AstNodeError] nodes deeper in the tree even though [hasErrors]
-     * returns false (because error-walking is skipped). In that case [toKsonValue]
-     * fails and this property returns null.
+     * When this parse checked for errors, this is null exactly when [hasErrors] is true, and [messages]
+     * says why.  A [CoreCompileConfig.ignoreErrors] parse makes no such promise: it never looked for the
+     * problems in its source, so it may come back null having reported none of them.
      */
     val ksonValue: KsonValue? by lazy {
         if (hasErrors()) {
             null
-        } else {
+        } else if (ignoreErrors) {
+            /**
+             * An error-tolerant parse may build arbitrarily broken ASTs, so throwing when attempting to construct a
+             * [KsonValue] is expected here
+             *
+             * TODO: a refactor to disallow [ksonValue]s from [ignoreErrors] parses would be nice if possible, letting
+             *       the Kotlin compiler own guiding callers to use these types correctly
+             */
             try {
                 ast.toKsonValue()
             } catch (_: ShouldNotHappenException) {
@@ -208,6 +215,8 @@ data class AstParseResult(
             } catch (_: UnsupportedOperationException) {
                 null
             }
+        } else {
+            ast.toKsonValue()
         }
     }
 

--- a/src/commonMain/kotlin/org/kson/parser/messages/Message.kt
+++ b/src/commonMain/kotlin/org/kson/parser/messages/Message.kt
@@ -587,6 +587,18 @@ enum class MessageType(
             return "Schema \"type\" must be a string or array of strings"
         }
     },
+    SCHEMA_UNUSABLE(MessageSeverity.WARNING) {
+        override fun expectedArgs(): List<String> {
+            return listOf("Schema Problem Location", "Schema Problem")
+        }
+
+        override fun doFormat(parsedArgs: ParsedErrorArgs): String {
+            val schemaProblemLocation = parsedArgs.getArg("Schema Problem Location")
+            val schemaProblem = parsedArgs.getArg("Schema Problem")
+            return "This document was not validated because its schema has problems.  " +
+                    "First problem in the schema, at $schemaProblemLocation: $schemaProblem"
+        }
+    },
     SCHEMA_VALUE_MUST_BE_MULTIPLE_OF(MessageSeverity.WARNING) {
         override fun expectedArgs(): List<String> {
             return listOf("Multiple Of Value")

--- a/src/commonMain/kotlin/org/kson/stdlibx/collections/Immutable.kt
+++ b/src/commonMain/kotlin/org/kson/stdlibx/collections/Immutable.kt
@@ -5,6 +5,10 @@ package org.kson.stdlibx.collections
  */
 
 class ImmutableList<T> private constructor(private val inner: List<T>) : List<T> by inner {
+    override fun equals(other: Any?): Boolean = inner.equals(other)
+    override fun hashCode(): Int = inner.hashCode()
+    override fun toString(): String = inner.toString()
+
     companion object {
         fun <T> create(inner: List<T>) = if (inner is ImmutableList<T>) {
             inner
@@ -15,6 +19,10 @@ class ImmutableList<T> private constructor(private val inner: List<T>) : List<T>
 }
 
 class ImmutableMap<K, V> private constructor(private val inner: Map<K, V>) : Map<K, V> by inner {
+    override fun equals(other: Any?): Boolean = inner.equals(other)
+    override fun hashCode(): Int = inner.hashCode()
+    override fun toString(): String = inner.toString()
+
     companion object {
         fun <K, V> create(inner: Map<K, V>) = if (inner is ImmutableMap<K, V>) {
             inner

--- a/src/commonTest/kotlin/org/kson/AstParseResultTest.kt
+++ b/src/commonTest/kotlin/org/kson/AstParseResultTest.kt
@@ -1,0 +1,108 @@
+package org.kson
+
+import org.kson.value.KsonValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests the contract of [AstParseResult.ksonValue]: when a parse yields `null`, and what a
+ * caller can learn from [AstParseResult.messages] about why.
+ */
+class AstParseResultTest {
+
+    /**
+     * Sources chosen to break parsing in as many ways as we can think of, so the contract is
+     * exercised against real failures rather than one representative of them
+     */
+    private val brokenSources = listOf(
+        "",
+        "   \n\n  ",
+        "# only a comment",
+        "{",
+        "{ a: }",
+        "key:",
+        "-",
+        ".",
+        "<",
+        "[",
+        "key: \"unterminated",
+        "%%%\nunclosed embed",
+        "{ a: 1 } trailing",
+        "{ a: { b: { c: { d: } } } }",
+        "a: ".repeat(600) + "1",
+        "- ".repeat(600) + "1"
+    )
+
+    /**
+     * A parse that checked for errors withholds its value exactly when it found errors.  Callers
+     * lean on both directions of this: no value means there is something in [AstParseResult.messages]
+     * to report, and no errors means the value is there to use.
+     */
+    @Test
+    fun testErrorCheckedParseWithholdsItsValueExactlyWhenItFoundErrors() {
+        for (source in brokenSources) {
+            val parseResult = KsonCore.parseToAst(source)
+            assertEquals(
+                parseResult.hasErrors(),
+                parseResult.ksonValue == null,
+                "a checked parse has no value exactly when it has errors: \"$source\""
+            )
+        }
+    }
+
+    /**
+     * [AstParseResult.hasErrors] is also true for an error root the parser built without logging
+     * anything, so this pins the part callers actually need: an absent value is always accompanied
+     * by something they can show a user.
+     */
+    @Test
+    fun testErrorCheckedParseExplainsEveryAbsentValue() {
+        for (source in brokenSources) {
+            val parseResult = KsonCore.parseToAst(source)
+            if (parseResult.ksonValue == null) {
+                assertTrue(
+                    parseResult.messages.isNotEmpty(),
+                    "a checked parse with no value must say why in `messages`: \"$source\""
+                )
+            }
+        }
+    }
+
+    /**
+     * Warnings mean we successfully parsed, so we definitely expect to get a value back
+     */
+    @Test
+    fun testWarningsDoNotSuppressTheValue() {
+        val duplicateKey = KsonCore.parseToAst("{ a: 1, a: 2 }")
+        assertNotNull(duplicateKey.ksonValue, "a duplicate key is a warning, not a failure to parse")
+        assertTrue(duplicateKey.messages.isNotEmpty(), "the duplicate key should still be reported")
+    }
+
+    /**
+     * An error-tolerant parse may return an AST that cannot be represented as a [org.kson.value.KsonValue],
+     * but nothing prevents a caller from asking for a [org.kson.value.KsonValue] anyway. They should get a
+     * value or `null` if/when they try, never an exception.
+     */
+    @Test
+    fun testErrorTolerantParseSurvivesEveryBrokenSource() {
+        for (source in brokenSources) {
+            val ignoreErrorsKsonValue = KsonCore.parseToAst(source, CoreCompileConfig(ignoreErrors = true)).ksonValue
+            assertTrue(ignoreErrorsKsonValue is KsonValue || ignoreErrorsKsonValue == null)
+        }
+    }
+
+    /**
+     * An error-tolerant parse never looked for problems, so unlike a checked parse it can come back
+     * with no value, but no messages explaining why.  Callers who need an explanation must parse
+     * with error checking to get one.
+     */
+    @Test
+    fun testErrorTolerantParseNeedNotExplainAnAbsentValue() {
+        val parseResult = KsonCore.parseToAst("key:", CoreCompileConfig(ignoreErrors = true))
+        assertNull(parseResult.ksonValue)
+        assertEquals(emptyList(), parseResult.messages)
+    }
+}

--- a/src/commonTest/kotlin/org/kson/parser/messages/MessagesTest.kt
+++ b/src/commonTest/kotlin/org/kson/parser/messages/MessagesTest.kt
@@ -37,6 +37,15 @@ class MessagesTest {
     }
 
     @Test
+    fun testSchemaUnusableQuotesTheProblemItReports() {
+        // this message is a document's only view of a problem in another file, so it must carry
+        // both the problem and where in that file to find it
+        val message = MessageType.SCHEMA_UNUSABLE.create("3:7", "Unclosed object")
+        assertContains(message.toString(), "3:7")
+        assertContains(message.toString(), "Unclosed object")
+    }
+
+    @Test
     fun testFormatNullArgs() {
         assertFailsWith(IllegalArgumentException::class, "should blow up on null argument") {
             MessageType.EMBED_BLOCK_NO_CLOSE.create(null)

--- a/src/commonTest/kotlin/org/kson/stdlibx/collections/ImmutableTest.kt
+++ b/src/commonTest/kotlin/org/kson/stdlibx/collections/ImmutableTest.kt
@@ -1,0 +1,53 @@
+package org.kson.stdlibx.collections
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class ImmutableTest {
+    @Test
+    fun testImmutableListSymmetricallyEqualsAnEqualList() {
+        val immutable = listOf("a", "b").toImmutableList()
+
+        assertEquals(listOf("a", "b"), immutable)
+        assertEquals(immutable, listOf("a", "b"))
+        assertEquals(listOf("a", "b").hashCode(), immutable.hashCode())
+    }
+
+    @Test
+    fun testEmptyImmutableListSymmetricallyEqualsAnEmptyList() {
+        val immutable = emptyList<String>().toImmutableList()
+
+        assertEquals(emptyList(), immutable)
+        assertEquals(immutable, emptyList())
+    }
+
+    @Test
+    fun testImmutableListDiffersFromADifferentList() {
+        assertNotEquals(listOf("a"), listOf("a", "b").toImmutableList())
+    }
+
+    @Test
+    fun testImmutableListRendersItsContentsRatherThanItsIdentity() {
+        assertEquals(listOf("a", "b").toString(), listOf("a", "b").toImmutableList().toString())
+    }
+
+    @Test
+    fun testImmutableMapSymmetricallyEqualsAnEqualMap() {
+        val immutable = mapOf("a" to 1).toImmutableMap()
+
+        assertEquals(mapOf("a" to 1), immutable)
+        assertEquals(immutable, mapOf("a" to 1))
+        assertEquals(mapOf("a" to 1).hashCode(), immutable.hashCode())
+    }
+
+    @Test
+    fun testImmutableMapDiffersFromADifferentMap() {
+        assertNotEquals(mapOf("a" to 2), mapOf("a" to 1).toImmutableMap())
+    }
+
+    @Test
+    fun testImmutableMapRendersItsContentsRatherThanItsIdentity() {
+        assertEquals(mapOf("a" to 1).toString(), mapOf("a" to 1).toImmutableMap().toString())
+    }
+}

--- a/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/BaseKsonCommand.kt
+++ b/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/BaseKsonCommand.kt
@@ -80,15 +80,14 @@ abstract class BaseKsonCommand(
 
     /**
      * Validates [ksonContent] against [schemaValidator], exiting on any schema validation problems, reporting those
-     * problems
+     * problems.  Says nothing when the document conforms: commands which transpile write their result to stdout,
+     * so anything said there on success lands in the middle of that result.
      */
     protected fun validateWithSchema(ksonContent: String) {
         val schemaValidator = schemaValidator() ?: return
 
         val validationErrors = schemaValidator.validate(ksonContent, getFilePath())
-        if (validationErrors.isEmpty()) {
-            echo("✓ Document is valid according to the schema")
-        } else {
+        if (validationErrors.isNotEmpty()) {
             echo("Validation errors:", err = true)
             validationErrors.forEach { error ->
                 echo("  ${errorFormat(error)}", err = true)

--- a/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/BaseKsonCommand.kt
+++ b/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/BaseKsonCommand.kt
@@ -9,7 +9,7 @@ import com.github.ajalt.clikt.parameters.types.outputStream
 import org.kson.Kson
 import org.kson.Message
 import org.kson.SchemaResult
-import java.io.File
+import org.kson.SchemaValidator
 
 abstract class BaseKsonCommand(
     name: String? = null
@@ -59,26 +59,15 @@ abstract class BaseKsonCommand(
         output.bufferedWriter().use { it.write(content) }
     }
 
-    protected fun validateWithSchema(ksonContent: String) {
-        val schemaFile = schema ?: return
+    /**
+     * Returns [schema] parsed into a [SchemaValidator], or null when [schema] is null.
+     * An invalid non-null [schema] will exit reporting the errors that prevented parsing.
+     */
+    protected fun schemaValidator(): SchemaValidator? {
+        val schemaContent = (schema ?: return null).readText()
 
-        val schemaContent = schemaFile.readText()
-
-        when (val schemaResult = Kson.parseSchema(schemaContent)) {
-            is SchemaResult.Success -> {
-                val validationErrors = schemaResult.schemaValidator.validate(ksonContent, getFilePath())
-
-                if (validationErrors.isEmpty()) {
-                    echo("✓ Document is valid according to the schema")
-                } else {
-                    echo("Validation errors:", err = true)
-                    validationErrors.forEach { error ->
-                        echo("  ${errorFormat(error)}", err = true)
-                    }
-                    throw ProgramResult(1)
-                }
-            }
-
+        return when (val schemaResult = Kson.parseSchema(schemaContent)) {
+            is SchemaResult.Success -> schemaResult.schemaValidator
             is SchemaResult.Failure -> {
                 echo("Failed to parse schema:", err = true)
                 schemaResult.errors.forEach { error ->
@@ -86,6 +75,25 @@ abstract class BaseKsonCommand(
                 }
                 throw ProgramResult(1)
             }
+        }
+    }
+
+    /**
+     * Validates [ksonContent] against [schemaValidator], exiting on any schema validation problems, reporting those
+     * problems
+     */
+    protected fun validateWithSchema(ksonContent: String) {
+        val schemaValidator = schemaValidator() ?: return
+
+        val validationErrors = schemaValidator.validate(ksonContent, getFilePath())
+        if (validationErrors.isEmpty()) {
+            echo("✓ Document is valid according to the schema")
+        } else {
+            echo("Validation errors:", err = true)
+            validationErrors.forEach { error ->
+                echo("  ${errorFormat(error)}", err = true)
+            }
+            throw ProgramResult(1)
         }
     }
 }

--- a/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/ValidateCommand.kt
+++ b/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/ValidateCommand.kt
@@ -30,8 +30,8 @@ class ValidateCommand : BaseKsonCommand() {
         |${"\u0085"}  $CLI_NAME validate -i file.$FILE_EXTENSION -s schema.$FILE_EXTENSION
         |
         |Exit codes:
-        |${"\u0085"}  0 - No errors found
-        |${"\u0085"}  1 - Errors detected (warnings don't affect exit code)
+        |${"\u0085"}  0 - No errors or warnings found
+        |${"\u0085"}  1 - Errors or warnings found
     """.trimMargin()
 
     private val showTokens by option("--show-tokens", help = "Display lexical tokens (for debugging)")

--- a/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/ValidateCommand.kt
+++ b/tooling/cli/src/main/kotlin/org/kson/tooling/cli/commands/ValidateCommand.kt
@@ -53,11 +53,7 @@ class ValidateCommand : BaseKsonCommand() {
             throw ProgramResult(1)
         }
 
-        // Validate against schema if provided
-        validateWithSchema(ksonContent)
-
-        // Perform analysis
-        val analysis = Kson.analyze(ksonContent, getFilePath())
+        val analysis = Kson.analyze(ksonContent, getFilePath(), schemaValidator())
         var outputString = ""
         if (analysis.errors.isEmpty()) {
             outputString += "✓ No errors or warnings found"

--- a/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
+++ b/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
@@ -73,6 +73,13 @@ class CommandLineInterfaceTest {
             }
             is OutputExpectation.Success -> {
                 assertEquals(expectedOutput.message, outputFile.readText())
+                /**
+                 * On success, a command's output to `-o`/[outputFile] must be identical to what it would pipe to
+                 * another command on stdout in the non-`-o` case. Which is to say: on success of a `-o` call,
+                 * which all these tests use to put their output in [outputFile], we must have no extraneous output
+                 * direct to stdout
+                 */
+                assertEquals("", result.stdout, "a successful command must not say anything extra on stdout")
             }
             is OutputExpectation.FailureMentioning -> {
                 assertEquals(1, result.statusCode, "expected a failing command, stderr was: ${result.stderr}")

--- a/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
+++ b/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
@@ -10,6 +10,7 @@ import org.kson.tooling.cli.generated.CLI_NAME
 import org.kson.tooling.cli.generated.KSON_VERSION
 import java.io.File
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 enum class SubCommands{
     JSON,
@@ -21,6 +22,12 @@ enum class SubCommands{
 sealed class OutputExpectation {
     data class Success(val message: String) : OutputExpectation()
     data class Failure(val message: String) : OutputExpectation()
+
+    /**
+     * A failure identified by what its report mentions rather than by its full text, for reports whose
+     * wording belongs to the messages being relayed rather than to this command line.
+     */
+    data class FailureMentioning(val fragments: List<String>) : OutputExpectation()
 }
 
 class CommandLineInterfaceTest {
@@ -29,11 +36,19 @@ class CommandLineInterfaceTest {
         subCommand: SubCommands,
         input: String,
         expectedOutput: OutputExpectation,
-        vararg args: String
+        vararg args: String,
+        schema: String? = null
     ) {
         val inputFile = File.createTempFile("input", ".kson")
         inputFile.deleteOnExit()
         inputFile.writeText(input)
+
+        val schemaArgs = schema?.let {
+            val schemaFile = File.createTempFile("schema", ".kson")
+            schemaFile.deleteOnExit()
+            schemaFile.writeText(it)
+            listOf("-s", schemaFile.absolutePath)
+        } ?: emptyList()
 
         val outputFile = File.createTempFile("output", ".txt")
         outputFile.deleteOnExit()
@@ -41,7 +56,7 @@ class CommandLineInterfaceTest {
         val commandArgs = listOf(
             "-i", inputFile.absolutePath,
             "-o", outputFile.absolutePath
-        ) + args
+        ) + schemaArgs + args
 
         val mainCommand = when(subCommand) {
             SubCommands.JSON -> JsonCommand()
@@ -58,6 +73,15 @@ class CommandLineInterfaceTest {
             }
             is OutputExpectation.Success -> {
                 assertEquals(expectedOutput.message, outputFile.readText())
+            }
+            is OutputExpectation.FailureMentioning -> {
+                assertEquals(1, result.statusCode, "expected a failing command, stderr was: ${result.stderr}")
+                expectedOutput.fragments.forEach {
+                    assertTrue(
+                        result.stderr.contains(it),
+                        "expected the report to mention \"$it\", stderr was: ${result.stderr}"
+                    )
+                }
             }
         }
 
@@ -608,5 +632,77 @@ class CommandLineInterfaceTest {
                 "Version output for '$flag' should contain version number, but was: ${result.output}"
             }
         }
+    }
+
+    private val requiresAgeSchema = """
+        {
+          type: object
+          properties: { name: { type: string } }
+          required: ["age"]
+        }
+    """.trimIndent()
+
+    @Test
+    fun testValidateWithSchemaAcceptsAConformingDocument() {
+        assertCommand(
+            subCommand = SubCommands.VALIDATE,
+            input = """{ name: "Alice", age: 30 }""",
+            expectedOutput = OutputExpectation.Success("\u2713 No errors or warnings found"),
+            schema = requiresAgeSchema
+        )
+    }
+
+    @Test
+    fun testValidateWithSchemaFailsOnASchemaViolation() {
+        assertCommand(
+            subCommand = SubCommands.VALIDATE,
+            input = """{ name: "Alice" }""",
+            expectedOutput = OutputExpectation.FailureMentioning(listOf("age")),
+            schema = requiresAgeSchema
+        )
+    }
+
+    @Test
+    fun testJsonWithSchemaFailsOnASchemaViolation() {
+        assertCommand(
+            subCommand = SubCommands.JSON,
+            input = """{ name: "Alice" }""",
+            expectedOutput = OutputExpectation.FailureMentioning(listOf("age")),
+            schema = requiresAgeSchema
+        )
+    }
+
+    /**
+     * Transpiling tolerates a document's own warnings, and asking to be held to a schema does not change
+     * that: this document has a duplicate key but breaks no schema rule, so the transpilation succeeds.
+     */
+    @Test
+    fun testJsonWithSchemaTranspilesADocumentCarryingItsOwnWarnings() {
+        assertCommand(
+            subCommand = SubCommands.JSON,
+            input = """{ name: "Alice", name: "Bob" }""",
+            expectedOutput = OutputExpectation.Success("""
+                {
+                  "name": "Alice",
+                  "name": "Bob"
+                }
+            """.trimIndent()),
+            schema = """
+                {
+                  type: object
+                  properties: { name: { type: string } }
+                }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testSchemaThatCannotBeUsedStopsTheCommand() {
+        assertCommand(
+            subCommand = SubCommands.JSON,
+            input = """{ name: "Alice" }""",
+            expectedOutput = OutputExpectation.FailureMentioning(listOf("Failed to parse schema")),
+            schema = "{ type: object"
+        )
     }
 }

--- a/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
+++ b/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
@@ -662,6 +662,21 @@ class CommandLineInterfaceTest {
         )
     }
 
+    /**
+     * Regression test for a bug where validate would swallow a document's warnings if it was also asked to validate
+     * against a schema. Validate's whole job is to validate, so it should always report everything (including
+     * warnings) that it finds.
+     */
+    @Test
+    fun testValidateWithSchemaAlsoReportsTheDocumentsOwnWarnings() {
+        assertCommand(
+            subCommand = SubCommands.VALIDATE,
+            input = """{ name: "Alice", name: "Bob" }""",
+            expectedOutput = OutputExpectation.FailureMentioning(listOf("Duplicate key", "age")),
+            schema = requiresAgeSchema
+        )
+    }
+
     @Test
     fun testJsonWithSchemaFailsOnASchemaViolation() {
         assertCommand(

--- a/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
+++ b/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
@@ -53,11 +53,11 @@ class CommandLineInterfaceTest {
 
         when(expectedOutput){
             is OutputExpectation.Failure -> {
-                assertEquals(result.statusCode, 1)
-                assertEquals(result.stderr, expectedOutput.message)
+                assertEquals(1, result.statusCode)
+                assertEquals(expectedOutput.message, result.stderr)
             }
             is OutputExpectation.Success -> {
-                assertEquals(outputFile.readText(), expectedOutput.message)
+                assertEquals(expectedOutput.message, outputFile.readText())
             }
         }
 

--- a/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
+++ b/tooling/cli/src/test/kotlin/org/kson/tooling/cli/CommandLineInterfaceTest.kt
@@ -406,6 +406,20 @@ class CommandLineInterfaceTest {
         )
     }
 
+    /**
+     * Our stance on `validate` is that it's strict: the user asked us to validate, and any issues, including
+     * warnings, result in exit(1)
+     */
+    @Test
+    fun testValidateCommandFailsOnAWarningOnlyDocument() {
+        assertCommand(
+            SubCommands.VALIDATE,
+            input = """{ name: "Alice", name: "Bob" }""",
+            expectedOutput = OutputExpectation.Failure(
+                """[WARNING] Duplicate key "name" in object at 0:17""" + "\n"
+            )
+        )
+    }
 
     @Test
     fun testTranspileToJsonWithEmptyObject() {

--- a/tooling/language-server-protocol/src/core/schema/FileSystemSchemaProvider.ts
+++ b/tooling/language-server-protocol/src/core/schema/FileSystemSchemaProvider.ts
@@ -10,7 +10,7 @@ import { minimatch } from 'minimatch';
 
 /**
  * Node.js-specific schema provider that reads from the file system.
- * This provider loads .kson-schema.json from the workspace root and resolves schemas for documents.
+ * This provider loads .kson-schema.kson from the workspace root and resolves schemas for documents.
  */
 export class FileSystemSchemaProvider implements SchemaProvider {
     private config: SchemaConfig | null = null;
@@ -36,7 +36,7 @@ export class FileSystemSchemaProvider implements SchemaProvider {
 
     /**
      * Reload the schema configuration from disk.
-     * Should be called when .kson-schema.json changes.
+     * Should be called when .kson-schema.kson changes.
      */
     reload(): void {
         this.loadConfiguration();
@@ -152,10 +152,9 @@ export class FileSystemSchemaProvider implements SchemaProvider {
 
     /**
      * Load a schema file from a workspace-relative path.
-     * If the schema file is in KSON format (.kson), it will be converted to JSON.
      *
      * @param schemaPath Workspace-relative path to the schema file
-     * @returns TextDocument containing the schema in JSON format, or undefined if file not found
+     * @returns TextDocument containing the schema, or undefined if file not found
      */
     private loadSchemaFile(schemaPath: string): TextDocument | undefined {
         if (!this.workspaceRoot) {
@@ -171,15 +170,6 @@ export class FileSystemSchemaProvider implements SchemaProvider {
 
         try {
             const schemaContent = fs.readFileSync(absolutePath, 'utf-8');
-
-            // Check whether the schema is a valid KSON file
-            let ksonSchema = Kson.getInstance().analyze(schemaContent)
-            let schemaErrors = ksonSchema.errors.asJsReadonlyArrayView()
-            if (schemaErrors.length != 0) {
-                this.logger?.error(`Failed to convert KSON schema to JSON: ${schemaErrors.join(', ')}`);
-                return undefined;
-            }
-
             const schemaUri = URI.file(absolutePath).toString();
             return TextDocument.create(schemaUri, 'kson', 1, schemaContent);
         } catch (error) {

--- a/tooling/language-server-protocol/src/core/schema/SchemaConfig.ts
+++ b/tooling/language-server-protocol/src/core/schema/SchemaConfig.ts
@@ -20,7 +20,7 @@ export interface SchemaMapping {
 }
 
 /**
- * The root configuration object for .kson-schema.json
+ * The root configuration object for .kson-schema.kson
  */
 export interface SchemaConfig {
     /**

--- a/tooling/language-server-protocol/src/core/schema/SchemaProvider.ts
+++ b/tooling/language-server-protocol/src/core/schema/SchemaProvider.ts
@@ -10,7 +10,7 @@ export interface SchemaProvider {
      * Get the schema document for a given KSON document URI.
      *
      * @param documentUri The URI of the KSON document
-     * @returns TextDocument containing the schema, or undefined if no schema is available
+     * @returns TextDocument containing the schema, or undefined if this provider has none for it
      */
     getSchemaForDocument(documentUri: DocumentUri): TextDocument | undefined;
 

--- a/tooling/language-server-protocol/src/test/TestHelpers.ts
+++ b/tooling/language-server-protocol/src/test/TestHelpers.ts
@@ -1,5 +1,6 @@
 import {TextDocument} from 'vscode-languageserver-textdocument';
-import {Position} from 'vscode-languageserver';
+import {DocumentUri, Position} from 'vscode-languageserver';
+import {SchemaProvider} from '../core/schema/SchemaProvider.js';
 import {KsonDocument, parseTextDocument} from '../core/document/KsonDocument.js';
 import {KsonSchemaDocument} from '../core/document/KsonSchemaDocument.js';
 
@@ -35,4 +36,33 @@ export function createKsonSchemaDocument(content: string, metaSchemaContent?: st
  */
 export function pos(line: number, character: number): Position {
     return {line, character};
+}
+
+/**
+ * Stub {@link SchemaProvider} whose document-to-schema mappings are registered directly, for tests that
+ * want a provider's answers without the disk a real one needs.
+ */
+export class SchemaProviderTestStub implements SchemaProvider {
+    private schemas: Map<string, TextDocument> = new Map();
+
+    addSchema(documentUri: DocumentUri, schema: TextDocument): void {
+        this.schemas.set(documentUri, schema);
+    }
+
+    getSchemaForDocument(documentUri: DocumentUri): TextDocument | undefined {
+        return this.schemas.get(documentUri);
+    }
+
+    getMetaSchemaForId(_schemaId: string): TextDocument | undefined {
+        return undefined;
+    }
+
+    reload(): void {}
+
+    isSchemaFile(fileUri: DocumentUri): boolean {
+        for (const schema of this.schemas.values()) {
+            if (schema.uri === fileUri) return true;
+        }
+        return false;
+    }
 }

--- a/tooling/language-server-protocol/src/test/core/document/KsonDocumentsManager.test.ts
+++ b/tooling/language-server-protocol/src/test/core/document/KsonDocumentsManager.test.ts
@@ -1,0 +1,58 @@
+import {describe, it} from 'mocha';
+import * as assert from 'assert';
+import {DidOpenTextDocumentParams} from 'vscode-languageserver';
+import {TextDocument} from 'vscode-languageserver-textdocument';
+import {ConnectionStub} from '../../ConnectionStub.js';
+import {KsonDocumentsManager} from '../../../core/document/KsonDocumentsManager.js';
+import {KsonDocument} from '../../../core/document/KsonDocument.js';
+import {SchemaProviderTestStub} from '../../TestHelpers.js';
+
+/**
+ * Covers what {@link KsonDocumentsManager} decides when a document is opened, for instance which schema,
+ * if any, the resulting {@link KsonDocument} carries.
+ */
+describe('KsonDocumentsManager', () => {
+
+    const DOCUMENT_URI = 'file:///workspace/document.kson';
+    const WORKSPACE_SCHEMA_URI = 'file:///workspace/schema.kson';
+
+    /**
+     * Open `document.kson` against a provider offering it the given schema, if any, and return the
+     * {@link KsonDocument} the manager built.
+     */
+    function openDocument(documentContent: string, schema?: TextDocument): KsonDocument {
+        const schemaProvider = new SchemaProviderTestStub();
+        if (schema) {
+            schemaProvider.addSchema(DOCUMENT_URI, schema);
+        }
+
+        const documentsManager = new KsonDocumentsManager(schemaProvider);
+        const connection = new ConnectionStub();
+        documentsManager.listen(connection);
+
+        const params: DidOpenTextDocumentParams = {
+            textDocument: {uri: DOCUMENT_URI, languageId: 'kson', version: 1, text: documentContent}
+        };
+        connection.didOpenHandler(params);
+
+        const ksonDocument = documentsManager.get(DOCUMENT_URI);
+        assert.ok(ksonDocument, 'the opened document should be tracked by the manager');
+        return ksonDocument;
+    }
+
+    describe('schema attachment', () => {
+        it('should attach the schema its provider offers', () => {
+            const schema = TextDocument.create(WORKSPACE_SCHEMA_URI, 'kson', 1, '{ type: object }');
+
+            const document = openDocument('{ name: "Alice" }', schema);
+
+            assert.strictEqual(document.getSchemaDocument(), schema);
+        });
+
+        it('should attach no schema when its provider offers none', () => {
+            const document = openDocument('{ name: "Alice" }');
+
+            assert.strictEqual(document.getSchemaDocument(), undefined);
+        });
+    });
+});

--- a/tooling/language-server-protocol/src/test/core/features/DiagnosticService.test.ts
+++ b/tooling/language-server-protocol/src/test/core/features/DiagnosticService.test.ts
@@ -140,12 +140,17 @@ describe('KSON Diagnostics', () => {
             }
         });
 
-        it('should return no errors for valid document when schema fails to parse', () => {
+        it('should report the unusable schema for a valid document', () => {
             const invalidSchema = '{ broken schema {{{{';
             const diagnostics = getDiagnostics('key: "value"', invalidSchema);
-            // Valid document + broken schema: should get 0 diagnostics since
-            // document is valid and schema parse failure returns no schema messages
-            assert.strictEqual(diagnostics.length, 0);
+            // The document is valid, but it was never validated against the schema: saying nothing
+            // here would report the document as fully checked
+            assert.strictEqual(diagnostics.length, 1);
+            assert.strictEqual(diagnostics[0].severity, DiagnosticSeverity.Warning);
+            assert.deepStrictEqual(diagnostics[0].range, {
+                start: {line: 0, character: 0},
+                end: {line: 0, character: 0}
+            });
         });
     });
 

--- a/tooling/language-server-protocol/src/test/core/schema/CompositeSchemaProvider.test.ts
+++ b/tooling/language-server-protocol/src/test/core/schema/CompositeSchemaProvider.test.ts
@@ -1,40 +1,10 @@
 import {describe, it} from 'mocha';
 import * as assert from 'assert';
 import {TextDocument} from 'vscode-languageserver-textdocument';
-import {DocumentUri} from 'vscode-languageserver';
 import {CompositeSchemaProvider} from '../../../core/schema/CompositeSchemaProvider';
 import {BundledSchemaProvider, BundledMetaSchemaConfig} from '../../../core/schema/BundledSchemaProvider';
 import {SchemaProvider, NoOpSchemaProvider} from '../../../core/schema/SchemaProvider';
-
-/**
- * Minimal mock that simulates FileSystemSchemaProvider behavior (URI-based lookup).
- * Only used because FileSystemSchemaProvider requires disk I/O.
- */
-class UriSchemaProvider implements SchemaProvider {
-    private schemas: Map<string, TextDocument> = new Map();
-
-    addSchema(documentUri: string, schema: TextDocument): void {
-        this.schemas.set(documentUri, schema);
-    }
-
-    getSchemaForDocument(documentUri: DocumentUri): TextDocument | undefined {
-        return this.schemas.get(documentUri);
-    }
-
-    getMetaSchemaForId(_schemaId: string): TextDocument | undefined {
-        return undefined;
-    }
-
-    reload(): void {}
-
-    isSchemaFile(fileUri: DocumentUri): boolean {
-        for (const schema of this.schemas.values()) {
-            if (schema.uri === fileUri) return true;
-        }
-        return false;
-    }
-
-}
+import {SchemaProviderTestStub} from '../../TestHelpers.js';
 
 describe('CompositeSchemaProvider', () => {
     let logs: string[] = [];
@@ -82,16 +52,16 @@ describe('CompositeSchemaProvider', () => {
         });
 
         it('should return schema from first matching provider', () => {
-            const uriProvider1 = new UriSchemaProvider();
-            const uriProvider2 = new UriSchemaProvider();
+            const firstProvider = new SchemaProviderTestStub();
+            const secondProvider = new SchemaProviderTestStub();
 
             const schema1 = TextDocument.create('file:///schema1.kson', 'kson', 1, '{ "from": "first" }');
-            uriProvider1.addSchema('file:///test.kson', schema1);
+            firstProvider.addSchema('file:///test.kson', schema1);
 
             const schema2 = TextDocument.create('file:///schema2.kson', 'kson', 1, '{ "from": "second" }');
-            uriProvider2.addSchema('file:///test.kson', schema2);
+            secondProvider.addSchema('file:///test.kson', schema2);
 
-            const provider = new CompositeSchemaProvider([uriProvider1, uriProvider2], logger);
+            const provider = new CompositeSchemaProvider([firstProvider, secondProvider], logger);
             const result = provider.getSchemaForDocument('file:///test.kson');
 
             assert.ok(result);
@@ -99,14 +69,14 @@ describe('CompositeSchemaProvider', () => {
         });
 
         it('should try next provider when first returns undefined', () => {
-            const uriProvider1 = new UriSchemaProvider();
-            const uriProvider2 = new UriSchemaProvider();
+            const firstProvider = new SchemaProviderTestStub();
+            const secondProvider = new SchemaProviderTestStub();
 
-            // uriProvider1 has no schema for test.kson
+            // firstProvider has no schema for test.kson
             const schema2 = TextDocument.create('file:///schema2.kson', 'kson', 1, '{ "from": "second" }');
-            uriProvider2.addSchema('file:///test.kson', schema2);
+            secondProvider.addSchema('file:///test.kson', schema2);
 
-            const provider = new CompositeSchemaProvider([uriProvider1, uriProvider2], logger);
+            const provider = new CompositeSchemaProvider([firstProvider, secondProvider], logger);
             const result = provider.getSchemaForDocument('file:///test.kson');
 
             assert.ok(result);
@@ -129,7 +99,7 @@ describe('CompositeSchemaProvider', () => {
 
         it('should prioritize file system provider over bundled (typical usage)', () => {
             // File system provider (has schema by URI) - higher priority
-            const fileSystemProvider = new UriSchemaProvider();
+            const fileSystemProvider = new SchemaProviderTestStub();
             const fsSchema = TextDocument.create('file:///workspace/schema.kson', 'kson', 1, '{ "from": "filesystem" }');
             fileSystemProvider.addSchema('file:///test.kxt', fsSchema);
 
@@ -148,7 +118,7 @@ describe('CompositeSchemaProvider', () => {
 
         it('should fall back to bundled when file system has no schema', () => {
             // File system provider with no schema
-            const fileSystemProvider = new UriSchemaProvider();
+            const fileSystemProvider = new SchemaProviderTestStub();
 
             // Bundled provider has schema
             const bundledProvider = new BundledSchemaProvider({
@@ -214,14 +184,14 @@ describe('CompositeSchemaProvider', () => {
             assert.strictEqual(result, undefined);
         });
 
-        it('should work with UriSchemaProvider (returns undefined)', () => {
-            const uriProvider = new UriSchemaProvider();
+        it('should skip a provider with no metaschemas', () => {
+            const noMetaSchemaProvider = new SchemaProviderTestStub();
             const metaSchemas: BundledMetaSchemaConfig[] = [
                 { schemaId: 'http://json-schema.org/draft-07/schema#', name: 'draft-07', schemaContent: '{ "metaschema": true }' }
             ];
             const bundledProvider = new BundledSchemaProvider({ schemas: [], metaSchemas, logger });
 
-            const composite = new CompositeSchemaProvider([uriProvider, bundledProvider], logger);
+            const composite = new CompositeSchemaProvider([noMetaSchemaProvider, bundledProvider], logger);
             const result = composite.getMetaSchemaForId('http://json-schema.org/draft-07/schema#');
 
             assert.ok(result);
@@ -236,13 +206,13 @@ describe('CompositeSchemaProvider', () => {
         });
 
         it('should return true when any provider considers it a schema file', () => {
-            const uriProvider = new UriSchemaProvider();
+            const noSchemaProvider = new SchemaProviderTestStub();
             const bundledProvider = new BundledSchemaProvider({
                 schemas: [{ fileExtension: 'kxt', schemaContent: '{}' }],
                 logger
             });
 
-            const provider = new CompositeSchemaProvider([uriProvider, bundledProvider], logger);
+            const provider = new CompositeSchemaProvider([noSchemaProvider, bundledProvider], logger);
             assert.strictEqual(provider.isSchemaFile('bundled://schema/kxt.schema.kson'), true);
         });
 
@@ -262,15 +232,15 @@ describe('CompositeSchemaProvider', () => {
         });
 
         it('should check all provider types', () => {
-            const uriProvider = new UriSchemaProvider();
-            uriProvider.addSchema('file:///test.kson', TextDocument.create('file:///my-schema.kson', 'kson', 1, '{}'));
+            const stubProvider = new SchemaProviderTestStub();
+            stubProvider.addSchema('file:///test.kson', TextDocument.create('file:///my-schema.kson', 'kson', 1, '{}'));
 
             const bundledProvider = new BundledSchemaProvider({
                 schemas: [{ fileExtension: 'kxt', schemaContent: '{}' }],
                 logger
             });
 
-            const provider = new CompositeSchemaProvider([uriProvider, bundledProvider], logger);
+            const provider = new CompositeSchemaProvider([stubProvider, bundledProvider], logger);
 
             assert.strictEqual(provider.isSchemaFile('file:///my-schema.kson'), true);
             assert.strictEqual(provider.isSchemaFile('bundled://schema/kxt.schema.kson'), true);

--- a/tooling/language-server-protocol/src/test/core/schema/FileSystemSchemaProvider.test.ts
+++ b/tooling/language-server-protocol/src/test/core/schema/FileSystemSchemaProvider.test.ts
@@ -135,6 +135,28 @@ describe('FileSystemSchemaProvider', () => {
             assert.ok(logs.some(msg => msg.includes('Schema file not found')));
         });
 
+        /**
+         * Regression test for a bug where we would silently drop broken schemas, leaving the editor communicating
+         * to the user that everything is fine rather than letting them know the schema they asked to validate
+         * against is _impossible_ to validate against.
+         */
+        it('should return a schema that does not parse', () => {
+            const workspace = createWorkspace();
+            // multiple unclosed objects defined gives broken KSON
+            const brokenSchema = '{ type: object properties: {{{';
+
+            writeConfig(workspace, {
+                schemas: [{fileMatch: ['*.kson'], schema: 'schemas/broken.kson'}]
+            });
+            writeSchema(workspace, 'schemas/broken.kson', brokenSchema);
+
+            const provider = new FileSystemSchemaProvider(workspace, logger);
+            const schema = provider.getSchemaForDocument(path.join(workspace.fsPath, 'test.kson'));
+
+            assert.ok(schema, 'a schema with a parse error must still be handed over');
+            assert.strictEqual(schema!.getText(), brokenSchema);
+        });
+
         it('should support glob patterns', () => {
             const workspace = createWorkspace();
             const schemaContent = JSON.stringify({type: 'object'});


### PR DESCRIPTION
Fix up a trio of gaps in how we serve parse requests with schema validation, plus some clean-ups adjacent to this work that either supported the fixes or came up naturally during this work. The bugs were all of the same flavor (incorrect or incomplete parse messages when a schema is provided), so I tackled them together here even though it makes this PR quite large. The individual commits should be read rather than reading this PR as a whole.

**NOTE:** bb3cbfbe is a breaking change to the public API, adding a parameter to the `analyze` endpoint.

## Fixes

- **3752f63c Stop reporting OK against broken schemas:** a schema that could not be used reported nothing at all, so a document looked fine
- **0f2de3f7 Do not silently swallow attached schemas in LSP:** the language server dropped a workspace schema it could not use rather than saying so
- **cea3326b Make schema validation part of "analyze":** stop silently dropping warnings when given a schema to validate against. **Breaking change:** adds an optional `SchemaValidator` parameter to the public `Kson.analyze` with it

## Clean-ups

- 36e99771: Clarify `ignoreErrors` parse contract
- e6a520b2: Fix assertEquals argument order in CLI tests
- 0806f34d: Stop applying LargeClass lint to tests
- b8942b70: Cover the CLI's `--schema` switch
- 3b3acbff: Use `null` for "no schema", not the trivial schema
- c25753f5: Don't pollute cli output with "schema success!"
- 826a825:  Fix inaccuracy in cli's validate help