### PR TITLE
Configure IntelliJ exclusions in Gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
+import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.gradle.tooling.GradleConnector
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
@@ -223,6 +224,41 @@ mavenPublishing {
 allprojects {
     plugins.withId("org.jetbrains.kotlin.multiplatform") { applyDetekt(project) }
     plugins.withId("org.jetbrains.kotlin.jvm") { applyDetekt(project) }
+    plugins.withId("idea") { keepGeneratedOutputOutOfTheIde(project) }
+}
+
+/**
+ * Tell IntelliJ which directories hold content that should be "excluded" (generated files, build files, etc.),
+ * so that search/navigation/inspections are scoped to the files developers actually work with.
+ * This is especially important for this project as it produces a myriad of non-Gradle-default build directories
+ * as part of its multi-platform and tooling builds.
+ *
+ * IntelliJ's Gradle import reads the exclusions that Gradle's `idea` plugin contributes to its project model,
+ * so this gives us a good in-source, version-controlled, project-level home for sharing this configuration
+ * with anyone who wishes to develop KSON.
+ *
+ * This is implemented to run outside the critical path of ordinary and CI builds: nothing here runs unless an IDE
+ * is building its project model.
+ */
+fun keepGeneratedOutputOutOfTheIde(project: Project) = with(project) {
+    /**
+     * IntelliJ only honours an exclusion on the module whose "content root" (the directory subtree a module
+     * owns) contains it, and it makes a module of every Gradle project.  So we note any nested modules (and the
+     * separate `buildSrc` project) here, so we can tell [GeneratedOutputDirectories] not to bother searching them.
+     */
+    val nestedContentRoots = subprojects.map { it.projectDir }.toSet() + rootProject.file("buildSrc")
+
+    the<IdeaModel>().module.excludeDirs.addAll(
+        GeneratedOutputDirectories(projectDir, nestedContentRoots).locate()
+    )
+
+    if (this == rootProject) {
+        /**
+         * The JDKs `jvmWrapper` installs are generated too, but sit at a path fixed by convention
+         *  rather than in a directory [GeneratedOutputDirectories] would recognize by name
+         */
+        the<IdeaModel>().module.excludeDirs.add(file("gradle/jdk"))
+    }
 }
 
 fun applyDetekt(project: Project) = with(project) {

--- a/buildSrc/src/main/kotlin/GeneratedOutputDirectories.kt
+++ b/buildSrc/src/main/kotlin/GeneratedOutputDirectories.kt
@@ -1,0 +1,85 @@
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * [GeneratedOutputDirectories] is used to [locate] the directories under [searchRoot] containing generated output
+ * rather than source: build output, installed dependencies, and tool-managed environments.
+ *
+ * These are found by directory name rather than a specific path so that conventional excludes may be found
+ * wherever they appear (i.e. `.pixi/` anywhere Pixi is used, `node_modules/` for every `package.json`),
+ * emulating how such directories are ignored in a `.gitignore`.
+ *
+ * Note that we don't dive into a generated output directory once it is found since the whole thing is
+ * generated. Directories listed in [doNotSearch] are totally skipped by our search.
+ */
+class GeneratedOutputDirectories(
+    private val searchRoot: File,
+    private val doNotSearch: Set<File> = emptySet()
+) {
+    /**
+     * The generated output directories beneath [searchRoot], ordered depth-first and alphabetically
+     * so that a given tree always yields the same list.
+     */
+    fun locate(): List<File> = mutableListOf<File>().also { collectInto(it, searchRoot) }
+
+    private fun collectInto(found: MutableList<File>, directory: File) {
+        val children = directory.listFiles() ?: return
+        for (child in children.sortedBy { it.name }) {
+            if (!child.isDirectory || child in doNotSearch) {
+                continue
+            }
+
+            // symlinks are not followed: a link may point outside [searchRoot] entirely, and
+            // reporting a directory that lives outside the tree we were asked about would attribute
+            // generated output to the wrong project (and a link cycle would never terminate)
+            if (Files.isSymbolicLink(child.toPath())) {
+                continue
+            }
+
+            if (child.name in GENERATED_DIRECTORY_NAMES) {
+                found.add(child)
+            } else {
+                collectInto(found, child)
+            }
+        }
+    }
+
+    /**
+     * The names of generated directories we exclude
+     */
+    companion object {
+        // Gradle
+        const val GRADLE_BUILD = "build"
+        const val GRADLE_CACHE = ".gradle"
+        const val KOTLIN_CACHE = ".kotlin"
+
+        // IntelliJ Platform Gradle Plugin, which caches the IDE distributions it builds against
+        const val INTELLIJ_PLATFORM_CACHE = ".intellijPlatform"
+
+        // Cargo
+        const val CARGO_TARGET = "target"
+
+        // npm, and the compiler and bundler output of our LSP clients
+        const val NODE_MODULES = "node_modules"
+        const val TYPESCRIPT_OUT = "out"
+        const val BUNDLER_DIST = "dist"
+
+        // Pixi, and the Python environment it manages
+        const val PIXI_ENVIRONMENTS = ".pixi"
+        const val PYTHON_VIRTUALENV = ".venv"
+
+        // the VS Code installs `vscode-test` downloads to run the extension's tests against
+        const val VSCODE_TEST = ".vscode-test"
+        const val VSCODE_TEST_WEB = ".vscode-test-web"
+
+        /** Every directory name above: the whole of what [locate] treats as generated output */
+        val GENERATED_DIRECTORY_NAMES = setOf(
+            GRADLE_BUILD, GRADLE_CACHE, KOTLIN_CACHE,
+            INTELLIJ_PLATFORM_CACHE,
+            CARGO_TARGET,
+            NODE_MODULES, TYPESCRIPT_OUT, BUNDLER_DIST,
+            PIXI_ENVIRONMENTS, PYTHON_VIRTUALENV,
+            VSCODE_TEST, VSCODE_TEST_WEB
+        )
+    }
+}

--- a/buildSrc/src/test/kotlin/GeneratedOutputDirectoriesTest.kt
+++ b/buildSrc/src/test/kotlin/GeneratedOutputDirectoriesTest.kt
@@ -1,0 +1,152 @@
+import GeneratedOutputDirectories.Companion.CARGO_TARGET
+import GeneratedOutputDirectories.Companion.GENERATED_DIRECTORY_NAMES
+import GeneratedOutputDirectories.Companion.GRADLE_BUILD
+import GeneratedOutputDirectories.Companion.NODE_MODULES
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
+import org.gradle.internal.os.OperatingSystem
+import org.junit.Assume.assumeFalse
+import org.junit.Assume.assumeTrue
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Files.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GeneratedOutputDirectoriesTest {
+
+    /**
+     * Create each of [relativeDirectories] under a fresh temp directory, and return that directory
+     */
+    private fun treeOf(vararg relativeDirectories: String): File {
+        val root = createTempDirectory("GeneratedOutputDirectoriesTest").toFile()
+        relativeDirectories.forEach { File(root, it).mkdirs() }
+        return root
+    }
+
+    /**
+     * What [GeneratedOutputDirectories] finds under [root], as paths relative to it
+     */
+    private fun locateUnder(root: File, doNotSearch: Set<File> = emptySet()): List<String> =
+        GeneratedOutputDirectories(root, doNotSearch).locate()
+            .map { it.relativeTo(root).invariantSeparatorsPath }
+
+    /**
+     * Every path in [repository]'s index, relative to the repo root and `/`-separated
+     */
+    private fun trackedPathsIn(repository: Repository): List<String> {
+        val index = repository.readDirCache()
+        return (0 until index.entryCount).map { index.getEntry(it).pathString }
+    }
+
+    /**
+     * The git checkout this test class was compiled into, or `null` if it was not compiled inside one
+     */
+    private fun enclosingCheckout(): Repository? {
+        val compiledInto = File(javaClass.protectionDomain.codeSource.location.toURI())
+        val builder = FileRepositoryBuilder().findGitDir(compiledInto)
+        return if (builder.gitDir == null) null else builder.build()
+    }
+
+    @Test
+    fun everyGeneratedDirectoryNameIsRecognized() {
+        val root = treeOf(*GENERATED_DIRECTORY_NAMES.toTypedArray())
+
+        assertEquals(
+            GENERATED_DIRECTORY_NAMES.sorted(),
+            locateUnder(root),
+            "Every name we publish as generated output should be reported when found"
+        )
+    }
+
+    @Test
+    fun generatedOutputIsFoundAtAnyDepth() {
+        val root = treeOf(GRADLE_BUILD, "crates/parser/$CARGO_TARGET", "clients/web/$NODE_MODULES")
+
+        assertEquals(
+            listOf(GRADLE_BUILD, "clients/web/$NODE_MODULES", "crates/parser/$CARGO_TARGET"),
+            locateUnder(root)
+        )
+    }
+
+    @Test
+    fun generatedOutputIsNotSearchedForMoreGeneratedOutput() {
+        val root = treeOf("crates/parser/$CARGO_TARGET/debug/$GRADLE_BUILD", "crates/parser/$CARGO_TARGET/debug/deps")
+
+        assertEquals(
+            listOf("crates/parser/$CARGO_TARGET"),
+            locateUnder(root),
+            "Should report the outermost generated directory and stop, not walk what is inside it"
+        )
+    }
+
+    @Test
+    fun generatedOutputWeAreToldNotToSearchIsLeftToItsOwner() {
+        val root = treeOf(GRADLE_BUILD, "nested/$GRADLE_BUILD", "nested/deeper/$CARGO_TARGET")
+
+        assertEquals(
+            listOf(GRADLE_BUILD),
+            locateUnder(root, doNotSearch = setOf(File(root, "nested"))),
+            "Everything under `nested` belongs to whoever searches from `nested`"
+        )
+    }
+
+    @Test
+    fun authoredDirectoriesAreLeftAlone() {
+        val root = treeOf("src/commonMain/kotlin", "docs", "assets/images")
+
+        assertEquals(emptyList(), locateUnder(root))
+    }
+
+    @Test
+    fun filesNamedLikeGeneratedDirectoriesAreNotReported() {
+        val root = treeOf("src")
+        File(root, GRADLE_BUILD).writeText("a file, not a directory")
+
+        assertEquals(emptyList(), locateUnder(root))
+    }
+
+    @Test
+    fun symlinkedGeneratedOutputIsLeftToTheTreeThatOwnsIt() {
+        assumeFalse("creating symlinks needs elevated privileges on Windows", OperatingSystem.current().isWindows)
+        val elsewhere = treeOf(CARGO_TARGET)
+        val root = treeOf("src")
+        Files.createSymbolicLink(File(root, "linked").toPath(), elsewhere.toPath())
+
+        assertEquals(
+            emptyList(),
+            locateUnder(root),
+            "Following the link would report a directory outside the tree we were asked about"
+        )
+    }
+
+    /**
+     * Guards the assumption the whole design rests on: that [GENERATED_DIRECTORY_NAMES] only ever
+     * names generated output. We do this by consulting Git's index: if a file we think is generated
+     * is ever reported by git as tracked, we want to raise that as an issue.
+     */
+    @Test
+    fun trackedContentIsNeverTreatedAsGeneratedOutput() {
+        val checkout = enclosingCheckout()
+        assumeTrue("reading the git index needs a git checkout to read it from", checkout != null)
+
+        checkout!!.use { repository ->
+            val trackedPaths = trackedPathsIn(repository)
+
+            val locatedHoldingTrackedFiles =
+                GeneratedOutputDirectories(repository.workTree).locate().mapNotNull { directory ->
+                    val relativePath = directory.relativeTo(repository.workTree).invariantSeparatorsPath
+                    trackedPaths.firstOrNull { it.startsWith("$relativePath/") }
+                        ?.let { "$relativePath (tracks $it)" }
+                }
+
+            assertEquals(
+                emptyList(),
+                locatedHoldingTrackedFiles,
+                "These directories are named like generated output but hold files tracked in git. " +
+                    "Either the content belongs somewhere else, or the name should leave " +
+                    GeneratedOutputDirectories.Companion::GENERATED_DIRECTORY_NAMES.name
+            )
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ We welcome you to dive in this project to explore, experiment, or contribute. A 
   * Open the root [`build.gradle.kts`](build.gradle.kts) file directly and select "Open as Project" when prompted
   * In Settings, under `Build, Execution, Deployment -> Build Tools -> Gradle`, for `Gradle JVM`:
     * choose "Add JDK..." and select the `Contents/Home` folder of the JDK under `gradle/jdk` (this JDK is installed the first time you run `./gradlew check` from the command line)
+  * Note that no manual configuration should be needed to exclude our generated directories (build output, `node_modules`, Cargo `target/`, etc.) from the IDE's index: they are wired into [the Gradle build](build.gradle.kts) from [GeneratedOutputDirectories](buildSrc/src/main/kotlin/GeneratedOutputDirectories.kt) and IntelliJ applies them automatically
 
 #### Project structure
 


### PR DESCRIPTION
This project produces a myriad of non-Gradle-default build/generated directories as part of its multi-platform and tooling builds. Some of these have many, many files which can unnecessarily bog down performance and pollute search results.

Use Gradle's `idea` plugin to manage these Intellij exclusions as part of our build so we have a good in-source, version-controlled, project-level home for sharing this configuration with anyone who wishes to develop KSON.