### PR TITLE
Complete inside the object a key is being typed into

### DIFF
--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/navigation/KsonValuePathBuilder.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/navigation/KsonValuePathBuilder.kt
@@ -1,8 +1,6 @@
 package org.kson.tooling.navigation
 
 import org.kson.ast.AstNode
-import org.kson.ast.ObjectNode
-import org.kson.ast.ObjectPropertyNodeImpl
 import org.kson.parser.Coordinates
 import org.kson.parser.Location
 import org.kson.parser.Token
@@ -12,7 +10,6 @@ import org.kson.value.navigation.json_pointer.JsonPointer
 import org.kson.walker.AstNodeWalker
 import org.kson.walker.NodeChildren
 import org.kson.walker.navigateToLocationWithPointer
-import org.kson.walker.navigateWithJsonPointer
 import org.kson.tooling.ToolingDocument
 
 /**
@@ -121,8 +118,7 @@ class KsonValuePathBuilder(
             targetNode = navResult.value,
             isLocationInsideToken = tokenContext.isInsideToken,
             includePropertyKeys = includePropertyKeys,
-            meaningfulTokens = document.meaningfulTokens,
-            rootNode = rootNode
+            meaningfulTokens = document.meaningfulTokens
         )
     }
 
@@ -232,8 +228,7 @@ class KsonValuePathBuilder(
         targetNode: AstNode,
         isLocationInsideToken: Boolean,
         includePropertyKeys: Boolean,
-        meaningfulTokens: List<Token>,
-        rootNode: AstNode
+        meaningfulTokens: List<Token>
     ): CaretPath {
         val colonToken = lastToken?.let { findNearestPrecedingColon(it, meaningfulTokens) }
         val colonPropertyName = colonToken?.let { findPropertyNameBeforeColon(it, meaningfulTokens) }
@@ -243,8 +238,7 @@ class KsonValuePathBuilder(
         afterColonCaretPath(pointer, colonToken, colonPropertyName, targetNode)?.let { return it }
         propertyKeyCaretPath(pointer, lastToken, isLocationInsideToken, targetNode, includePropertyKeys)
             ?.let { return it }
-        parentCaretPath(pointer, lastToken, isLocationInsideToken, includePropertyKeys, targetNode, rootNode)
-            ?.let { return it }
+        parentCaretPath(pointer, lastToken, isLocationInsideToken, includePropertyKeys)?.let { return it }
         return leafOrAsIsCaretPath(pointer, lastToken, targetNode, includePropertyKeys)
     }
 
@@ -301,32 +295,24 @@ class KsonValuePathBuilder(
 
     /**
      * Location outside the token while completing (not keeping property keys): target the parent element
-     * by dropping the last path segment.  Excludes container-opening delimiters (`[`, `{`, `<`), where the
-     * caret is inside an empty container the pointer already names and dropping would overshoot to the
-     * grandparent.  A fresh dash-list item (`- `) additionally exposes its enclosing property as the
-     * placeholder so its incomplete item never disqualifies the branches being completed; on a fresh
-     * property-name line the caret follows a committed sibling's last token (not a dash), so there is no
-     * placeholder and those committed siblings still narrow.  Returns null when the caret is not in this
-     * position.
+     * by dropping the last path segment.  Excludes the tokens that open a value the caret is now inside
+     * and the pointer already names: the container delimiters (`[`, `{`, `<`) and a list dash, which opens
+     * an element the same way.  Dropping a segment at any of those would overshoot to the grandparent.
+     * Returns null when the caret is not in this position.
      */
     private fun parentCaretPath(
         pointer: JsonPointer,
         lastToken: Token?,
         isLocationInsideToken: Boolean,
-        includePropertyKeys: Boolean,
-        targetNode: AstNode,
-        rootNode: AstNode
+        includePropertyKeys: Boolean
     ): CaretPath? {
         val targetsParent = !isLocationInsideToken && !includePropertyKeys &&
                 lastToken?.tokenType != TokenType.SQUARE_BRACKET_L &&
                 lastToken?.tokenType != TokenType.CURLY_BRACE_L &&
-                lastToken?.tokenType != TokenType.ANGLE_BRACKET_L
+                lastToken?.tokenType != TokenType.ANGLE_BRACKET_L &&
+                lastToken?.tokenType != TokenType.LIST_DASH
         if (!targetsParent) return null
-        val parentPointer = JsonPointer.fromTokens(pointer.tokens.dropLast(1))
-        val placeholder = if (lastToken?.tokenType == TokenType.LIST_DASH)
-            enclosingPropertyLocation(rootNode, parentPointer, targetNode)
-        else null
-        return CaretPath(parentPointer, placeholder)
+        return CaretPath(JsonPointer.fromTokens(pointer.tokens.dropLast(1)), placeholderLocation = null)
     }
 
     /**
@@ -347,24 +333,5 @@ class KsonValuePathBuilder(
                 lastToken.tokenType == TokenType.STRING_CLOSE_QUOTE &&
                 isAtOrAfter(location, lastToken.lexeme.location.end)
         return CaretPath(pointer, placeholder, caretPastValueToken)
-    }
-
-    /**
-     * Location of the object property at [parentPointer] whose value is [valueNode], or null when
-     * [parentPointer] is not an object or owns no such property (e.g. a dash list nested directly
-     * in another list).  The property's location spans its key through its value; passing it as the
-     * caret's incomplete region forgives the type/additional-property errors the half-typed item
-     * would otherwise trigger against sibling-discriminated branches.
-     */
-    private fun enclosingPropertyLocation(
-        rootNode: AstNode,
-        parentPointer: JsonPointer,
-        valueNode: AstNode
-    ): Location? {
-        val parent = AstNodeWalker.navigateWithJsonPointer(rootNode, parentPointer) as? ObjectNode ?: return null
-        val property = parent.properties.firstOrNull {
-            (it as? ObjectPropertyNodeImpl)?.value === valueNode
-        } ?: return null
-        return AstNodeWalker.getLocation(property)
     }
 }

