### PR TITLE
Make kson-lang for Python wheel-only

### DIFF
--- a/.circleci/config.kson
+++ b/.circleci/config.kson
@@ -214,65 +214,6 @@ commands:
           .
         .
     .
-  'setup-python-test':
-    description: 'Common setup for Python sdist testing'
-    parameters:
-      platform:
-        type: string
-        .
-      .
-    steps:
-      - checkout
-      - when:
-          condition:
-            equal:
-              - '<< parameters.platform >>'
-              - windows
-            .
-          steps:
-            - 'clean-git-config':
-                shell: powershell
-            =
-
-      - when:
-          condition:
-            not:
-              equal:
-                - '<< parameters.platform >>'
-                - windows
-              .
-            .
-          steps:
-            - 'clean-git-config':
-                shell: bash
-            =
-
-      - attach_workspace:
-          at: '~/repo'
-          .
-        .
-    .
-  'run-python-tests-unix':
-    description: 'Run Python sdist tests and build wheel for Unix-like systems'
-    steps:
-      - run:
-          name: 'Install kson from sdist'
-          command: 'python3 -m pip install lib-python/dist/kson_lang-*.tar.gz'
-
-      - run:
-          name: 'Install test dependencies'
-          command: 'python3 -m pip install pytest'
-
-      - run:
-          name: 'Run smoke tests on sdist installation'
-          command: 'python3 -m pytest lib-python -v'
-
-      - run:
-          name: 'Build platform-specific wheel'
-          command: './gradlew :lib-python:buildWheel'
-          .
-        .
-    .
   .
 # Job definitions
 jobs:
@@ -372,7 +313,7 @@ jobs:
           .
         .
     .
-  'build-python-sdist':
+  'test-python-sdist':
     docker:
       - image: 'cimg/python:3.11'
         .
@@ -385,38 +326,37 @@ jobs:
           platform: 'linux-amd64'
       - run:
           name: 'Build Python source distribution'
-          command: './gradlew :lib-python:createSdistBuildEnvironment'
+          command: './gradlew :lib-python:buildSdist'
 
       - run:
-          name: 'Verify sdist was created'
-          command: 'ls -la lib-python/dist/\ntest -f lib-python/dist/kson_lang-*.tar.gz\n'
+          name: 'Verify the sdist is source only'
+          command: 'ls -la lib-python/dist/\ntest -f lib-python/dist/kson_lang-*.tar.gz\n# The sdist builds nothing, so it must carry none of the Gradle output that\n# `[tool.setuptools.package-data]` offers it. tests/test_manifest.py pins MANIFEST.in\n# against that list; this is the only place anyone opens the archive itself.\ntar tzf lib-python/dist/kson_lang-*.tar.gz | tee /tmp/sdist-contents.txt\n! grep -E "[.](so|dylib|dll|pyd|h)$" /tmp/sdist-contents.txt\n'
 
-      - persist_to_workspace:
-          root: '~/repo'
-          paths:
-            - 'lib-python/dist/*.tar.gz'
-            =
+      - run:
+          name: 'Verify installing the sdist fails with a useful message'
+          command: '# Refusing to build is the whole contract of the sdist, so hold it to the\n# message build_backend.py means to give: a bare install failure reads like a broken release.\n! python3 -m pip install --no-cache-dir lib-python/dist/kson_lang-*.tar.gz > /tmp/sdist-install.log 2>&1\ncat /tmp/sdist-install.log\ngrep -q "Cannot build kson-lang" /tmp/sdist-install.log\n'
 
       - 'save-build-caches':
           platform: 'linux-amd64'
-      - store_artifacts:
-          path: 'lib-python/dist'
-          destination: 'python-sdist'
           .
         .
     .
-  'test-python-sdist-linux-amd64':
+  'build-python-wheel-linux-amd64':
     docker:
       - image: 'cimg/python:3.11'
         .
     working_directory: '~/repo'
     steps:
-      - 'setup-python-test':
-          platform: linux
+      - checkout
+      - 'clean-git-config':
+          shell: bash
       - 'restore-build-caches':
           platform: 'linux-amd64'
       - setup_remote_docker
-      - 'run-python-tests-unix'
+      - run:
+          name: 'Build platform-specific wheel'
+          command: './gradlew :lib-python:buildWheel'
+
       - 'save-build-caches':
           platform: 'linux-amd64'
       - store_artifacts:
@@ -425,17 +365,21 @@ jobs:
           .
         .
     .
-  'test-python-sdist-macos':
+  'build-python-wheel-macos':
     macos:
       xcode: '14.2.0'
       .
     working_directory: '~/repo'
     steps:
-      - 'setup-python-test':
-          platform: macos
+      - checkout
+      - 'clean-git-config':
+          shell: bash
       - 'restore-build-caches':
           platform: 'macos-python'
-      - 'run-python-tests-unix'
+      - run:
+          name: 'Build platform-specific wheel'
+          command: './gradlew :lib-python:buildWheel'
+
       - 'save-build-caches':
           platform: 'macos-python'
       - store_artifacts:
@@ -444,34 +388,18 @@ jobs:
           .
         .
     .
