### PR TITLE
Make the Monaco package installable from npm

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -191,6 +191,52 @@ The KSON language support includes VSCode extensions published to both the Visua
 5. Verify the extensions are available at:
    - VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=kson.kson
    - Open VSX: https://open-vsx.org/extension/kson/kson
+#### [tooling/lsp-clients/monaco](../tooling/lsp-clients/monaco) Publishing Process
+
+The Monaco editor integration is published to npm as `@kson_org/monaco-editor`.
+
+##### Prerequisites
+
+- You will need a npm account at https://www.npmjs.com/
+- You will need publish access to the `@kson_org` organization
+
+##### Publishing Steps
+
+1. Ensure you've checked out **the tag to be released and that `git status` is clean**
+
+2. Build the package:
+   ```bash
+   ./gradlew :tooling:lsp-clients:npm_run_buildMonaco
+   ```
+
+   This builds `tooling/lsp-clients/monaco/dist`. The build inlines `@kson/lsp-shared` and
+   `kson-language-server` into the bundle, which is why they are `devDependencies`: the published
+   package resolves nothing at install time beyond its `monaco-editor` and `react` peers.
+
+3. Check what would be published:
+   ```bash
+   cd tooling/lsp-clients/monaco
+   npm pack --dry-run
+   ```
+
+   `dist/` must be present, and the manifest must declare no `dependencies`. A `file:` dependency
+   here is a path that exists only on the machine that published it, so it installs as a dangling
+   link and breaks `npm ls` for everyone downstream.
+
+4. Publish to npm:
+   ```bash
+   npm login
+   npm publish --access=public
+   ```
+
+5. Verify the package:
+   ```bash
+   npm view @kson_org/monaco-editor dist-tags
+   ```
+
+   `latest` should now be the released version. Development builds are published under the `dev`
+   tag, so `latest` otherwise keeps pointing at whichever prerelease was published without a tag.
+
 #### [tooling/jetbrains](../tooling/jetbrains) Publishing Process
 
 Note: it is possible to automate this process us some Gradle tasks provided by the [IntelliJ Platform Gradle Plugin](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html), if/when this manual process become onerous.

--- a/tooling/lsp-clients/monaco/LICENSE
+++ b/tooling/lsp-clients/monaco/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021-2025 Daniel Marcotte
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tooling/lsp-clients/monaco/package.json
+++ b/tooling/lsp-clients/monaco/package.json
@@ -13,7 +13,7 @@
     "name": "KSON",
     "email": "kson@kson.org"
   },
-  "license": "ISC",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/kson-org/kson",
   "repository": {
     "type": "git",
@@ -35,10 +35,6 @@
     "./react": { "import": "./dist/react/index.js", "types": "./dist/react/index.d.ts" }
   },
   "files": ["dist", "dist-iframe", "readme.md"],
