### PR TITLE
Point the npm package's types at the declarations Kotlin/JS emits

### DIFF
--- a/buildSrc/src/main/kotlin/org/kson/UniversalJsPackage.kt
+++ b/buildSrc/src/main/kotlin/org/kson/UniversalJsPackage.kt
@@ -1,0 +1,104 @@
+package org.kson
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import org.gradle.api.GradleException
+import java.io.File
+
+/**
+ * The `package.json` for the npm package published as `@kson_org/kson`, which ships a browser build
+ * and a Node.js build side by side.
+ *
+ * Kotlin/JS emits each module as `kson-kson-lib.mjs` with sibling declarations named
+ * `kson-kson-lib.d.mts`, one pair per environment, so there is no single set of declarations at the
+ * package root. That shapes the `exports` map in two ways:
+ *
+ * - each condition names its own `types`, listed first, since Node and TypeScript take the first
+ *   matching key within a condition.
+ * - a `default` condition is required for TypeScript's `bundler` module resolution, which resolves
+ *   using `["types", "import"]` and so matches neither `browser` nor `node`.
+ */
+object UniversalJsPackage {
+    /**
+     * Generates the `package.json` contents for the package at [version].
+     */
+    fun packageJson(version: String): String = """
+        {
+          "name": "@kson_org/kson",
+          "version": "$version",
+          "description": "KSON - Extended JSON format with comments and more",
+          "author": {
+            "name": "KSON Team",
+            "email": "kson@kson.org"
+          },
+          "repository": {
+            "type": "git",
+            "url": "https://github.com/kson-org/kson"
+          },
+          "license": "Apache-2.0",
+          "keywords": ["json", "kson", "yaml", "configuration"],
+          "exports": {
+            ".": {
+              "browser": {
+                "types": "./browser/kson-kson-lib.d.mts",
+                "default": "./browser/kson-kson-lib.mjs"
+              },
+              "node": {
+                "types": "./node/kson-kson-lib.d.mts",
+                "default": "./node/kson-kson-lib.mjs"
+              },
+              "default": {
+                "types": "./node/kson-kson-lib.d.mts",
+                "default": "./node/kson-kson-lib.mjs"
+              }
+            }
+          },
+          "main": "./node/kson-kson-lib.mjs",
+          "browser": "./browser/kson-kson-lib.mjs",
+          "types": "./node/kson-kson-lib.d.mts",
+          "files": [
+            "browser/",
+            "node/",
+            "README.md"
+          ]
+        }
+    """.trimIndent()
+
+    /**
+     * Writes [packageJson] for [version] into [packageDir], failing the build if any entry point it
+     * names is missing.
+     *
+     * npm packs a manifest whose entry points do not exist without complaining, so an unchecked
+     * typo would surface only as a resolution failure in a consuming project.
+     */
+    fun writePackageJson(packageDir: File, version: String) {
+        val packageJson = packageJson(version)
+
+        val missing = referencedFiles(Json.parseToJsonElement(packageJson))
+            .distinct()
+            .filterNot { packageDir.resolve(it.removePrefix("./")).isFile }
+        if (missing.isNotEmpty()) {
+            throw GradleException(
+                "package.json names entry points that are missing from ${packageDir.absolutePath}: " +
+                    missing.joinToString()
+            )
+        }
+
+        packageDir.resolve("package.json").writeText(packageJson)
+    }
+
+    /**
+     * Every relative path [element] points at, recognized by the `./` prefix npm requires on
+     * `exports` entry points. Bare directory names under `files` are pack globs rather than entry
+     * points, so they are not matched.
+     */
+    private fun referencedFiles(element: JsonElement): List<String> = when (element) {
+        is JsonObject -> element.values.flatMap(::referencedFiles)
+        is JsonArray -> element.flatMap(::referencedFiles)
+        is JsonPrimitive -> listOfNotNull(element.contentOrNull?.takeIf { it.startsWith("./") })
+    }
+}