-  'test-python-sdist-windows':
+  'build-python-wheel-windows':
     executor:
       name: 'windows/default'
       size: medium
       .
     working_directory: '~/repo'
     steps:
-      - 'setup-python-test':
-          platform: windows
+      - checkout
+      - 'clean-git-config':
+          shell: powershell
       - 'restore-build-caches':
           platform: 'windows-python'
-      - run:
-          name: 'Check Python version and upgrade if needed'
-          command: 'python --version\npython -m pip install --upgrade pip\n'
-
-      - run:
-          name: 'Install kson from sdist'
-          command: 'python -m pip install (Get-ChildItem lib-python/dist/kson_lang-*.tar.gz).FullName\n'
-          shell: 'powershell.exe'
-
-      - run:
-          name: 'Install test dependencies'
-          command: 'python -m pip install pytest'
-
-      - run:
-          name: 'Run smoke tests on sdist installation'
-          command: 'python -m pytest lib-python -v'
-
       - run:
           name: 'Build platform-specific wheel'
           command: '.\\gradlew.bat :lib-python:buildWheel --no-daemon\n'
@@ -506,27 +434,21 @@ workflows:
     .
   'build-python-and-test':
     jobs:
-      - 'build-python-sdist':
+      - 'test-python-sdist':
           filters:
             branches:
               only: '/release.*\\d+\\.\\d+\\.\\d+$/'
-      - 'test-python-sdist-linux-amd64':
-          requires:
-            - 'build-python-sdist'
-          filters:
-            branches:
-              only: '/release.*\\d+\\.\\d+\\.\\d+$/'
-
-      - 'test-python-sdist-macos':
-          requires:
-            - 'build-python-sdist'
+      - 'build-python-wheel-linux-amd64':
           filters:
             branches:
               only: '/release.*\\d+\\.\\d+\\.\\d+$/'
 
-      - 'test-python-sdist-windows':
-          requires:
-            - 'build-python-sdist'
+      - 'build-python-wheel-macos':
+          filters:
+            branches:
+              only: '/release.*\\d+\\.\\d+\\.\\d+$/'
+
+      - 'build-python-wheel-windows':
           filters:
             branches:
               only: '/release.*\\d+\\.\\d+\\.\\d+$/'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,55 +195,6 @@ commands:
 
 
 
-  "setup-python-test":
-    description: "Common setup for Python sdist testing"
-    parameters:
-      platform:
-        type: string
-    steps:
-      - checkout
-      - when:
-          condition:
-            equal:
-              - "<< parameters.platform >>"
-              - windows
-          steps:
-            - "clean-git-config":
-                shell: powershell
-
-      - when:
-          condition:
-            not:
-              equal:
-                - "<< parameters.platform >>"
-                - windows
-          steps:
-            - "clean-git-config":
-                shell: bash
-
-      - attach_workspace:
-          at: "~/repo"
-
-  "run-python-tests-unix":
-    description: "Run Python sdist tests and build wheel for Unix-like systems"
-    steps:
-      - run:
-          name: "Install kson from sdist"
-          command: "python3 -m pip install lib-python/dist/kson_lang-*.tar.gz"
-
-      - run:
-          name: "Install test dependencies"
-          command: "python3 -m pip install pytest"
-
-      - run:
-          name: "Run smoke tests on sdist installation"
-          command: "python3 -m pytest lib-python -v"
-
-      - run:
-          name: "Build platform-specific wheel"
-          command: "./gradlew :lib-python:buildWheel"
-
-
 
 # Job definitions
 jobs:
@@ -333,7 +284,7 @@ jobs:
       - "save-gradle-caches":
           platform: "macos-arm64"
 
-  "build-python-sdist":
+  "test-python-sdist":
     docker:
       - image: "cimg/python:3.11"
     working_directory: "~/repo"
@@ -345,35 +296,34 @@ jobs:
           platform: "linux-amd64"
       - run:
           name: "Build Python source distribution"
-          command: "./gradlew :lib-python:createSdistBuildEnvironment"
+          command: "./gradlew :lib-python:buildSdist"
 
       - run:
-          name: "Verify sdist was created"
-          command: "ls -la lib-python/dist/\ntest -f lib-python/dist/kson_lang-*.tar.gz\n"
+          name: "Verify the sdist is source only"
+          command: "ls -la lib-python/dist/\ntest -f lib-python/dist/kson_lang-*.tar.gz\n# The sdist builds nothing, so it must carry none of the Gradle output that\n# `[tool.setuptools.package-data]` offers it. tests/test_manifest.py pins MANIFEST.in\n# against that list; this is the only place anyone opens the archive itself.\ntar tzf lib-python/dist/kson_lang-*.tar.gz | tee /tmp/sdist-contents.txt\n! grep -E \"[.](so|dylib|dll|pyd|h)$\" /tmp/sdist-contents.txt\n"
 