-  "dependencies": {
-    "@kson/lsp-shared": "file:../shared",
-    "kson-language-server": "file:../../language-server-protocol"
-  },
   "peerDependencies": {
     "monaco-editor": ">=0.50.0",
     "react": ">=18.0.0"
@@ -47,6 +43,8 @@
     "react": { "optional": true }
   },
   "devDependencies": {
+    "@kson/lsp-shared": "file:../shared",
+    "kson-language-server": "file:../../language-server-protocol",
     "@types/react": "^18.3.0",
     "happy-dom": "^20.8.4",
     "monaco-editor": "^0.52.0",

--- a/tooling/lsp-clients/monaco/readme.md
+++ b/tooling/lsp-clients/monaco/readme.md
@@ -1,4 +1,4 @@
-# @kson/monaco-editor
+# @kson_org/monaco-editor
 
 A Monaco editor with full KSON language support — completions, diagnostics,
 hover, go-to-definition, formatting, and semantic highlighting — powered by
@@ -10,7 +10,7 @@ Monaco and a bundler.
 ## Install
 
 ```
-npm install @kson/monaco-editor monaco-editor
+npm install @kson_org/monaco-editor monaco-editor
 ```
 
 ## API
@@ -84,23 +84,23 @@ automatically; the worker is torn down when the last editor is disposed.
 
 #### Additional exports
 
-| Export                  | Sub-path                          | Description                                          |
-|-------------------------|-----------------------------------|------------------------------------------------------|
-| `attachKsonLsp`         | `@kson/monaco-editor`             | Attach the LSP to an editor you already created (e.g. via `@monaco-editor/react`).  See [the React demo](https://github.com/kson-org/kson/tree/main/tooling/lsp-clients/demos/react) for a worked example. |
-| `useKsonLsp`            | `@kson/monaco-editor/react`       | React hook over `attachKsonLsp` — handles the StrictMode-safe attach/detach lifecycle for you. |
-| `registerKsonLanguage`  | `@kson/monaco-editor`             | Register the KSON language with Monaco (called automatically by `createKsonEditor`). |
-| `KSON_LANGUAGE_ID`      | `@kson/monaco-editor`             | The language identifier string (`'kson'`).           |
-| `KsonLspBridge`         | `@kson/monaco-editor`             | The LSP bridge class, for advanced use.              |
-| `TabBar`                | `@kson/monaco-editor`             | The tab bar component used for multi-document navigation. |
+| Export                 | Sub-path                        | Description                                                                                                                                                                                                |
+|------------------------|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `attachKsonLsp`        | `@kson_org/monaco-editor`       | Attach the LSP to an editor you already created (e.g. via `@monaco-editor/react`).  See [the React demo](https://github.com/kson-org/kson/tree/main/tooling/lsp-clients/demos/react) for a worked example. |
+| `useKsonLsp`           | `@kson_org/monaco-editor/react` | React hook over `attachKsonLsp` — handles the StrictMode-safe attach/detach lifecycle for you.                                                                                                             |
+| `registerKsonLanguage` | `@kson_org/monaco-editor`       | Register the KSON language with Monaco (called automatically by `createKsonEditor`).                                                                                                                       |
+| `KSON_LANGUAGE_ID`     | `@kson_org/monaco-editor`       | The language identifier string (`'kson'`).                                                                                                                                                                 |
+| `KsonLspBridge`        | `@kson_org/monaco-editor`       | The LSP bridge class, for advanced use.                                                                                                                                                                    |
+| `TabBar`               | `@kson_org/monaco-editor`       | The tab bar component used for multi-document navigation.                                                                                                                                                  |
 
 ### React (`@monaco-editor/react`)
 
 For apps that already render Monaco via `@monaco-editor/react`, the
-`useKsonLsp` hook from `@kson/monaco-editor/react` is a one-hook
+`useKsonLsp` hook from `@kson_org/monaco-editor/react` is a one-hook
 integration.
 
 ```
-npm install @kson/monaco-editor @monaco-editor/react monaco-editor react react-dom
+npm install @kson_org/monaco-editor @monaco-editor/react monaco-editor react react-dom
 ```
 
 Three pieces are required:
@@ -109,7 +109,7 @@ Three pieces are required:
 import { useState } from 'react';
 import * as monaco from 'monaco-editor';
 import { Editor, loader } from '@monaco-editor/react';
-import { useKsonLsp } from '@kson/monaco-editor/react';
+import { useKsonLsp } from '@kson_org/monaco-editor/react';
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 
 // 1. Reuse the bundled monaco — otherwise @monaco-editor/react fetches a

--- a/tooling/lsp-clients/pnpm-lock.yaml
+++ b/tooling/lsp-clients/pnpm-lock.yaml
@@ -13,20 +13,19 @@ importers:
         version: 5.9.3
 
   monaco:
-    dependencies:
+    devDependencies:
       '@kson/lsp-shared':
         specifier: file:../shared
         version: link:../shared
-      kson-language-server:
-        specifier: file:../../language-server-protocol
-        version: file:../language-server-protocol
-    devDependencies:
       '@types/react':
         specifier: ^18.3.0
         version: 18.3.28
       happy-dom:
         specifier: ^20.8.4
         version: 20.9.0
+      kson-language-server:
+        specifier: file:../../language-server-protocol
+        version: file:../language-server-protocol
       monaco-editor:
         specifier: ^0.52.0
         version: 0.52.2
@@ -41,7 +40,7 @@ importers:
         version: 8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.0(esbuild@0.27.7)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 5.0.0(esbuild@0.27.7)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0))
       vitest:
         specifier: ^4.1.0
         version: 4.1.5(@types/node@24.12.3)(happy-dom@20.9.0)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0))