--- a/buildSrc/src/test/kotlin/org/kson/UniversalJsPackageTest.kt
+++ b/buildSrc/src/test/kotlin/org/kson/UniversalJsPackageTest.kt
@@ -1,0 +1,132 @@
+package org.kson
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.gradle.api.GradleException
+import java.io.File
+import java.nio.file.Files.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class UniversalJsPackageTest {
+
+    private val packageJson = Json.parseToJsonElement(UniversalJsPackage.packageJson("1.2.3")).jsonObject
+
+    /** The `exports` conditions, in the order npm and TypeScript consider them. */
+    private val exportConditions: Map<String, JsonObject>
+        get() = packageJson["exports"]!!.jsonObject["."]!!.jsonObject
+            .mapValues { (_, condition) -> condition.jsonObject }
+
+    /** The `./`-prefixed entry points named anywhere in the manifest. */
+    private val entryPoints: List<String>
+        get() = listOf("main", "browser", "types")
+            .map { packageJson[it]!!.jsonPrimitive.content } +
+            exportConditions.values.flatMap { condition ->
+                condition.values.map { it.jsonPrimitive.content }
+            }
+
+    /** A package directory laid out like a built one: a module and its declarations per environment. */
+    private fun createPackageDir(): File {
+        val packageDir = createTempDirectory("UniversalJsPackageTest").toFile()
+        for (environment in listOf("browser", "node")) {
+            val environmentDir = File(packageDir, environment).apply { mkdirs() }
+            File(environmentDir, "kson-kson-lib.mjs").writeText("// module")
+            File(environmentDir, "kson-kson-lib.d.mts").writeText("// declarations")
+        }
+        return packageDir
+    }
+
+    @Test
+    fun versionIsRenderedAsAJsonString() {
+        assertEquals("1.2.3", packageJson["version"]!!.jsonPrimitive.content)
+        assertTrue(
+            packageJson["version"]!!.jsonPrimitive.isString,
+            "npm requires a string version"
+        )
+    }
+
+    @Test
+    fun entryPointsNameTheFilesKotlinJsEmits() {
+        // spelled out in full: asserting a property of these paths rather than the paths
+        // themselves lets a `types` that points at a `.mjs` satisfy the assertion vacuously
+        assertEquals(
+            Json.parseToJsonElement(
+                """
+                {
+                  "browser": {
+                    "types": "./browser/kson-kson-lib.d.mts",
+                    "default": "./browser/kson-kson-lib.mjs"
+                  },
+                  "node": {
+                    "types": "./node/kson-kson-lib.d.mts",
+                    "default": "./node/kson-kson-lib.mjs"
+                  },
+                  "default": {
+                    "types": "./node/kson-kson-lib.d.mts",
+                    "default": "./node/kson-kson-lib.mjs"
+                  }
+                }
+                """.trimIndent()
+            ),
+            packageJson["exports"]!!.jsonObject["."]!!
+        )
+        assertEquals("./node/kson-kson-lib.mjs", packageJson["main"]!!.jsonPrimitive.content)
+        assertEquals("./browser/kson-kson-lib.mjs", packageJson["browser"]!!.jsonPrimitive.content)
+        assertEquals("./node/kson-kson-lib.d.mts", packageJson["types"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun everyExportConditionListsTypesFirst() {
+        for ((name, condition) in exportConditions) {
+            // Node and TypeScript take the first matching key, so `types` after `default` is unreachable
+            assertEquals("types", condition.keys.first(), "`$name` must resolve `types` first")
+        }
+    }
+
+    @Test
+    fun exportsCoverBrowserNodeAndBundlerResolution() {
+        // `bundler` resolution matches neither `browser` nor `node`, so `default` must be present
+        assertEquals(listOf("browser", "node", "default"), exportConditions.keys.toList())
+    }
+
+    @Test
+    fun everyEntryPointIsPacked() {
+        val packedPaths = packageJson["files"]!!.jsonArray.map { it.jsonPrimitive.content }
+        for (entryPoint in entryPoints) {
+            val packed = packedPaths.any { entryPoint.removePrefix("./").startsWith(it) }
+            assertTrue(packed, "`files` $packedPaths does not pack the entry point $entryPoint")
+        }
+    }
+
+    @Test
+    fun writesTheManifestForACompletePackage() {
+        val packageDir = createPackageDir()
+
+        UniversalJsPackage.writePackageJson(packageDir, "1.2.3")
+
+        assertEquals(
+            UniversalJsPackage.packageJson("1.2.3"),
+            File(packageDir, "package.json").readText()
+        )
+    }
+
+    @Test
+    fun failsWhenAnEntryPointIsMissingFromThePackage() {
+        val packageDir = createPackageDir()
+        // a manifest advertising declarations that are not present in the package
+        packageDir.walkTopDown().filter { it.name.endsWith(".d.mts") }.forEach { it.delete() }
+
+        val exception = assertFailsWith<GradleException> {
+            UniversalJsPackage.writePackageJson(packageDir, "1.2.3")
+        }
+
+        assertContains(exception.message!!, "browser/kson-kson-lib.d.mts")
+        assertContains(exception.message!!, "node/kson-kson-lib.d.mts")
+    }
+}

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -111,7 +111,7 @@ The KSON JavaScript/TypeScript library is published to npm as `@kson_org/kson` w
 
 2. Build the universal JavaScript package:
    ```bash
-   ./gradlew buildUniversalJsPackage
+   ./gradlew buildUniversalJsPackage -Prelease=true
    ```
 
    This builds a package for both the browser and Node.js and bundles it into `kson-lib/build/js-package`

--- a/kson-lib/README-npm.md
+++ b/kson-lib/README-npm.md
@@ -36,7 +36,7 @@ Running this should print the following:
 This package includes TypeScript definitions out of the box:
 
 ```typescript
-import { Kson, Result, FormatOptions, IndentType, FormattingStyle } from 'kson';
+import { Kson, Result, FormatOptions, IndentType, FormattingStyle } from '@kson_org/kson';
 
 const kson = Kson.getInstance();
 
@@ -53,7 +53,9 @@ if (jsonResult instanceof Result.Success) {
   const data = JSON.parse(jsonResult.output);
   console.log(data);
 } else if (jsonResult instanceof Result.Failure) {
-  console.error('Errors:', jsonResult.errors);
+  for (const error of jsonResult.errors.asJsReadonlyArrayView()) {
+    console.error(`${error.severity} at ${error.start.line}: ${error.message}`);
+  }
 }
 
 // Format KSON (returns string directly)
@@ -82,7 +84,7 @@ if (yamlResult instanceof Result.Success) {
 - **`toJson(kson: string, retainEmbedTags?: boolean): Result`**
   Converts KSON to formatted JSON. Returns a `Result` which can be either:
   - `Result.Success` with an `output` property containing the JSON string
-  - `Result.Failure` with an `errors` property containing a list of error messages
+  - `Result.Failure` with an `errors` property containing the errors (see [Reading errors](#reading-errors))
 
 - **`toYaml(kson: string, retainEmbedTags?: boolean): Result`**
   Converts KSON to YAML format. Returns a `Result` with Success/Failure variants.
@@ -106,11 +108,36 @@ if (yamlResult instanceof Result.Success) {
 
 - **`Result`**: Success/Failure union type for operations that can fail
   - `Result.Success`: Contains `output` property with the result string
-  - `Result.Failure`: Contains `errors` property with error messages
+  - `Result.Failure`: Contains `errors` property with the errors
 
 - **`SchemaResult`**: Success/Failure for schema parsing
   - `SchemaResult.Success`: Contains `schemaValidator` for validating documents
-  - `SchemaResult.Failure`: Contains error messages
+  - `SchemaResult.Failure`: Contains `errors` property with the errors
+
+- **`Message`**: A single error or warning
+  - `message`: the text of the error
+  - `severity`: a `MessageSeverity`
+  - `start` / `end`: `Position`s marking the span the error covers
+
+### Reading errors
+
+`errors` is a `KtList`, not a JavaScript array, because these bindings are
+compiled from Kotlin. Indexing it or reading `.length` yields `undefined`. Call
+`asJsReadonlyArrayView()` to get a real array first:
+
+```javascript
+if (result instanceof Result.Failure) {
+  const errors = result.errors.asJsReadonlyArrayView();
+  console.log(errors.length);
+  console.log(errors[0].message);
+}
+```
+
+Printing the list directly still works, since it renders itself:
+
+```javascript
+console.error(String(result.errors)); // [[ERROR] Unclosed list at 1:6]
+```
 
 ## KSON Syntax Highlights
 

--- a/kson-lib/build.gradle.kts
+++ b/kson-lib/build.gradle.kts
@@ -2,6 +2,7 @@ import nl.ochagavia.krossover.gradle.ReturnTypeMapping
 import org.kson.BinaryArtifactPaths
 import org.gradle.internal.os.OperatingSystem
 import org.kson.GraalVmHelper
+import org.kson.UniversalJsPackage
 
 import kotlin.io.path.Path
 import kotlin.io.path.createDirectories
@@ -165,50 +166,7 @@ tasks.register("buildUniversalJsPackage") {
         // Ensure directory exists
         jsPackageDir.mkdirs()
 
-
-        // Copy TypeScript definitions (from browser, they should be the same)
-        copy {
-            from(jsPackageDir.resolve("browser"))
-            include("*.d.ts")
-            into(jsPackageDir)
-        }
-
-        // Write universal package.json
-        val packageJson = """
-        {
-          "name": "@kson_org/kson",
-          "version": $version,
-          "description": "KSON - Extended JSON format with comments and more",
-          "author": {
-            "name": "KSON Team",
-            "email": "kson@kson.org"
-          },
-          "repository": {
-            "type": "git",
-            "url": "https://github.com/kson-org/kson"
-          },
-          "license": "Apache-2.0",
-          "keywords": ["json", "kson", "yaml", "configuration"],
-          "exports": {
-            ".": {
-              "browser": "./browser/kson-kson-lib.mjs",
-              "node": "./node/kson-kson-lib.mjs",
-              "types": "./kson-kson-lib.d.ts"
-            }
-          },
-          "main": "./node/kson-kson-lib.mjs",
-          "browser": "./browser/kson-kson-lib.mjs",
-          "types": "./kson-kson-lib.d.ts",
-          "files": [
-            "browser/",
-            "node/",
-            "*.d.ts",
-            "README.md"
-          ]
-        }
-        """.trimIndent()
-
-        jsPackageDir.resolve("package.json").writeText(packageJson)
+        UniversalJsPackage.writePackageJson(jsPackageDir, version.toString())
 
         // Copy README if it exists
         val readmeFile = projectDir.resolve("README-npm.md")


### PR DESCRIPTION
The generated `package.json` advertised `./kson-kson-lib.d.ts` at the package root. That file was never in the tarball: Kotlin/JS emits `.d.mts` beside each module, and the copy step meant to hoist declarations to the root matched `*.d.ts`, so it silently copied nothing.

Under `moduleResolution: nodenext` this went unnoticed — the `node` condition matches first and TypeScript falls back to the sibling `.d.mts`. Under `bundler` resolution, the Vite and Next.js default, it failed outright:

```
error TS2307: Cannot find module '@kson_org/kson' or its corresponding type declarations.
```

So the published package had no usable types for anyone resolving that way.

## The fix

Each export condition now names the declarations sitting beside the module it resolves to, with `types` listed first so it is reachable — Node and TypeScript take the first matching key within a condition, and a `types` entry after `default` is never read.

The `default` condition is load-bearing rather than boilerplate: `bundler` resolution uses the conditions `["types", "import"]`, which match neither `browser` nor `node`, so without it those projects still fail to resolve.

Also corrects the README's TypeScript example, which imported from `kson` rather than `@kson_org/kson` and so could not resolve, and the `-Prelease=true` missing from the documented build step.
