### PR TITLE
 Build and CI maintenance

### DIFF
--- a/.circleci/config.kson
+++ b/.circleci/config.kson
@@ -428,8 +428,9 @@ jobs:
     .
   'test-python-sdist-macos':
     macos:
-      xcode: '14.2.0'
+      xcode: '16.4.0'
       .
+    resource_class: 'm4pro.medium'
     working_directory: '~/repo'
     steps:
       - 'setup-python-test':

--- a/.circleci/config.kson
+++ b/.circleci/config.kson
@@ -376,6 +376,7 @@ jobs:
     docker:
       - image: 'cimg/python:3.11'
         .
+    resource_class: large
     working_directory: '~/repo'
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,8 @@ jobs:
 
   "test-python-sdist-macos":
     macos:
-      xcode: "14.2.0"
+      xcode: "16.4.0"
+    resource_class: "m4pro.medium"
     working_directory: "~/repo"
     steps:
       - "setup-python-test":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,6 +336,7 @@ jobs:
   "build-python-sdist":
     docker:
       - image: "cimg/python:3.11"
+    resource_class: large
     working_directory: "~/repo"
     steps:
       - checkout

--- a/buildSrc/src/main/kotlin/org/kson/jsonsuite/JsonTestSuiteGenerator.kt
+++ b/buildSrc/src/main/kotlin/org/kson/jsonsuite/JsonTestSuiteGenerator.kt
@@ -349,8 +349,10 @@ private class JsonTestDataLoader(private val testDefinitionFilesDir: Path, priva
         return testFiles.map {
             JsonTestData(
                 it.nameWithoutExtension,
-                // explicitly note UTF-8 here since the JSON spec specifies that as the proper json encoding
-                it.readText(Charsets.UTF_8),
+                // explicitly note UTF-8 here since the JSON spec specifies that as the proper json encoding.
+                // Normalize CRLF: the checkout test suite has no `.gitattributes`, so `core.autocrlf` on Windows
+                // would otherwise leak CRLFs into the generated file
+                it.readText(Charsets.UTF_8).replace("\r\n", "\n"),
                 it.absolutePath.replace(File.separatorChar, '/').replace("${projectRoot.toString().replace(File.separatorChar, '/')}/", ""),
                 JsonTestSuiteEditList.get(it.name)
             )

--- a/kson-lib/build.gradle.kts
+++ b/kson-lib/build.gradle.kts
@@ -329,6 +329,10 @@ tasks.register<PixiExecTask>("buildWithGraalVmNativeImage") {
 
         buildList {
             add(nativeImageExe.absolutePath)
+            // Restrict the resources `native-image` tries to reserve so that it doesn't accidentally  ask for too
+            // much and blow up the build
+            add("-J-Xmx2560m")
+            add("--parallelism=2")
             add("--shared")
             add("-cp"); add(classPath)
             add("-H:+UnlockExperimentalVMOptions") // Necessary to use JNIConfigurationFiles option below


### PR DESCRIPTION
Four independent build fixes that landed on `release/0.3.0` 

## Restrict native-image resource demands

`native-image` sized its memory allocation from the machine it was running on rather than the resources it was granted on that machine, which was blowing up CI. Restricted to `-J-Xmx2560m` and `--parallelism=2`, values known to fit in
the overhead we are granted.

## Normalize CRLF in JSONTestSuite when generating

Windows checkouts of the vendored suite use `core.autocrlf`, which leaked CRLFs into the generated `JsonSuiteTest.kt`. Normalized to `\n` at read time so the generated file does not depend on the checkout's line-ending settings.

## Run build-python-sdist on a large executor

Bumps the job to `resource_class: large`.

## Run test-python-sdist-macos on Apple silicon

CircleCI retired the Intel macOS fleet, and Xcode 14.2 only existed on Intel, so the job was rejected as having no valid resource class. Moved to Xcode 16.4.0 on `m4pro.medium`, the same executor as `build-macos-arm64`.