@@ -97,13 +96,13 @@ importers:
         version: 1.99.0
       '@vscode/test-electron':
         specifier: ^3.1.0
-        version: 3.1.0(supports-color@8.1.1)
+        version: 3.1.0
       '@vscode/test-web':
         specifier: ^0.0.81
         version: 0.0.81
       '@vscode/vsce':
         specifier: ^3.6.0
-        version: 3.9.1(supports-color@8.1.1)
+        version: 3.9.1
       esbuild:
         specifier: ^0.25.5
         version: 0.25.12
@@ -3464,8 +3463,8 @@ snapshots:
 
   '@typespec/ts-http-runtime@0.3.5':
     dependencies:
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -3523,10 +3522,10 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vscode/test-electron@3.1.0(supports-color@8.1.1)':
+  '@vscode/test-electron@3.1.0':
     dependencies:
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       jszip: 3.10.1
       ora: 8.2.0
       semver: 7.7.4
@@ -3596,7 +3595,7 @@ snapshots:
       '@vscode/vsce-sign-win32-arm64': 2.0.6
       '@vscode/vsce-sign-win32-x64': 2.0.6
 
-  '@vscode/vsce@3.9.1(supports-color@8.1.1)':
+  '@vscode/vsce@3.9.1':
     dependencies:
       '@azure/identity': 4.13.1
       '@secretlint/node': 10.2.2
@@ -3619,7 +3618,7 @@ snapshots:
       minimatch: 3.1.5
       parse-semver: 1.1.1
       read: 1.0.7
-      secretlint: 10.2.2(supports-color@8.1.1)
+      secretlint: 10.2.2
       semver: 7.7.4
       tmp: 0.2.5
       typed-rest-client: 1.8.11
@@ -4322,7 +4321,7 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2(supports-color@8.1.1):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -4338,7 +4337,7 @@ snapshots:
       - kerberos
       - supports-color
 
-  https-proxy-agent@7.0.6(supports-color@8.1.1):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -5132,7 +5131,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  secretlint@10.2.2(supports-color@8.1.1):
+  secretlint@10.2.2:
     dependencies:
       '@secretlint/config-creator': 10.2.2
       '@secretlint/formatter': 10.2.2
@@ -5458,7 +5457,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unplugin-dts@1.0.0(esbuild@0.27.7)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0)):
+  unplugin-dts@1.0.0(esbuild@0.27.7)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
       '@rollup/pluginutils': 5.3.0
       '@volar/typescript': 2.4.28
@@ -5497,9 +5496,9 @@ snapshots:
 
   version-range@4.15.0: {}
 
-  vite-plugin-dts@5.0.0(esbuild@0.27.7)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0)):
+  vite-plugin-dts@5.0.0(esbuild@0.27.7)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
-      unplugin-dts: 1.0.0(esbuild@0.27.7)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0))
+      unplugin-dts: 1.0.0(esbuild@0.27.7)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0))
     optionalDependencies:
       vite: 8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(tsx@4.21.0)
     transitivePeerDependencies:


### PR DESCRIPTION
`@kson_org/monaco-editor` declared `@kson/lsp-shared` and `kson-language-server` as `dependencies`, by `file:` path. Neither is published to npm, so a `file:` path that exists only on the publishing machine went to the registry. Installing from it produces a dangling symlink and a failing `npm ls`:

```
@kson/lsp-shared@ invalid: "file:../shared"
npm error code ELSPROBLEMS
```

Vite inlines both into the bundle at build time, so they are build-time inputs rather than install-time requirements — the shipped `dist` names no external module beyond the `monaco-editor` and `react` peers, and the bundled language
server runs with neither package present on disk. Moving them to `devDependencies` leaves the package working exactly as before and stops npm directing consumers at packages that do not exist.

## Also fixed

The readme referenced `@kson/monaco-editor` throughout — the wrong scope — so both install commands 404'd and no import example resolved.

The license claimed ISC while the project is Apache-2.0. Corrected, and the terms now ship: npm includes a `LICENSE` file whether or not `files` lists it.