--- a/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/navigation/KsonValuePathBuilder.kt
+++ b/kson-tooling-lib/src/commonMain/kotlin/org/kson/tooling/navigation/KsonValuePathBuilder.kt
@@ -10,6 +10,7 @@ import org.kson.value.navigation.json_pointer.JsonPointer
 import org.kson.walker.AstNodeWalker
 import org.kson.walker.NodeChildren
 import org.kson.walker.navigateToLocationWithPointer
+import org.kson.walker.navigateWithJsonPointer
 import org.kson.tooling.ToolingDocument
 
 /**
@@ -94,6 +95,10 @@ class KsonValuePathBuilder(
      * caret coordinates is needed.  It is only populated for completion (`includePropertyKeys =
      * false`); definition/hover lookups leave it null and treat the committed value as authoritative.
      *
+     * A caret can also fall outside the tree entirely: a key with no `:` yet is not a keyword, so an
+     * undelimited object ends at it and everything from there on is trailing content.  For completion
+     * we resolve such a caret from the last token that is in the tree — see [caretOutsideTreePath].
+     *
      * @return The resolved [CaretPath], or null if the document is completely unparseable
      */
     fun buildCaretPath(includePropertyKeys: Boolean = true): CaretPath? {
@@ -101,7 +106,7 @@ class KsonValuePathBuilder(
             ?: return if (document.content.isBlank()) CaretPath(JsonPointer.ROOT, null) else null
 
         // Analyze token context using meaningful (non-whitespace) tokens
-        val tokenContext = analyzeTokenContext(document.meaningfulTokens, location)
+        val tokenContext = analyzeTokenContext(location)
 
         // Determine the search position: use token start if available, otherwise location
         val searchPosition = tokenContext.lastToken?.lexeme?.location?.start ?: location
@@ -109,7 +114,7 @@ class KsonValuePathBuilder(
         // Navigate to the target node and build the path via the AST walker
         val navResult = AstNodeWalker.navigateToLocationWithPointer(
             rootNode, searchPosition
-        ) ?: return CaretPath(JsonPointer.ROOT, null)
+        ) ?: return caretOutsideTreePath(rootNode, includePropertyKeys)
 
         // Adjust the path based on token context (colon handling, boundary checks)
         return adjustPathForLocationContext(
@@ -123,35 +128,73 @@ class KsonValuePathBuilder(
     }
 
     /**
+     * The [CaretPath] for a caret the parser placed nothing at: past the end of the tree in trailing
+     * content, or before its start.  Resolves from the last token at or before the caret that IS in
+     * the tree, as if the caret sat in the whitespace just after that token, so a key being typed
+     * into an undelimited object—which ends that object—still completes against it.
+     *
+     * Only completion asks for this.  A definition or hover lookup has no reason to believe the
+     * caret is mid-keystroke, and reading a target off a token that may be pages away would answer
+     * a question nobody asked, so those keep resolving to the root.
+     */
+    private fun caretOutsideTreePath(rootNode: AstNode, includePropertyKeys: Boolean): CaretPath {
+        if (includePropertyKeys) return CaretPath(JsonPointer.ROOT, null)
+
+        val (anchor, navResult) = meaningfulTokensUpTo(location).asReversed().firstNotNullOfOrNull { token ->
+            AstNodeWalker.navigateToLocationWithPointer(rootNode, token.lexeme.location.start)
+                ?.let { token to it }
+        } ?: return CaretPath(JsonPointer.ROOT, null)
+
+        val caretPath = adjustPathForLocationContext(
+            pointer = navResult.pointerFromRoot,
+            lastToken = anchor,
+            targetNode = navResult.value,
+            isLocationInsideToken = false,
+            includePropertyKeys = false,
+            meaningfulTokens = document.meaningfulTokens
+        )
+        return caretPath.copy(pointer = enclosingObjectPointer(rootNode, caretPath.pointer))
+    }
+
+    /**
+     * [pointer] with any trailing list segments dropped.  A key belongs to an object, so a key typed
+     * under a list belongs to the object that owns the list: `tags:\n  - red\nother: x` reads `other`
+     * as a property of the object holding `tags`, not as part of the list.
+     */
+    private fun enclosingObjectPointer(rootNode: AstNode, pointer: JsonPointer): JsonPointer {
+        var enclosing = pointer
+        while (enclosing.tokens.isNotEmpty() && namesAList(rootNode, enclosing)) {
+            enclosing = JsonPointer.fromTokens(enclosing.tokens.dropLast(1))
+        }
+        return enclosing
+    }
+
+    /** True when [pointer] names a list in the tree rooted at [rootNode]. */
+    private fun namesAList(rootNode: AstNode, pointer: JsonPointer): Boolean {
+        val node = AstNodeWalker.navigateWithJsonPointer(rootNode, pointer) ?: return false
+        return AstNodeWalker.getChildren(node) is NodeChildren.Array
+    }
+
+    /**
      * Analyzes the token context at a specific location.
      *
      * Determines which token (if any) is at or before the location,
      * and whether the location falls within that token's bounds.
      */
-    private fun analyzeTokenContext(
-        tokens: List<Token>,
-        location: Coordinates
-    ): TokenContext {
-        val lastToken = findLastTokenBeforeLocation(tokens, location)
+    private fun analyzeTokenContext(location: Coordinates): TokenContext {
+        val lastToken = meaningfulTokensUpTo(location).lastOrNull()
         val isInsideToken = isPositionInsideToken(lastToken, location)
         return TokenContext(lastToken, isInsideToken)
     }
 
     /**
-     * Finds the last token that starts at or before the location.
+     * The meaningful tokens that start at or before the location, in document order.
      * The EOF token is excluded from consideration.
      */
-    private fun findLastTokenBeforeLocation(
-        tokens: List<Token>,
-        location: Coordinates
-    ): Token? {
-        return tokens
+    private fun meaningfulTokensUpTo(location: Coordinates): List<Token> {
+        return document.meaningfulTokens
             .dropLast(1)  // Exclude EOF token
-            .lastOrNull { token ->
-                val tokenStart = token.lexeme.location.start
-                tokenStart.line < location.line ||
-                        (tokenStart.line == location.line && tokenStart.column <= location.column)
-            }
+            .filter { isAtOrAfter(location, it.lexeme.location.start) }
     }
 
     /**

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/KsonValuePathBuilderTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/KsonValuePathBuilderTest.kt
@@ -116,6 +116,49 @@ class KsonValuePathBuilderTest {
     }
 
     @Test
+    fun testBuildJsonPointerToPosition_keyBeingTypedInPlainObject() {
+        // the colon-less key lands in trailing content, so the path comes from `John` instead
+        assertPathAtCaret(
+            """
+            person:
+              name: John
+              a<caret>
+            """.trimIndent(),
+            expectedPath = JsonPointer.fromTokens(listOf("person")),
+            includePropertyKeys = false
+        )
+    }
+
+    @Test
+    fun testBuildJsonPointerToPosition_keyBeingTypedAfterList() {
+        // a key can only belong to an object, so the path walks back out of the list above it
+        assertPathAtCaret(
+            """
+            person:
+              hobbies:
+                - reading
+              a<caret>
+            """.trimIndent(),
+            expectedPath = JsonPointer.fromTokens(listOf("person")),
+            includePropertyKeys = false
+        )
+    }
+
+    @Test
+    fun testBuildJsonPointerToPosition_definitionAtKeyBeingTyped() {
+        // only completion knows the caret is mid-keystroke: a definition lookup on content the
+        // parser dropped resolves nothing rather than guessing from a token elsewhere
+        assertPathAtCaret(
+            """
+            person:
+              name: John
+              a<caret>
+            """.trimIndent(),
+            expectedPath = JsonPointer.ROOT
+        )
+    }
+
+    @Test
     fun testBuildJsonPointerToPosition_nestedArrayItem() {
         assertPathAtCaret(
             """

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/KsonValuePathBuilderTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/KsonValuePathBuilderTest.kt
@@ -102,6 +102,20 @@ class KsonValuePathBuilderTest {
     }
 
     @Test
+    fun testBuildJsonPointerToPosition_freshDashListItem() {
+        // a dash with no value yet opens the list's next item, so the caret targets that index
+        assertPathAtCaret(
+            """
+            tags:
+              - kotlin
+              - <caret>
+            """.trimIndent(),
+            expectedPath = JsonPointer.fromTokens(listOf("tags", "1")),
+            includePropertyKeys = false
+        )
+    }
+
+    @Test
     fun testBuildJsonPointerToPosition_nestedArrayItem() {
         assertPathAtCaret(
             """
@@ -382,10 +396,13 @@ class KsonValuePathBuilderTest {
      * false), so that is the mode asserted here.
      *
      * [expectedPlaceholderText], when non-null, is the exact source substring the placeholder must
-     * span; it must occur exactly once in the document so its location is unambiguous. Pass null to
-     * assert the caret contributes no placeholder.
+     * span; a placeholder is the value the caret is authoring, so the occurrence looked for is the
+     * one nearest before the caret. Pass null to assert the caret contributes no placeholder.
      */
-    private fun assertPlaceholderAtCaret(documentWithCaret: String, expectedPlaceholderText: String?) {
+    private fun assertPlaceholderAtCaret(
+        documentWithCaret: String,
+        expectedPlaceholderText: String?
+    ) {
         val caretMarker = "<caret>"
         val caretIndex = documentWithCaret.indexOf(caretMarker)
         require(caretIndex >= 0) { "Document must contain $caretMarker marker" }
@@ -403,9 +420,8 @@ class KsonValuePathBuilderTest {
         val placeholder = caretPath?.placeholderLocation
 
         val expected = expectedPlaceholderText?.let { text ->
-            val start = document.indexOf(text)
-            require(start >= 0) { "Expected placeholder text not found in document: \"$text\"" }
-            require(document.indexOf(text, start + 1) < 0) { "Expected placeholder text is ambiguous: \"$text\"" }
+            val start = document.lastIndexOf(text, caretIndex)
+            require(start >= 0) { "Expected placeholder text not found before the caret: \"$text\"" }
             locationOf(document, start, start + text.length)
         }
 
@@ -446,27 +462,24 @@ class KsonValuePathBuilderTest {
 
     @Test
     fun testBuildCaretPath_placeholder_freshDashListItem() {
-        // A fresh dash-list item's placeholder is the enclosing property (key through dash), so its
-        // incomplete item can't disqualify sibling-discriminated branches.
         assertPlaceholderAtCaret(
             """
             items:
               - <caret>
             """.trimIndent(),
-            expectedPlaceholderText = "items:\n  -"
+            expectedPlaceholderText = "- "
         )
     }
 
     @Test
     fun testBuildCaretPath_placeholder_freshDashListItemAfterCommittedItem() {
-        // The excluded span is the whole property, reaching past an already-committed sibling item.
         assertPlaceholderAtCaret(
             """
             items:
               - one
               - <caret>
             """.trimIndent(),
-            expectedPlaceholderText = "items:\n  - one\n  -"
+            expectedPlaceholderText = "- "
         )
     }
 

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaCompletionLocationTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaCompletionLocationTest.kt
@@ -1769,6 +1769,111 @@ class SchemaCompletionLocationTest {
         assertTrue("and" in labels, "Should include 'and' from AndExpression, got: $labels")
     }
 
+    /** Nested object plus root-level siblings, so a leaking scope is unmistakable */
+    private val nestedPersonSchema = """
+        {
+            "type": "object",
+            "properties": {
+                "person": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "age": { "type": "number" }
+                    }
+                },
+                "hobby": { "type": "string" },
+                "other": { "type": "string" }
+            }
+        }
+    """
+
+    /**
+     * A key with no `:` yet is not a keyword, so the object ends before it and it lands in trailing
+     * content: completion reads its scope off `John`, the last token the parser placed.
+     */
+    @Test
+    fun testHalfTypedKeyCompletesEnclosingEndDottedObject() {
+        assertCompletionLabels(nestedPersonSchema, """
+            person:
+              name: John
+              a<caret>
+              .
+            hobby: reading
+        """.trimIndent(), setOf("age"))
+    }
+
+    @Test
+    fun testHalfTypedKeyCompletesEnclosingIndentedObject() {
+        assertCompletionLabels(nestedPersonSchema, """
+            hobby: reading
+            person:
+              name: John
+              a<caret>
+        """.trimIndent(), setOf("age"))
+    }
+
+    /** `name` is offered too: the error sits inside the `{}`, leaving no committed value to filter against */
+    @Test
+    fun testHalfTypedKeyCompletesEnclosingDelimitedObject() {
+        assertCompletionLabels(nestedPersonSchema, """
+            person: {
+              name: John
+              a<caret>
+            }
+            hobby: reading
+        """.trimIndent(), setOf("age", "name"))
+    }
+
+    @Test
+    fun testHalfTypedKeyAtRootCompletesRoot() {
+        assertCompletionLabels(nestedPersonSchema, """
+            hobby: reading
+            o<caret>
+        """.trimIndent(), setOf("other", "person"))
+    }
+
+    /** Same, with lists to walk back out of */
+    private val personWithListsSchema = """
+        {
+            "type": "object",
+            "properties": {
+                "tags": { "type": "array", "items": { "type": "string" } },
+                "person": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "age": { "type": "number" },
+                        "hobbies": { "type": "array", "items": { "type": "string" } }
+                    }
+                },
+                "other": { "type": "string" }
+            }
+        }
+    """
+
+    /**
+     * A key can only belong to an object, so a key typed under a list belongs to the object owning
+     * that list—`tags:\n  - red\nother: x` reads `other` as a root property.
+     */
+    @Test
+    fun testHalfTypedKeyAfterListCompletesObjectOwningIt() {
+        assertCompletionLabels(personWithListsSchema, """
+            tags:
+              - red
+            o<caret>
+        """.trimIndent(), setOf("other", "person"))
+    }
+
+    @Test
+    fun testHalfTypedKeyAfterNestedListCompletesEnclosingObject() {
+        assertCompletionLabels(personWithListsSchema, """
+            person:
+              hobbies:
+                - reading
+              a<caret>
+        """.trimIndent(), setOf("age", "name"))
+    }
+
     @Test
     fun testCompletionsInsideDashListWithRefToAnyOf() {
         val schema = searchExpressionSchema

--- a/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaCompletionLocationTest.kt
+++ b/kson-tooling-lib/src/commonTest/kotlin/org/kson/SchemaCompletionLocationTest.kt
@@ -30,6 +30,13 @@ class SchemaCompletionLocationTest {
         return KsonTooling.getCompletionsAtLocation(KsonTooling.parse(document), KsonTooling.parse(schema), line, column)
     }
 
+    /**
+     * Helper to assert the set of labels offered at the <caret> position in the document
+     */
+    private fun assertCompletionLabels(schema: String, documentWithCaret: String, expected: Set<String>) {
+        assertEquals(expected, getCompletionsAtCaret(schema, documentWithCaret).map { it.label }.toSet())
+    }
+
     @Test
     fun testConstValueCompletions() {
         val schema = """
@@ -1826,6 +1833,31 @@ class SchemaCompletionLocationTest {
             labels,
             "Empty recursive-anyOf array item offers the union of both branches, got: $labels"
         )
+    }
+
+    /** A dash with nothing after it yet is the list's next item, so the caret completes that item */
+    @Test
+    fun testCompletionsAtFreshDashItemOfferItemValues() {
+        val schema = """
+            {
+                "type": "object",
+                "properties": {
+                    "colors": {
+                        "type": "array",
+                        "items": { "enum": ["red", "green", "blue"] }
+                    },
+                    "other": { "type": "string" }
+                }
+            }
+        """
+
+        assertCompletionLabels(schema, """
+            colors:
+              - red
+              - <caret>
+              =
+            other: x
+        """.trimIndent(), setOf("blue", "green", "red"))
     }
 
     @Test

--- a/src/commonMain/kotlin/org/kson/walker/AstNodeWalker.kt
+++ b/src/commonMain/kotlin/org/kson/walker/AstNodeWalker.kt
@@ -12,6 +12,13 @@ import org.kson.parser.Location
  * Error nodes are treated as leaves, so navigation algorithms stop
  * descending at them while the surrounding tree structure remains intact.
  *
+ * A list element in error is such a leaf: it is addressed by its index, so it is
+ * listed among its siblings to keep their indices as written.  A property in error
+ * is dropped instead—it is addressed by name, and a broken property has none.
+ *
+ * Note [org.kson.value.toKsonValueOrNull] drops elements in error and so renumbers the
+ * ones after them: an index built by walking here addresses this tree, not that one.
+ *
  * This makes the walker suitable for IDE features (path building,
  * completions, hover) that need to work on partially-typed documents
  * where [org.kson.value.KsonValue] conversion would fail.
@@ -25,9 +32,8 @@ object AstNodeWalker : KsonTreeWalker<AstNode> {
             val keyString = (keyImpl.key as? StringNodeImpl)?.processedStringContent ?: return@mapNotNull null
             TreeProperty(keyString, propImpl.value as AstNode)
         })
-        is ListNode -> NodeChildren.Array(node.elements.mapNotNull { elem ->
-            val elemImpl = elem as? ListElementNodeImpl ?: return@mapNotNull null
-            elemImpl.value as AstNode
+        is ListNode -> NodeChildren.Array(node.elements.map { elem ->
+            if (elem is ListElementNodeImpl) elem.value as AstNode else elem
         })
         else -> NodeChildren.Leaf
     }

--- a/src/commonTest/kotlin/org/kson/walker/AstNodeWalkerTest.kt
+++ b/src/commonTest/kotlin/org/kson/walker/AstNodeWalkerTest.kt
@@ -158,6 +158,18 @@ class AstNodeWalkerTest {
     }
 
     @Test
+    fun testErrorElementKeepsItsIndex() {
+        // `- ` with no value yet is still an element of the list, addressable at index 1
+        val node = parseAst("- one\n- \n=")
+        assertNotNull(node)
+        val children = walker.getChildren(node)
+        assertIs<NodeChildren.Array<AstNode>>(children)
+        assertEquals(2, children.elements.size)
+        assertEquals("one", (children.elements[0] as StringNodeImpl).processedStringContent)
+        assertIs<AstNodeError>(children.elements[1])
+    }
+
+    @Test
     fun testCompletelyUnparseableDocumentReturnsNull() {
         // Some inputs produce KsonRootError — parseAst returns null
         val node = parseAst("")


### PR DESCRIPTION
Typing a property key inside an undelimited object offered the root schema's completions instead of the object's. A key with no `:` yet is not a keyword, so the object ends at it and everything from there is trailing content.

The problem was in the caret resolver: it navigated from the half-typed key, found it outside the tree, and fell back to the root pointer.

A second, related fix: completion at a fresh `- ` offered the enclosing object's properties rather than the item's values. `AstNodeWalker` dropped list elements in error, which both hid the caret's target and renumbered every element after it, so an element in error now stands among its siblings as a leaf. With the item addressable, the placeholder machinery that compensated for it (a fresh item borrowing its enclosing property's span) is deleted.
