### PR TITLE
Update release docs with `-Prelease=true`

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -86,8 +86,10 @@ signing.secretKeyRingFile=<path-to-secring.gpg>
 
 2. Publish to Maven Central:
    ```bash
-   ./gradlew publishAllPublicationsToMavenCentralRepository
+   ./gradlew publishAllPublicationsToMavenCentralRepository -Prelease=true
    ```
+
+   Note that without `-Prelease=true` both artifacts will be have snapshot coordinates (`X.Y.Z-{gitSha}-SNAPSHOT`) instead of the release version.
 
 3. Verify the publications are valid and ready to be published: https://central.sonatype.com/publishing/deployments
 


### PR DESCRIPTION
Our maven publish requires a `-Prelease=true` flag since 17b70cbb4f. Update the documentation to reflect that.