-      - persist_to_workspace:
-          root: "~/repo"
-          paths:
-            - "lib-python/dist/*.tar.gz"
+      - run:
+          name: "Verify installing the sdist fails with a useful message"
+          command: "# Refusing to build is the whole contract of the sdist, so hold it to the\n# message build_backend.py means to give: a bare install failure reads like a broken release.\n! python3 -m pip install --no-cache-dir lib-python/dist/kson_lang-*.tar.gz > /tmp/sdist-install.log 2>&1\ncat /tmp/sdist-install.log\ngrep -q \"Cannot build kson-lang\" /tmp/sdist-install.log\n"
 
       - "save-build-caches":
           platform: "linux-amd64"
-      - store_artifacts:
-          path: "lib-python/dist"
-          destination: "python-sdist"
 
-
-  "test-python-sdist-linux-amd64":
+  "build-python-wheel-linux-amd64":
     docker:
       - image: "cimg/python:3.11"
     working_directory: "~/repo"
     steps:
-      - "setup-python-test":
-          platform: linux
+      - checkout
+      - "clean-git-config":
+          shell: bash
       - "restore-build-caches":
           platform: "linux-amd64"
       - setup_remote_docker
-      - "run-python-tests-unix"
+      - run:
+          name: "Build platform-specific wheel"
+          command: "./gradlew :lib-python:buildWheel"
+
       - "save-build-caches":
           platform: "linux-amd64"
       - store_artifacts:
@@ -381,16 +331,20 @@ jobs:
           destination: "python-linux-amd64"
 
 
-  "test-python-sdist-macos":
+  "build-python-wheel-macos":
     macos:
       xcode: "14.2.0"
     working_directory: "~/repo"
     steps:
-      - "setup-python-test":
-          platform: macos
+      - checkout
+      - "clean-git-config":
+          shell: bash
       - "restore-build-caches":
           platform: "macos-python"
-      - "run-python-tests-unix"
+      - run:
+          name: "Build platform-specific wheel"
+          command: "./gradlew :lib-python:buildWheel"
+
       - "save-build-caches":
           platform: "macos-python"
       - store_artifacts:
@@ -398,34 +352,18 @@ jobs:
           destination: "python-macos"
 
 
-  "test-python-sdist-windows":
+  "build-python-wheel-windows":
     executor:
       name: "windows/default"
       size: medium
 
     working_directory: "~/repo"
     steps:
-      - "setup-python-test":
-          platform: windows
+      - checkout
+      - "clean-git-config":
+          shell: powershell
       - "restore-build-caches":
           platform: "windows-python"
-      - run:
-          name: "Check Python version and upgrade if needed"
-          command: "python --version\npython -m pip install --upgrade pip\n"
-
-      - run:
-          name: "Install kson from sdist"
-          command: "python -m pip install (Get-ChildItem lib-python/dist/kson_lang-*.tar.gz).FullName\n"
-          shell: "powershell.exe"
-
-      - run:
-          name: "Install test dependencies"
-          command: "python -m pip install pytest"
-
-      - run:
-          name: "Run smoke tests on sdist installation"
-          command: "python -m pytest lib-python -v"
-
       - run:
           name: "Build platform-specific wheel"
           command: ".\\gradlew.bat :lib-python:buildWheel --no-daemon\n"
@@ -454,27 +392,19 @@ workflows:
               only: "/release.*\\d+\\.\\d+\\.\\d+$/"
   "build-python-and-test":
     jobs:
-      - "build-python-sdist":
+      - "test-python-sdist":
           filters:
             branches:
               only: "/release.*\\d+\\.\\d+\\.\\d+$/"
-      - "test-python-sdist-linux-amd64":
-          requires:
-            - "build-python-sdist"
+      - "build-python-wheel-linux-amd64":
           filters:
             branches:
               only: "/release.*\\d+\\.\\d+\\.\\d+$/"
-
-      - "test-python-sdist-macos":
-          requires:
-            - "build-python-sdist"
+      - "build-python-wheel-macos":
           filters:
             branches:
               only: "/release.*\\d+\\.\\d+\\.\\d+$/"
-
-      - "test-python-sdist-windows":
-          requires:
-            - "build-python-sdist"
+      - "build-python-wheel-windows":
           filters:
             branches:
               only: "/release.*\\d+\\.\\d+\\.\\d+$/"

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -147,9 +147,8 @@ The Python package is published to PyPI as `kson-lang` using platform-specific w
    step 3.
 
 3. Download the pre-built wheels from the CircleCI `build-python-wheel-*` jobs for this tag:
-   - Download the wheel artifacts from CircleCI (they will download as `.zip` files)
+   - Download the wheel artifacts from CircleCI
    - Copy all wheels into the `lib-python/dist/` directory
-   - Change the file extensions from `.zip` to `.whl`
 
 4. Upload to PyPI using `twine`:
    ```bash

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -139,10 +139,14 @@ The Python package is published to PyPI as `kson-lang` using platform-specific w
 
 2. Create the source distribution:
    ```bash
-   ./gradlew createDist
+   ./gradlew :lib-python:buildSdist
    ```
 
-3. Download the pre-built wheels from the CircleCI build for this tag:
+   This archive is source only: it carries no native library and cannot build one, so nobody
+   installs from it. It puts the source on PyPI; every installable artifact is a wheel from
+   step 3.
+
+3. Download the pre-built wheels from the CircleCI `build-python-wheel-*` jobs for this tag:
    - Download the wheel artifacts from CircleCI (they will download as `.zip` files)
    - Copy all wheels into the `lib-python/dist/` directory
    - Change the file extensions from `.zip` to `.whl`

--- a/lib-python/.gitignore
+++ b/lib-python/.gitignore
@@ -1,7 +1,6 @@
 __pycache__
 .pytest_cache
 .venv
-kson-sdist
 *.dll
 *.dylib
 *.so

--- a/lib-python/MANIFEST.in
+++ b/lib-python/MANIFEST.in
@@ -1,32 +1,20 @@
 include build_backend.py
 include pyproject.toml
-include README.md
+include readme.md
 recursive-include src *.py
 recursive-include src *.c
 
-# Include necessary Gradle files from kson-sdist
-recursive-include kson-sdist *.kts *.kt *.properties *.md
-# Include Python source files from kson-sdist
-recursive-include kson-sdist *.py
-include kson-sdist/.circleci/config.kson
-include kson-sdist/gradlew
-include kson-sdist/gradlew.bat
-include kson-sdist/buildSrc/gradlew
-include kson-sdist/buildSrc/gradlew.bat
-include kson-sdist/gradle/wrapper/gradle-wrapper.jar
-include kson-sdist/gradle/wrapper/gradle-wrapper.properties
-include kson-sdist/buildSrc/gradle/wrapper/gradle-wrapper.jar
-include kson-sdist/buildSrc/gradle/wrapper/gradle-wrapper.properties
+# The sdist is source only: it can build no native library, so it must not look as though it
+# ships one.  `[tool.setuptools.package-data]` sweeps the native library and the headers beside
+# it in from whatever local Gradle build left them in src/kson, and only these exclusions take
+# them back out - tests/test_manifest.py holds the two lists together.  MANIFEST.in commands
+# apply in order, so these must follow the includes.
+exclude src/kson/*.so
+exclude src/kson/*.dylib
+exclude src/kson/*.dll
+exclude src/kson/*.pyd
+exclude src/kson/*.h
 
-# Explicitly exclude all build artifacts
-prune kson-sdist/**/.gradle
-prune kson-sdist/**/build
-prune kson-sdist/**/.kotlin
 global-exclude __pycache__
 global-exclude *.py[co]
 global-exclude .DS_Store
-global-exclude *.class
-global-exclude *.lock
-global-exclude *.bin
-global-exclude *.hprof
-global-exclude *.log

--- a/lib-python/build.gradle.kts
+++ b/lib-python/build.gradle.kts
@@ -50,82 +50,10 @@ tasks {
         dependsOn(typeCheck)
     }
 
-    val prepareSdistBuildEnvironment by register<Copy>("prepareSdistBuildEnvironment") {
-        dependsOn("copyLicense", copyNativeArtifacts, ":kson-lib:generateJniBindingsJvm")
+    register<Exec>("buildSdist") {
+        dependsOn("copyLicense")
         group = "build"
-        description = "Prepare kson-sdist directory with necessary Gradle files for sdist"
-
-        val ksonCopyDir = layout.projectDirectory.dir("kson-sdist")
-
-        // Clear existing kson-sdist directory
-        doFirst {
-            delete(ksonCopyDir)
-        }
-
-        // Copy gradlew scripts
-        from(rootProject.file("gradlew"))
-        from(rootProject.file("gradlew.bat"))
-        into(ksonCopyDir)
-
-        // Make gradlew executable
-        filePermissions {
-            unix("755")
-        }
-
-        // Copy gradle wrapper (excluding JDK)
-        from(rootProject.file("gradle/wrapper")) {
-            into("gradle/wrapper")
-        }
-
-        // Need this file to satisfy the `transpileCircleCiConfigTask`
-        from(rootProject.file(".circleci/config.kson")){
-            into(".circleci")
-        }
-
-        // Copy build configuration files
-        from(rootProject.file("build.gradle.kts"))
-        from(rootProject.file("settings.gradle.kts"))
-        from(rootProject.file("gradle.properties"))
-        from(rootProject.file("jdk.properties"))
-
-        from(rootProject.file("src")){
-            into("src")
-            exclude("commonTest/**")
-        }
-        // Copy buildSrc (excluding build output and JDK)
-        from(rootProject.file("buildSrc")) {
-            into("buildSrc")
-            exclude("build/**")
-            exclude(".gradle/**")
-            exclude("gradle/jdk/**")
-            exclude(".kotlin/**")
-            exclude("support/**")
-            exclude("out/**")
-        }
-
-        // Copy kson-lib source (needed for native artifact build)
-        from(rootProject.file("kson-lib")) {
-            into("kson-lib")
-            exclude("build/**")
-            exclude(".gradle/**")
-        }
-
-        // Copy lib-python (build files and source, excluding native binaries
-        // which are platform-specific and must be built from source)
-        // Keep in sync with PLATFORM_NATIVE_LIBRARIES in build_backend.py
-        from(project.projectDir) {
-            into("lib-python")
-            include("build.gradle.kts")
-            include("src/**")
-            exclude("src/kson/kson.dll")
-            exclude("src/kson/libkson.dylib")
-            exclude("src/kson/libkson.so")
-        }
-    }
-
-    register<Exec>("createSdistBuildEnvironment"){
-        dependsOn(prepareSdistBuildEnvironment)
-        group = "build"
+        description = "Build the source distribution, which carries no native library and so builds no wheel"
         commandLine = "$uvwPath build --sdist".split(" ")
     }
 

--- a/lib-python/build_backend.py
+++ b/lib-python/build_backend.py
@@ -1,11 +1,11 @@
 """
-Custom build backend for kson Python package.
-This backend ensures native artifacts are built when creating source distributions.
+Custom build backend for the kson Python package.
+
+The native library is Gradle output from a full checkout, so no wheel build can conjure one:
+this backend's whole job is to refuse rather than emit a wheel that imports and then fails on
+the first call.  The sdist is source only and therefore always lands in that refusal.
 """
 
-import os
-import subprocess
-import shutil
 import sys
 from pathlib import Path
 from setuptools import build_meta as _orig
@@ -33,76 +33,23 @@ def _required_artifacts():
 
 
 def _ensure_native_artifacts():
-    """Build native artifacts using the bundled Gradle setup."""
-    lib_python_dir = Path(__file__).parent
-    kson_copy_dir = lib_python_dir / "kson-sdist"
-    src_dir = lib_python_dir / "src"
-    src_kson_dir = src_dir / "kson"
-
-    # Only check for the native library needed on *this* platform
-    required = _required_artifacts()
-    artifacts_exist = all((src_kson_dir / f).exists() for f in required)
-
-    if not artifacts_exist and kson_copy_dir.exists():
-        print(f"Building native artifacts for {sys.platform} with bundled Gradle setup...")
-
-        gradlew = "./gradlew" if os.name != "nt" else "gradlew.bat"
-        result = subprocess.run(
-            [gradlew, "lib-python:build"],
-            capture_output=True,
-            text=True,
-            cwd=kson_copy_dir,
-        )
-
-        if result.returncode != 0:
-            print(f"Gradle build stdout:\n{result.stdout}")
-            print(f"Gradle build stderr:\n{result.stderr}")
-            raise RuntimeError("Failed to build native artifacts")
-
-        print("Native artifacts built successfully")
-
-        # Replace the entire src directory with the one from kson-sdist
-        kson_copy_src = kson_copy_dir / "lib-python" / "src"
-        if kson_copy_src.exists():
-            print("Replacing src directory with built artifacts...")
-            # Save _marker.c if it exists
-            marker_c = src_kson_dir / "_marker.c"
-            marker_c_content = None
-            if marker_c.exists():
-                marker_c_content = marker_c.read_bytes()
-
-            shutil.rmtree(src_dir, ignore_errors=True)
-            shutil.copytree(kson_copy_src, src_dir)
-
-            # Restore _marker.c if it existed
-            if marker_c_content is not None:
-                marker_c_new = src_kson_dir / "_marker.c"
-                marker_c_new.parent.mkdir(parents=True, exist_ok=True)
-                marker_c_new.write_bytes(marker_c_content)
-
-        # Clean up kson-sdist after successful build
-        print("Cleaning up build files...")
-        shutil.rmtree(kson_copy_dir, ignore_errors=True)
-
-    # Post-condition: verify all required artifacts are present
-    missing = [f for f in required if not (src_kson_dir / f).exists()]
+    """Raise unless this platform's native artifacts already sit in src/kson."""
+    src_kson_dir = Path(__file__).parent / "src" / "kson"
+    missing = [f for f in _required_artifacts() if not (src_kson_dir / f).exists()]
     if missing:
         raise RuntimeError(
-            f"Required native artifacts missing for {sys.platform}: {', '.join(missing)}. "
-            f"Install from a pre-built wheel instead, or ensure a JDK is available "
-            f"so the Gradle build can produce them."
+            f"Cannot build kson-lang for {sys.platform}: {', '.join(missing)} missing from "
+            f"{src_kson_dir}.\n"
+            f"Those are Gradle output. kson-lang ships prebuilt wheels carrying them, so either "
+            f"none matched this platform and Python version and pip fell back to the source "
+            f"distribution, or this is a checkout where the Gradle build has not run.\n"
+            f"Either way, \"Build from source\" in the readme is the way to get them:\n"
+            f"    git clone https://github.com/kson-org/kson.git\n"
+            f"    cd kson && ./gradlew :lib-python:build"
         )
-
-
-def build_sdist(sdist_directory, config_settings=None):
-    """Build source distribution."""
-    # Note: When creating sdist, we keep kson-sdist for later use
-    # The kson-sdist directory should be prepared beforehand by release process
-    return _orig.build_sdist(sdist_directory, config_settings)
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
-    """Build wheel with native artifacts."""
+    """Build a wheel, refusing unless the native artifacts to put in it are already there."""
     _ensure_native_artifacts()
-    # kson-sdist will be deleted after building artifacts, so it won't be in the wheel
     return _orig.build_wheel(wheel_directory, config_settings, metadata_directory)

--- a/lib-python/readme.md
+++ b/lib-python/readme.md
@@ -2,7 +2,7 @@
 
 Python bindings for [KSON](https://kson.org), a next-gen configuration language. Convert KSON to JSON/YAML, format and validate documents, and parse KSON into structured values.
 
-Available on Linux, macOS, and Windows. Requires Python 3.10+.
+Requires Python 3.11+. Prebuilt wheels are published for Linux x86_64 (glibc 2.34+), macOS arm64 and Windows x86_64.
 
 ## Installation
 
@@ -10,6 +10,10 @@ Available on Linux, macOS, and Windows. Requires Python 3.10+.
 ```bash
 pip install kson-lang
 ```
+
+Installing needs one of those wheels: kson-lang wraps a native library and the source
+distribution cannot build one, so anywhere else pip falls back to the sdist and fails with a
+pointer to [Build from source](#build-from-source).
 
 ## Quick start
 

--- a/lib-python/tests/test_build_backend.py
+++ b/lib-python/tests/test_build_backend.py
@@ -1,6 +1,9 @@
-"""Tests for the custom build backend's platform-aware native artifact detection."""
+"""Tests for the custom build backend.
 
-import subprocess
+The backend cannot produce the native library - only a Gradle build in a full checkout can - so
+all it decides is who gets through, and what it tells whoever does not.
+"""
+
 import sys
 from unittest.mock import patch
 
@@ -9,129 +12,99 @@ import pytest
 import build_backend
 
 
-class TestPlatformNativeLibrary:
-    def test_darwin(self):
-        with patch.object(sys, "platform", "darwin"):
-            assert build_backend._platform_native_library() == "libkson.dylib"
-
-    def test_linux(self):
-        with patch.object(sys, "platform", "linux"):
-            assert build_backend._platform_native_library() == "libkson.so"
-
-    def test_windows(self):
-        with patch.object(sys, "platform", "win32"):
-            assert build_backend._platform_native_library() == "kson.dll"
-
-    def test_unsupported_platform(self):
-        with patch.object(sys, "platform", "freebsd"):
-            with pytest.raises(RuntimeError, match="Unsupported platform: freebsd"):
-                build_backend._platform_native_library()
+@pytest.fixture
+def src_kson(tmp_path):
+    """An empty `src/kson`, with the backend pointed at the source tree holding it."""
+    src_kson_dir = tmp_path / "src" / "kson"
+    src_kson_dir.mkdir(parents=True)
+    with patch.object(build_backend, "__file__", str(tmp_path / "build_backend.py")):
+        yield src_kson_dir
 
 
-class TestEnsureNativeArtifacts:
-    """Verify that _ensure_native_artifacts only considers the current platform's library."""
+def _refusal_message():
+    """What `_ensure_native_artifacts` refuses with, given whatever the `src_kson` fixture holds."""
+    with pytest.raises(RuntimeError) as refused:
+        build_backend._ensure_native_artifacts()
+    return str(refused.value)
 
-    def _place_all_required_artifacts(self, directory):
-        """Place all required artifacts for the current platform."""
-        for f in build_backend._required_artifacts():
-            (directory / f).touch()
 
-    def test_skips_build_when_current_platform_artifacts_exist(self, tmp_path):
-        """Build is skipped when all required artifacts for *this* platform are present."""
-        src_kson = tmp_path / "src" / "kson"
-        src_kson.mkdir(parents=True)
-        kson_sdist = tmp_path / "kson-sdist"
-        kson_sdist.mkdir()
+@pytest.mark.parametrize(
+    "platform, library",
+    [("darwin", "libkson.dylib"), ("linux", "libkson.so"), ("win32", "kson.dll")],
+)
+def test_platform_native_library(platform, library):
+    with patch.object(sys, "platform", platform):
+        assert build_backend._platform_native_library() == library
 
-        self._place_all_required_artifacts(src_kson)
 
-        with patch.object(build_backend, "__file__", str(tmp_path / "build_backend.py")):
-            with patch.object(build_backend.subprocess, "run") as mock_run:
-                build_backend._ensure_native_artifacts()
-                mock_run.assert_not_called()
+def test_unsupported_platform_is_named_in_the_error():
+    with patch.object(sys, "platform", "freebsd"):
+        with pytest.raises(RuntimeError, match="Unsupported platform: freebsd"):
+            build_backend._platform_native_library()
 
-    def test_triggers_build_when_only_foreign_artifact_exists(self, tmp_path):
-        """Build is triggered when only a *different* platform's library is present."""
-        src_kson = tmp_path / "src" / "kson"
-        src_kson.mkdir(parents=True)
-        kson_sdist = tmp_path / "kson-sdist"
-        kson_sdist.mkdir()
 
-        # Place foreign platform libraries (but not the current one)
-        current_lib = build_backend._platform_native_library()
-        for lib in build_backend.PLATFORM_NATIVE_LIBRARIES.values():
-            if lib != current_lib:
-                (src_kson / lib).touch()
-        (src_kson / "jni_simplified.h").touch()
+def test_passes_when_this_platforms_artifacts_are_present(src_kson):
+    for artifact in build_backend._required_artifacts():
+        (src_kson / artifact).touch()
 
-        with patch.object(build_backend, "__file__", str(tmp_path / "build_backend.py")):
-            with patch.object(build_backend.subprocess, "run") as mock_run:
-                mock_run.return_value = subprocess.CompletedProcess(
-                    args=[], returncode=1, stdout="", stderr="fail",
-                )
-                with pytest.raises(RuntimeError, match="Failed to build native artifacts"):
-                    build_backend._ensure_native_artifacts()
-                mock_run.assert_called_once()
+    build_backend._ensure_native_artifacts()
 
-    def test_triggers_build_when_header_missing(self, tmp_path):
-        """Build is triggered when the native lib exists but jni_simplified.h is missing."""
-        src_kson = tmp_path / "src" / "kson"
-        src_kson.mkdir(parents=True)
-        kson_sdist = tmp_path / "kson-sdist"
-        kson_sdist.mkdir()
 
-        current_lib = build_backend._platform_native_library()
-        (src_kson / current_lib).touch()
+def test_refuses_when_only_another_platforms_library_is_present(src_kson):
+    """A wheel around a foreign library imports fine and dies on the first call."""
+    ours = build_backend._platform_native_library()
+    for library in build_backend.PLATFORM_NATIVE_LIBRARIES.values():
+        if library != ours:
+            (src_kson / library).touch()
+    (src_kson / "jni_simplified.h").touch()
 
-        with patch.object(build_backend, "__file__", str(tmp_path / "build_backend.py")):
-            with patch.object(build_backend.subprocess, "run") as mock_run:
-                mock_run.return_value = subprocess.CompletedProcess(
-                    args=[], returncode=1, stdout="", stderr="fail",
-                )
-                with pytest.raises(RuntimeError, match="Failed to build native artifacts"):
-                    build_backend._ensure_native_artifacts()
-                mock_run.assert_called_once()
+    assert ours in _refusal_message()
 
-    def test_errors_when_artifacts_missing_and_no_kson_sdist(self, tmp_path):
-        """Raises when artifacts are missing and there's no kson-sdist to build from."""
-        src_kson = tmp_path / "src" / "kson"
-        src_kson.mkdir(parents=True)
 
-        with patch.object(build_backend, "__file__", str(tmp_path / "build_backend.py")):
-            with pytest.raises(RuntimeError, match="Required native artifacts missing"):
-                build_backend._ensure_native_artifacts()
+def test_refuses_when_the_jni_header_is_missing(src_kson):
+    """`kson/__init__.py` reads the header at import time, so the library alone is not enough."""
+    (src_kson / build_backend._platform_native_library()).touch()
 
-    def test_successful_build_replaces_src_and_preserves_marker(self, tmp_path):
-        """On successful build, src is replaced with kson-sdist output and _marker.c is preserved."""
-        src_kson = tmp_path / "src" / "kson"
-        src_kson.mkdir(parents=True)
-        kson_sdist = tmp_path / "kson-sdist"
+    assert "jni_simplified.h" in _refusal_message()
 
-        # Set up the kson-sdist build output that Gradle would produce
-        native_lib = build_backend._platform_native_library()
-        kson_sdist_src = kson_sdist / "lib-python" / "src" / "kson"
-        kson_sdist_src.mkdir(parents=True)
-        (kson_sdist_src / "__init__.py").write_text("# built")
-        (kson_sdist_src / native_lib).write_bytes(b"built-lib")
-        (kson_sdist_src / "jni_simplified.h").write_text("/* header */")
 
-        # Place _marker.c in the original src (should be preserved)
-        marker_content = b"/* platform marker */"
-        (src_kson / "_marker.c").write_bytes(marker_content)
+def test_refusal_says_what_the_reader_needs(src_kson):
+    """This message is the whole user-facing contract of the source distribution, and its wording
+    is load-bearing twice over: `test-python-sdist` greps CI's copy of it, and missing artifacts
+    mean either that no wheel matched or that Gradle has not run in this checkout - only the
+    reader can tell which, so naming one cause sends the other kind of reader after the wrong
+    problem."""
+    refusal = _refusal_message()
 
-        with patch.object(build_backend, "__file__", str(tmp_path / "build_backend.py")):
-            with patch.object(build_backend.subprocess, "run") as mock_run:
-                mock_run.return_value = subprocess.CompletedProcess(
-                    args=[], returncode=0, stdout="", stderr="",
-                )
-                build_backend._ensure_native_artifacts()
+    # what CI greps for, and which machine it is talking about
+    assert "Cannot build kson-lang" in refusal
+    assert sys.platform in refusal
 
-        # src was replaced with kson-sdist output
-        assert (tmp_path / "src" / "kson" / "__init__.py").read_text() == "# built"
-        assert (tmp_path / "src" / "kson" / native_lib).read_bytes() == b"built-lib"
+    # both ways of arriving here, neither one claimed as *the* cause
+    assert "prebuilt wheels" in refusal
+    assert "fell back" in refusal
+    assert "checkout" in refusal
 
-        # _marker.c was preserved
-        assert (tmp_path / "src" / "kson" / "_marker.c").read_bytes() == marker_content
+    # where to go next
+    assert "git clone https://github.com/kson-org/kson.git" in refusal
+    assert "./gradlew :lib-python:build" in refusal
 
-        # kson-sdist was cleaned up
-        assert not kson_sdist.exists()
+
+def test_build_wheel_refuses_before_setuptools_gets_a_look(src_kson):
+    """The check is only worth having if the hook a frontend calls actually runs it."""
+    with pytest.raises(RuntimeError, match="Cannot build kson-lang"):
+        build_backend.build_wheel(str(src_kson))
+
+
+def test_backend_exposes_every_pep_517_hook():
+    """Only `build_wheel` is ours; the rest ride in on the `setuptools.build_meta` star import,
+    and a frontend that cannot find them refuses to build at all."""
+    hooks = [
+        "build_sdist",
+        "build_wheel",
+        "get_requires_for_build_sdist",
+        "get_requires_for_build_wheel",
+        "prepare_metadata_for_build_wheel",
+    ]
+    assert [hook for hook in hooks if not callable(getattr(build_backend, hook, None))] == []
+    assert build_backend.build_wheel.__module__ == "build_backend"

--- a/lib-python/tests/test_manifest.py
+++ b/lib-python/tests/test_manifest.py
@@ -1,0 +1,60 @@
+"""Tests that the sdist's exclusions keep step with the wheel's package data.
+
+`[tool.setuptools.package-data]` lists what a *wheel* must carry, and setuptools offers the same
+files to the sdist.  Only the `exclude` commands in MANIFEST.in take them back out again, so a
+name added to one list and not the other quietly puts a platform binary in a source archive -
+which is how the sdist came to ship `libkson.so` in the first place.  Opening the tarball is a
+release-branch job; this runs on every build.
+"""
+
+import fnmatch
+import tomllib
+from pathlib import Path
+
+LIB_PYTHON = Path(__file__).parent.parent
+
+# what a wheel carries and an sdist must not: the native library, and the headers generated
+# beside it.  Kept in step with the `grep` guarding `test-python-sdist` in .circleci/config.kson
+BUILD_OUTPUT_SUFFIXES = (".so", ".dylib", ".dll", ".pyd", ".h")
+
+
+def _setuptools_config():
+    with (LIB_PYTHON / "pyproject.toml").open("rb") as pyproject:
+        return tomllib.load(pyproject)["tool"]["setuptools"]
+
+
+def _package_data_paths():
+    """every `package-data` entry as the path MANIFEST.in patterns are written against"""
+    config = _setuptools_config()
+    source_root = config["package-dir"][""]
+    return [
+        f"{source_root}/{package}/{filename}"
+        for package, filenames in config["package-data"].items()
+        for filename in filenames
+    ]
+
+
+def _manifest_excludes():
+    """the patterns MANIFEST.in's `exclude` commands take back out of the sdist"""
+    patterns = []
+    for line in (LIB_PYTHON / "MANIFEST.in").read_text().splitlines():
+        command, *rest = line.split() or [""]
+        if command == "exclude":
+            patterns.extend(rest)
+    return patterns
+
+
+def test_every_build_artifact_in_package_data_is_excluded_from_the_sdist():
+    artifacts = [p for p in _package_data_paths() if p.endswith(BUILD_OUTPUT_SUFFIXES)]
+    assert artifacts, "package-data names no build output, so this test proves nothing"
+
+    excludes = _manifest_excludes()
+    unexcluded = [
+        artifact
+        for artifact in artifacts
+        if not any(fnmatch.fnmatch(artifact, pattern) for pattern in excludes)
+    ]
+    assert unexcluded == [], (
+        f"package-data puts {unexcluded} in the sdist and no MANIFEST.in `exclude` in {excludes} "
+        f"takes them out"
+    )


### PR DESCRIPTION
`kson-lang` wraps a native library. The sdist bundled a whole Gradle build so it could try to produce one at install time — a vendored wrapper, a `buildSrc` copy, `MANIFEST.in` entries to ship it all, and CI jobs to exercise it.

Making and keeping this working added quite a lot of complexity, instead we decided to make wheels the supported way to install, the sdist is source, not a buid.

## What this means for users

Installing needs a published wheel. When none matches, pip falls back to the sdist and it refuses immediately with a pointer to building from source, rather than failing part-way through a Gradle run:

```
RuntimeError: Cannot build kson-lang for darwin: libkson.dylib, jni_simplified.h missing from .../src/kson.
Those are Gradle output. kson-lang ships prebuilt wheels carrying them, so either none matched this platform and Python version and pip fell back to the source distribution, or this is a checkout where the Gradle build has not run.
Either way, "Build from source" in the readme is the way to get them:
    git clone https://github.com/kson-org/kson.git
    cd kson && ./gradlew :lib-python:build
```

The sdist still goes to PyPI. It puts the source there; every installable artifact is a wheel.